### PR TITLE
Fixed segfault in server destructor

### DIFF
--- a/server/server.cc
+++ b/server/server.cc
@@ -95,6 +95,11 @@ Server::Server(co::CoroutineScheduler &scheduler,
       discovery_port_(disc_port), discovery_peer_port_(peer_port),
       local_(local), notify_fd_(notify_fd), co_scheduler_(scheduler) {}
 
+Server::~Server() {
+  // Clear this before other data members get destroyed.
+  client_handlers_.clear();
+}
+
 void Server::Stop() { co_scheduler_.Stop(); }
 
 void Server::CloseHandler(ClientHandler *handler) {

--- a/server/server.h
+++ b/server/server.h
@@ -40,6 +40,7 @@ public:
   Server(co::CoroutineScheduler &scheduler, const std::string &socket_name,
          const std::string &interface, int disc_port, int peer_port, bool local,
          int notify_fd = -1);
+  ~Server();
   void SetLogLevel(const std::string &level) { logger_.SetLogLevel(level); }
   absl::Status Run();
   void Stop();


### PR DESCRIPTION
Fixed segfault in server destructor due to client handlers being destroyed after the channels_ data member that they refer to. This fix just clears the client handlers vector in the destructor's body first.