### PR TITLE
Build fixes

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -21,4 +21,10 @@ cc_library(
         "@coroutines//:co",
         "@toolbelt//toolbelt",
     ],
+    linkopts = select({
+        "//:macos_x86_64": [],
+        "//:macos_arm64": [],
+        "//:macos_default": [],
+        "//conditions:default": [ "-lrt" ],
+    }),
 )

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -204,7 +204,7 @@ Channel::Allocate(const toolbelt::FileDescriptor &scb_fd, int slot_size,
     return p.status();
   }
   ccb_ = reinterpret_cast<ChannelControlBlock *>(*p);
-  memset(ccb_, 0, ccb_size);
+  *ccb_ = ChannelControlBlock{};
 
   // Create a single buffer but don't map it in.  There is no need to
   // map in the buffers in the server since they will never be used.

--- a/common/channel.h
+++ b/common/channel.h
@@ -94,26 +94,26 @@ struct SystemControlBlock {
 // addresses in each client.  Instead they use an offset from the
 // start of the ChannelControlBlock (CCB) as a pointer.
 struct SlotListElement {
-  int32_t prev;
-  int32_t next;
+  int32_t prev = 0;
+  int32_t next = 0;
 };
 
 // Double linked list header in shared memory.
 struct SlotList {
-  int32_t first;
-  int32_t last;
+  int32_t first = 0;
+  int32_t last = 0;
 };
 
 // This is the meta data for a slot.  It is always in a linked list.
 struct MessageSlot {
-  SlotListElement element;
-  int32_t id;                 // Unique ID for slot (0...num_slots-1).
-  int16_t ref_count;          // Number of subscribers referring to this slot.
-  int16_t reliable_ref_count; // Number of reliable subscriber references.
-  int64_t ordinal;            // Message ordinal held currently in slot.
-  int64_t message_size;       // Size of message held in slot.
-  int32_t buffer_index;       // Index of buffer.
-  toolbelt::BitSet<kMaxSlotOwners> owners; // One bit per publisher/subscriber.
+  SlotListElement element{};
+  int32_t id = 0;                 // Unique ID for slot (0...num_slots-1).
+  int16_t ref_count = 0;          // Number of subscribers referring to this slot.
+  int16_t reliable_ref_count = 0; // Number of reliable subscriber references.
+  int64_t ordinal = 0;            // Message ordinal held currently in slot.
+  int64_t message_size = 0;       // Size of message held in slot.
+  int32_t buffer_index = 0;       // Index of buffer.
+  toolbelt::BitSet<kMaxSlotOwners> owners{}; // One bit per publisher/subscriber.
 };
 
 // This is located just before the prefix of the first slot's buffer.  It
@@ -130,29 +130,29 @@ struct BufferHeader {
 //
 // This is in shared memory so no pointers are possible.
 struct ChannelControlBlock {          // a.k.a CCB
-  char channel_name[kMaxChannelName]; // So that you can see the name in a
+  char channel_name[kMaxChannelName]{}; // So that you can see the name in a
                                       // debugger or hexdump.
-  int num_slots;
-  int64_t next_ordinal; // Next ordinal to use.
-  int buffer_index;     // Which buffer in buffers array to use.
-  int num_buffers;      // Size of buffers array in shared memory.
+  int num_slots = 0;
+  int64_t next_ordinal = 0; // Next ordinal to use.
+  int buffer_index = 0;     // Which buffer in buffers array to use.
+  int num_buffers = 0;      // Size of buffers array in shared memory.
 
   // Statistics counters.
-  int64_t total_bytes;
-  int64_t total_messages;
+  int64_t total_bytes = 0;
+  int64_t total_messages = 0;
 
   // Slot lists.
   // Active list: slots with active messages in them.
   // Busy list: slots allocated to publishers
   // Free list: slots not allocated.
-  SlotList active_list;
-  SlotList busy_list;
-  SlotList free_list;
+  SlotList active_list{};
+  SlotList busy_list{};
+  SlotList free_list{};
 
-  pthread_mutex_t lock; // Lock for this channel only.
+  pthread_mutex_t lock{}; // Lock for this channel only.
 
   // Variable number of MessageSlot structs (num_slots long).
-  MessageSlot slots[0];
+  MessageSlot slots[0]{};
 };
 
 absl::StatusOr<SystemControlBlock *>


### PR DESCRIPTION
- Fixes a link error on Ubuntu 18.04
- Fixes a compile warning

I built subspace on my desktop and got a couple errors/warnings. These changes seem to repair them, but let me know what you think. For the memaccess warning I default initialized only the stuff related to ChannelControlBlock, but happy to put default values into everything, if you want.

```
CC=clang bazel build //...
Starting local Bazel server and connecting to it...
INFO: Analyzed 17 targets (81 packages loaded, 3789 targets configured).
INFO: Found 17 targets...
INFO: From Compiling common/channel.cc:
common/channel.cc: In member function 'absl::lts_20211102::StatusOr<subspace::SharedMemoryFds> subspace::Channel::Allocate(const toolbelt::FileDescriptor&, int, int)':
common/channel.cc:207:27: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct subspace::ChannelControlBlock'; use assignment or value-initialization instead [-Wclass-memaccess]
  207 |   memset(ccb_, 0, ccb_size);
      |                           ^
In file included from common/channel.cc:5:
./common/channel.h:132:8: note: 'struct subspace::ChannelControlBlock' declared here
  132 | struct ChannelControlBlock {          // a.k.a CCB
      |        ^~~~~~~~~~~~~~~~~~~
ERROR: /home/maeve/subspace/client/BUILD.bazel:24:8: Linking client/client_test failed: (Exit 1): gcc failed: error executing command (from target //client:client_test) /usr/bin/gcc @bazel-out/k8-fastbuild/bin/client/client_test-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-fastbuild/bin/_solib_k8/libcommon_Slibsubspace_Ucommon.so: error: undefined reference to 'shm_open'
bazel-out/k8-fastbuild/bin/_solib_k8/libcommon_Slibsubspace_Ucommon.so: error: undefined reference to 'shm_unlink'
collect2: error: ld returned 1 exit status
INFO: Elapsed time: 34.645s, Critical Path: 5.08s
INFO: 402 processes: 126 internal, 276 linux-sandbox.
FAILED: Build did NOT complete successfully
```