### PR TITLE
Tweaked for server, sub, and pub on Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ CC=clang bazel build ...
 It does build with *g++* but you will get some compiler warnings about different signed comparisons
 that clang doesn't care about.
 
+### Example: Ubuntu 20.04
+Build a minimal set of binaries:
+
+```
+CC=clang bazel build //server:subspace_server //manual_tests:{pub,sub}
+```
+
+Then run each in a separate terminal:
+
+ * `./bazel-bin/server/subspace_server`
+ * `./bazel-bin/manual_tests/sub`
+ * `./bazel-bin/manual_tests/pub`
+
 # Bazel WORKSPACE
 Add this to your Bazel WORKSPACE file to get access to this library without downloading it manually.
 

--- a/manual_tests/BUILD.bazel
+++ b/manual_tests/BUILD.bazel
@@ -14,8 +14,10 @@ cc_binary(
         "@com_google_absl//absl/flags:parse",
  
     ],
+    linkopts = [
+        "-lrt"
+    ],
 )
-
 
 
 cc_binary(
@@ -30,6 +32,9 @@ cc_binary(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
+    ],
+    linkopts = [
+        "-lrt"
     ],
 )
 

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -34,5 +34,8 @@ cc_binary(
     deps = [
       ":server",
       "@coroutines//:co",
-    ]
+    ],
+    linkopts = [
+        "-lrt"
+    ],
 )


### PR DESCRIPTION
It didn't build for me out of the box, I had to add `-lrt` to the binaries. Whether or not that also works on Mac OS is another question. I'd be happy to adjust the PR as needed.

I also added copy-pastable build and run commands. I hadn't used `bazel` in a while and figure it might help others to have them handy.