### PR TITLE
Added accessor for underlying message to shared_ptr

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -124,6 +124,8 @@ public:
                : slot_->ref_count;
   }
 
+  const Message& GetMessage() const { return msg_; }
+
 private:
   friend class Client;
   void CopyFrom(const shared_ptr &p) {


### PR DESCRIPTION
This PR is just to add access to the underlying Message record from a shared_ptr. This is because as a user trying to switch to using a shared_ptr instead of storing and aliasing the Message record manually, I ran into the issue that I needed access to length (to calculate serialization buffer), ordinal and timestamp (both for logging purposes), which unfortunately gets hidden away once you use ReadMessage<T>.

I guess an alternative would be individual accessors for the other fields (length, ordinal, timestamp).