### PR TITLE
Fixed more shadowing warnings of variable names

### DIFF
--- a/manual_tests/perf_subspace.cc
+++ b/manual_tests/perf_subspace.cc
@@ -17,10 +17,10 @@ ABSL_FLAG(int, num_slots, 500, "Number of slots in channel");
 
 void PubCoroutine(co::Coroutine *c) {
   subspace::Client client(c);
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
     fprintf(stderr, "Can't connect to Subspace server: %s\n",
-            s.ToString().c_str());
+            init_status.ToString().c_str());
     exit(1);
   }
   int num_slots = absl::GetFlag(FLAGS_num_slots);
@@ -46,9 +46,9 @@ void PubCoroutine(co::Coroutine *c) {
       }
       if (*buffer == nullptr) {
         // Wait for publisher trigger.
-        absl::Status s = pub->Wait();
-        if (!s.ok()) {
-          fprintf(stderr, "Can't wait for publisher: %s", s.ToString().c_str());
+        absl::Status wait_status = pub->Wait();
+        if (!wait_status.ok()) {
+          fprintf(stderr, "Can't wait for publisher: %s", wait_status.ToString().c_str());
           exit(1);
         }
         continue;
@@ -66,10 +66,10 @@ void PubCoroutine(co::Coroutine *c) {
 
 void SubCoroutine(co::Coroutine *c) {
   subspace::Client client(c);
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
     fprintf(stderr, "Can't connect to Subspace server: %s\n",
-            s.ToString().c_str());
+            init_status.ToString().c_str());
     exit(1);
   }
   int slot_size = absl::GetFlag(FLAGS_slot_size);
@@ -97,8 +97,8 @@ void SubCoroutine(co::Coroutine *c) {
     if (start != 0) {
       wait_start = toolbelt::Now();
     }
-    if (absl::Status s = sub->Wait(); !s.ok()) {
-      fprintf(stderr, "Can't wait for subscriber: %s\n", s.ToString().c_str());
+    if (absl::Status wait_status = sub->Wait(); !wait_status.ok()) {
+      fprintf(stderr, "Can't wait for subscriber: %s\n", wait_status.ToString().c_str());
       exit(1);
     }
     if (wait_start != 0) {

--- a/manual_tests/perf_subspace_pub.cc
+++ b/manual_tests/perf_subspace_pub.cc
@@ -20,9 +20,9 @@ int main(int argc, char **argv) {
   signal(SIGPIPE, SIG_IGN);
 
   subspace::Client client;
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
-    fprintf(stderr, "Can't connect to Subspace server: %s\n", s.ToString().c_str());
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
+    fprintf(stderr, "Can't connect to Subspace server: %s\n", init_status.ToString().c_str());
     exit(1);
   }
   bool reliable = absl::GetFlag(FLAGS_reliable);
@@ -49,9 +49,9 @@ int main(int argc, char **argv) {
       }
       if (*buffer == nullptr) {
         // Wait for publisher trigger.
-        absl::Status s = pub->Wait();
-        if (!s.ok()) {
-          fprintf(stderr, "Can't wait for publisher: %s", s.ToString().c_str());
+        absl::Status wait_status = pub->Wait();
+        if (!wait_status.ok()) {
+          fprintf(stderr, "Can't wait for publisher: %s", wait_status.ToString().c_str());
           exit(1);
         }
         continue;

--- a/manual_tests/perf_subspace_sub.cc
+++ b/manual_tests/perf_subspace_sub.cc
@@ -21,10 +21,10 @@ int main(int argc, char **argv) {
   signal(SIGPIPE, SIG_IGN);
 
   subspace::Client client;
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
     fprintf(stderr, "Can't connect to Subspace server: %s\n",
-            s.ToString().c_str());
+            init_status.ToString().c_str());
     exit(1);
   }
   bool reliable = absl::GetFlag(FLAGS_reliable);
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
     if (start != 0) {
       wait_start = toolbelt::Now();
     }
-    if (absl::Status s = sub->Wait(); !s.ok()) {
-      fprintf(stderr, "Can't wait for subscriber: %s\n", s.ToString().c_str());
+    if (absl::Status wait_status = sub->Wait(); !wait_status.ok()) {
+      fprintf(stderr, "Can't wait for subscriber: %s\n", wait_status.ToString().c_str());
       exit(1);
     }
     if (wait_start != 0) {

--- a/manual_tests/pub.cc
+++ b/manual_tests/pub.cc
@@ -18,10 +18,10 @@ int main(int argc, char **argv) {
   absl::ParseCommandLine(argc, argv);
 
   subspace::Client client;
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
     fprintf(stderr, "Can't connect to Subspace server: %s\n",
-            s.ToString().c_str());
+            init_status.ToString().c_str());
     exit(1);
   }
   bool reliable = absl::GetFlag(FLAGS_reliable);
@@ -63,10 +63,10 @@ int main(int argc, char **argv) {
         }
         if (*buffer == nullptr) {
           // Wait for publisher trigger.
-          absl::Status s = pub->Wait();
-          if (!s.ok()) {
+          absl::Status wait_status = pub->Wait();
+          if (!wait_status.ok()) {
             fprintf(stderr, "Can't wait for publisher: %s",
-                    s.ToString().c_str());
+                    wait_status.ToString().c_str());
             exit(1);
           }
           continue;

--- a/manual_tests/sub.cc
+++ b/manual_tests/sub.cc
@@ -18,9 +18,9 @@ int main(int argc, char **argv) {
 
   subspace::Client client;
 
-  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
-  if (!s.ok()) {
-    fprintf(stderr, "Can't connect to Subspace server: %s\n", s.ToString().c_str());
+  absl::Status init_status = client.Init(absl::GetFlag(FLAGS_socket));
+  if (!init_status.ok()) {
+    fprintf(stderr, "Can't connect to Subspace server: %s\n", init_status.ToString().c_str());
     exit(1);
   }
   bool reliable = absl::GetFlag(FLAGS_reliable);
@@ -39,8 +39,8 @@ int main(int argc, char **argv) {
       });
 
   for (;;) {
-    if (absl::Status s = sub->Wait(); !s.ok()) {
-      fprintf(stderr, "Can't wait for subscriber: %s\n", s.ToString().c_str());
+    if (absl::Status wait_status = sub->Wait(); !wait_status.ok()) {
+      fprintf(stderr, "Can't wait for subscriber: %s\n", wait_status.ToString().c_str());
       exit(1);
     }
     for (;;) {

--- a/server/server.cc
+++ b/server/server.cc
@@ -895,12 +895,12 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
     }
     prefix->flags |= kMessageBridged;
 
-    absl::StatusOr<const Message> s =
+    absl::StatusOr<const Message> pub_msg =
         pub->PublishMessageInternal(*n, /*omit_prefix=*/true);
-    if (!s.ok()) {
+    if (!pub_msg.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to publish bridge message for %s: %s",
-                  channel_name.c_str(), s.status().ToString().c_str());
+                  channel_name.c_str(), pub_msg.status().ToString().c_str());
     }
   }
 


### PR DESCRIPTION
Fixed more shadowing warnings of variable names

Mostly trivial renaming, only in channel.cc where I consolidated to nearly identical bits of code into a function. No change in behavior.

Warnings before this PR, using `bazel build -c opt --config=clang --cxxopt=-Wshadow //...:all`:

```
INFO: From Compiling common/channel.cc:
external/_main~_repo_rules~subspace/common/channel.cc:323:19: warning: declaration shadows a local variable [-Wshadow]
          int64_t buffers_size =
                  ^
external/_main~_repo_rules~subspace/common/channel.cc:310:13: note: previous declaration is here
    int64_t buffers_size =
            ^
external/_main~_repo_rules~subspace/common/channel.cc:414:21: warning: declaration shadows a local variable [-Wshadow]
        for (size_t i = start; i < buffers_.size(); i++) {
                    ^
external/_main~_repo_rules~subspace/common/channel.cc:402:15: note: previous declaration is here
  for (size_t i = start; i < buffers.size(); i++) {
              ^
external/_main~_repo_rules~subspace/common/channel.cc:415:19: warning: declaration shadows a local variable [-Wshadow]
          int64_t buffers_size =
                  ^
external/_main~_repo_rules~subspace/common/channel.cc:405:13: note: previous declaration is here
    int64_t buffers_size =
            ^
3 warnings generated.
INFO: From Compiling server/server.cc:
external/_main~_repo_rules~subspace/server/server.cc:898:35: warning: declaration shadows a local variable [-Wshadow]
    absl::StatusOr<const Message> s =
                                  ^
external/_main~_repo_rules~subspace/server/server.cc:763:16: note: previous declaration is here
  absl::Status s =
               ^
1 warning generated.
INFO: From Compiling server/server.cc:
external/_main~_repo_rules~subspace/server/server.cc:898:35: warning: declaration shadows a local variable [-Wshadow]
    absl::StatusOr<const Message> s =
                                  ^
external/_main~_repo_rules~subspace/server/server.cc:763:16: note: previous declaration is here
  absl::Status s =
               ^
1 warning generated.
INFO: From Compiling toolbelt/sockets.cc:
external/toolbelt/toolbelt/sockets.cc:471:9: warning: declaration shadows a local variable [-Wshadow]
    int e = getsockname(fd_.Fd(), reinterpret_cast<struct sockaddr *>(&bound),
        ^
external/toolbelt/toolbelt/sockets.cc:458:7: note: previous declaration is here
  int e =
      ^
1 warning generated.
INFO: From Compiling manual_tests/sub.cc:
manual_tests/sub.cc:42:22: warning: declaration shadows a local variable [-Wshadow]
    if (absl::Status s = sub->Wait(); !s.ok()) {
                     ^
manual_tests/sub.cc:21:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
1 warning generated.
INFO: From Compiling manual_tests/perf_subspace.cc:
manual_tests/perf_subspace.cc:49:22: warning: declaration shadows a local variable [-Wshadow]
        absl::Status s = pub->Wait();
                     ^
manual_tests/perf_subspace.cc:20:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
manual_tests/perf_subspace.cc:100:22: warning: declaration shadows a local variable [-Wshadow]
    if (absl::Status s = sub->Wait(); !s.ok()) {
                     ^
manual_tests/perf_subspace.cc:69:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
2 warnings generated.
INFO: From Compiling manual_tests/perf_subspace_sub.cc:
manual_tests/perf_subspace_sub.cc:57:22: warning: declaration shadows a local variable [-Wshadow]
    if (absl::Status s = sub->Wait(); !s.ok()) {
                     ^
manual_tests/perf_subspace_sub.cc:24:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
1 warning generated.
INFO: From Compiling manual_tests/perf_subspace_pub.cc:
manual_tests/perf_subspace_pub.cc:52:22: warning: declaration shadows a local variable [-Wshadow]
        absl::Status s = pub->Wait();
                     ^
manual_tests/perf_subspace_pub.cc:23:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
1 warning generated.
INFO: From Compiling manual_tests/pub.cc:
manual_tests/pub.cc:66:24: warning: declaration shadows a local variable [-Wshadow]
          absl::Status s = pub->Wait();
                       ^
manual_tests/pub.cc:21:16: note: previous declaration is here
  absl::Status s = client.Init(absl::GetFlag(FLAGS_socket));
               ^
1 warning generated.
```
