### PR TITLE
Fixed a couple of compilation issues on clang/libc++ and gcc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,9 +17,9 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 # Toolbelt
 http_archive(
     name = "toolbelt",
-    integrity = "sha256-nvSdw7++daGPlTKGXc/yMfgDownE2UrANQVelyUtHvo=",
-    strip_prefix = "cpp_toolbelt-1.3.2",
-    urls = ["https://github.com/dallison/cpp_toolbelt/archive/refs/tags/1.3.2.tar.gz"],
+    integrity = "sha256-0ErXeftHwSUzm5Q2rBM19tpRBnpXwMLcMzciDGgwTcA=",
+    strip_prefix = "cpp_toolbelt-1.4.0",
+    urls = ["https://github.com/dallison/cpp_toolbelt/archive/refs/tags/1.4.0.tar.gz"],
 )
 # For local debugging of toolbelt coroutine library.
 # bazel_dep(name = "toolbelt")
@@ -31,9 +31,9 @@ http_archive(
 # Coroutines
 http_archive(
     name = "coroutines",
-    integrity = "sha256-P4nLeTzHht8uk/Jzee5OGRVgRD4Dr8Ww61RBpl0mp1E=",
-    strip_prefix = "co-2.0.2",
-    urls = ["https://github.com/dallison/co/archive/refs/tags/2.0.2.tar.gz"],
+    integrity = "sha256-PhOYq1eE8Q8UOhzDHq2+rafTU4VTt9fZ0ZZyNE+hWb4=",
+    strip_prefix = "co-2.1.0",
+    urls = ["https://github.com/dallison/co/archive/refs/tags/2.1.0.tar.gz"],
 )
 # For local debugging of co coroutine library.
 # bazel_dep(name = "coroutines")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 11,
+  "lockFileVersion": 18,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -14,14 +14,14 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20240722.0.bcr.1/source.json": "e067fdd217bacbe74c88a975434be5df0b44315a247be180f0e20f891715210c",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
-    "https://bcr.bazel.build/modules/bazel_features/1.19.0/source.json": "d7bf14517c1b25b9d9c580b0f8795fceeae08a7590f507b76aace528e941375d",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -48,7 +48,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -64,7 +65,6 @@
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
     "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
-    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/MODULE.bazel": "2d746fda559464b253b2b2e6073cb51643a2ac79009ca02100ebbc44b4548656",
@@ -80,11 +80,12 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.16/source.json": "227e83737046aa4f50015da48e98e0d8ab42fd0ec74d8d653b6cc9f9a357f200",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -96,11 +97,11 @@
     "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
-    "https://bcr.bazel.build/modules/rules_java/7.12.2/source.json": "b0890f9cda8ff1b8e691a3ac6037b5c14b7fd4134765a3946b89f31ea02e5884",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -125,7 +126,6 @@
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
-    "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
@@ -146,80 +146,107 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "ltCGFbl/LQQZXn/LEMXfKX7pGwyqNiOCHcmiQW0tmjM=",
-        "usagesDigest": "RkqDb8JtSSm4rLheCLMw/Dx3QQE7dZbl4taOVEYaQZg=",
+        "bzlTransitiveDigest": "E970FlMbwpgJPdPUQzatKh6BMfeE0ZpWABvwshh7Tmg=",
+        "usagesDigest": "aYRVMk+1OupIp+5hdBlpzT36qgd6ntgSxYTzMLW5K4U=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf",
+          "local_config_apple_cc_toolchains": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
             "attributes": {}
           },
-          "local_config_apple_cc_toolchains": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf_toolchains",
+          "local_config_apple_cc": {
+            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
             "attributes": {}
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "apple_support~",
+            "apple_support+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "CkoYCqOgC/Xs59gJ1r3BNo2zDkwqdfWlBeZr5f004os=",
+        "usagesDigest": "tVQNvLoXMWAbiK39am3yovKGpwINdftfn7RpDyN+JZc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.13.6",
+              "url": "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz",
+              "integrity": "sha256-4Iy4f0dz2pf6e18DXeh2OrxlbYfVdz5i9toFh9Hw7CA="
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
             "bazel_tools",
             "bazel_tools"
           ]
         ]
       }
     },
-    "@@platforms//host:extension.bzl%host_platform": {
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "V1R2Y2oMxKNfx2WCWpSCaUV1WefW1o8HZGm3v1vHgY4=",
+        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "host_platform": {
-            "bzlFile": "@@platforms//host:extension.bzl",
-            "ruleClassName": "host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
-      "general": {
-        "bzlTransitiveDigest": "l//eFZVgEUHSUfuQ1zQw9uxmcJku8ikraA2fv/2Pyh0=",
-        "usagesDigest": "NXmdQOmIAdsAdtLv3dhkX8UQ+0st9iQ0EkR28lUNdHc=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "rules_android": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
             "attributes": {
-              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-              "strip_prefix": "rules_android-0.1.1",
               "urls": [
-                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
-              ]
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
             }
           },
           "com_github_pinterest_ktlint": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_file",
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
               "urls": [
@@ -228,39 +255,20 @@
               "executable": true
             }
           },
-          "com_github_jetbrains_kotlin": {
-            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
-            "ruleClassName": "kotlin_capabilities_repository",
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "git_repository_name": "com_github_jetbrains_kotlin_git",
-              "compiler_version": "1.9.23"
-            }
-          },
-          "com_github_jetbrains_kotlin_git": {
-            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
-            "ruleClassName": "kotlin_compiler_git_repository",
-            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
               "urls": [
-                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
-              ],
-              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
-            }
-          },
-          "com_github_google_ksp": {
-            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:ksp.bzl",
-            "ruleClassName": "ksp_compiler_plugin_repository",
-            "attributes": {
-              "urls": [
-                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
-              ],
-              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
-              "strip_version": "1.9.23-1.0.20"
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_kotlin~",
+            "rules_kotlin+",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/common/atomic_bitset.h
+++ b/common/atomic_bitset.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <iostream>
 #include <strings.h>
+#include <vector>
 
 namespace subspace {
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -6,6 +6,9 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "subspace_proto",
     srcs = ["subspace.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
 )
 
 cc_proto_library(

--- a/proto/subspace.proto
+++ b/proto/subspace.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 David Allison
+// Copyright 2023-2025 David Allison
 // All Rights Reserved
 // See LICENSE file for licensing information.
 
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 package subspace;
 
+import "google/protobuf/any.proto";
 message InitRequest { string client_name = 1; }
 
 // All Request and Response messages are carried over a Unix Domain
@@ -30,7 +31,7 @@ message CreatePublisherRequest {
   bool is_fixed_size = 8;
   string mux = 9;
   int32 vchan_id = 10;
-  bool notify_retirement = 11;  // Notify publisher of slot retirement.
+  bool notify_retirement = 11; // Notify publisher of slot retirement.
 }
 
 message CreatePublisherResponse {
@@ -45,8 +46,8 @@ message CreatePublisherResponse {
   int32 num_sub_updates = 9;
   bytes type = 10;
   int32 vchan_id = 11;
-  int32 retirement_fd_index = 14;             // My retirement fd index (read end)
-  repeated int32 retirement_fd_indexes = 15;  // Write end of all retirement fds.
+  int32 retirement_fd_index = 14; // My retirement fd index (read end)
+  repeated int32 retirement_fd_indexes = 15; // Write end of all retirement fds.
 }
 
 // This is used both to create a new subscriber and to reload
@@ -132,15 +133,15 @@ message ChannelInfo {
   int32 slot_size = 2;
   int32 num_slots = 3;
   bytes type = 4;
-  int32 num_pubs = 5;         // Total number of publishers for this channel.
-  int32 num_subs = 6;         // Total number of subscribers for this channel.
-  int32 num_bridge_pubs = 7;  // Number of publishers that are bridges.
-  int32 num_bridge_subs = 8;  // Number of subscribers that are bridges.
-  bool is_reliable = 9;       // True if channel is reliable.
-  bool is_virtual = 10;       // True if channel is virtual.
+  int32 num_pubs = 5;        // Total number of publishers for this channel.
+  int32 num_subs = 6;        // Total number of subscribers for this channel.
+  int32 num_bridge_pubs = 7; // Number of publishers that are bridges.
+  int32 num_bridge_subs = 8; // Number of subscribers that are bridges.
+  bool is_reliable = 9;      // True if channel is reliable.
+  bool is_virtual = 10;      // True if channel is virtual.
 
   // Only if is_virtual is true.
-  int32 vchan_id = 11;        // Virtual channel ID.
+  int32 vchan_id = 11; // Virtual channel ID.
   string mux = 12;
 }
 
@@ -171,7 +172,7 @@ message Statistics {
 
 message ChannelAddress {
   bytes address = 1; // In host byte order.
-  int32 port = 2;       // In host byte order.
+  int32 port = 2;    // In host byte order.
 }
 
 // This is sent over the connected channel TCP bridge when the
@@ -191,9 +192,7 @@ message Subscribed {
 
 // This is sent over a TCP connection from the peer server when the
 // given slot retires and the publisher wants notification of it.
-message RetirementNotification {
-  int32 slot_id = 1;
-}
+message RetirementNotification { int32 slot_id = 1; }
 
 // This message is sent over UDP.
 message Discovery {
@@ -224,3 +223,91 @@ message Discovery {
     Subscribe subscribe = 5;
   }
 }
+
+//
+// Remote procedure call messages.
+//
+
+// Ask the server to open connection to a server.  The response will contain the
+// session ID for the server and a list of methods that can be called on it.
+message RpcOpenRequest {}
+
+message RpcOpenResponse {
+  message RequestChannel {
+    string name = 1;     // Name of the channel.
+    int32 slot_size = 2; // Size of each slot in bytes.
+    int32 num_slots = 3; // Number of slots in the channel.
+    string type = 4;     // Type of data carried on this channel.
+  }
+
+  message ResponseChannel {
+    string name = 1; // Name of the channel.
+    string type = 2; // Type of data carried on this channel.
+  }
+  message Method {
+    string name = 1; // Name of the method to call
+    int32 id = 2;
+    RequestChannel request_channel = 3;   // Channel to send request on.
+    ResponseChannel response_channel = 4; // Channel to receive response on.
+    string cancel_channel = 5;            // To cancel streams.
+  }
+  int32 session_id = 1;        // Session ID for this server.
+  repeated Method methods = 2; // List of methods available on this server.
+  uint64 client_id = 3;        // Client that this is destined for.
+}
+
+message RpcCloseRequest {
+  int32 session_id = 1; // Session ID to close.
+}
+
+message RpcCloseResponse {}
+
+message RpcServerRequest {
+  uint64 client_id = 1;
+  int32 request_id = 2;
+  oneof request {
+    RpcOpenRequest open = 3;
+    RpcCloseRequest close = 4;
+  }
+}
+
+message RpcServerResponse {
+  uint64 client_id = 1;
+  int32 request_id = 2;
+  oneof response {
+    RpcOpenResponse open = 3;
+    RpcCloseResponse close = 4;
+  }
+  string error = 5;
+}
+
+message RpcRequest {
+  int32 method = 1;
+  google.protobuf.Any argument = 2; // Data to send to the server.
+  int32 session_id = 3;             // Session ID for this request.
+  int32 request_id = 4;             // Unique ID for this request.
+  uint64 client_id = 5;             // Client ID making the request.
+}
+
+message RpcResponse {
+  string error = 1;               // Error message if any.
+  google.protobuf.Any result = 2; // Data returned by the server.
+  int32 session_id = 3;           // Session ID for this response.
+  int32 request_id = 4;           // Unique ID for this response, matches request.
+  uint64 client_id = 5;           // Client ID making the request.
+  bool is_last = 6;               // Whether this is the last response in a stream.
+  bool is_cancelled = 7;          // Whether this response is for a cancelled request.
+}
+
+// This is sent to cancel a streaming method.
+message RpcCancelRequest {
+  int32 session_id = 1; // Session ID for this request.
+  int32 request_id = 2; // Request ID for method invocation.
+  uint64 client_id = 3; // Client ID making the request.
+}
+
+// Carries raw bytes over RPC.
+message RawMessage { bytes data = 1; }
+
+// RPC calls with no result return this.
+message VoidMessage {}

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1,0 +1,653 @@
+# Subspace Remote Procedure Calls
+This library provides a remote procedure call (RPC) facility built on top of Subspace IPC.
+It has the following features:
+
+1. Reliable shared memory transport
+1. Intra and inter-computer calls
+1. Type safe client and server API
+1. Coroutine aware (you don't need to use coroutines)
+1. Bazel integration using Starlark
+1. `gRPC` style services in proto file
+1. Server streaming calls
+1. Protobuf serialization
+
+The API looks something like a simpler version of `gRPC`.
+
+## Service definition
+A service is defined in a `.proto` file, just like `gRPC` does.  A Starlark
+Bazel extension is provided to handle the service and generate code for both
+the client and server side.
+
+The Bazel extension is in `//rpc/subspace_rpc_library.bzl` and provides a
+`subspace_rpc_library` macro that generates the client and server `cc_library`
+rules.
+
+For example, given the following `rpc_test.proto`file:
+
+```
+syntax = "proto3";
+
+package rpc;
+
+message TestRequest {
+  string message = 1;
+  int32 stream_period = 2;    // In milliseconds
+}
+
+message TestResponse {
+  string message = 1;
+  int32 foo = 2;
+}
+
+message PerfRequest {
+  uint64 send_time = 1;
+}
+
+message PerfResponse {
+  uint64 client_send_time = 1;   // Time sent by client.
+  uint64 server_send_time = 2;   // Time sent by server.
+}
+
+service TestService {
+  rpc TestMethod(TestRequest) returns (TestResponse);
+  rpc PerfMethod(PerfRequest) returns (PerfResponse);
+  rpc StreamMethod(TestRequest) returns (stream TestResponse);
+}
+```
+
+You can write a `BUILD.bazel` (or just BUILD) that contains:
+
+```
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("//:rpc/subspace_rpc_library.bzl", "subspace_rpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "rpc_test_proto",
+    srcs = ["rpc_test.proto"],
+)
+
+cc_proto_library(
+    name = "rpc_test_cc_proto",
+    deps = [":rpc_test_proto"],
+)
+
+# Generates both client and server:
+# :rpc_test_subspace_rpc_client
+# :rpc_test_subspace_rpc_server
+
+subspace_rpc_library(
+    name = "rpc_test_subspace_rpc",
+    deps = [
+        ":rpc_test_proto",
+    ],
+)
+
+```
+
+The target names for the macro are:
+
+1. rpc_test_subspace_rpc_client
+1. rpc_test_subspace_rpc_server
+
+These are both `cc_library` rules that generate the client and server libraries
+respectively.
+
+The client and server will implement the `TestService` service with the following
+RPC functions:
+
+1. TestMethod
+2. PerfMethod
+3. StreamMethod
+
+The client library will define a class with a member function for each of these
+functions and the server library will define a class that has a pure virtual
+function for each of them
+
+The output files are placed in the Bazel output directory.  For example,
+for the `rpc_test.proto` service, in a top level `rpc/proto` directory, the header files are in:
+
+```
+bazel-bin/rpc/proto/rpc_test.subspace.rpc_client.h
+bazel-bin/rpc/proto/rpc_test.subspace.rpc_server.h
+```
+
+To include them in a program, just use:
+
+```c++
+#include "rpc/proto/rpc_test.subspace.rpc_client.h"
+```
+
+## RPC server
+Each service that wants to export a set of remote procedure calls runs an
+`RPC Server` that handles those calls.  This may be in a process with other
+RPC servers or might be in its own process.  The user registers a set of
+functions with the server and those are called when the client asks for the
+server to invoke them.  The server is aware of coroutines (my own coroutine
+library that uses multiplex IO for scheduling) but you can just ignore that
+and use a thread if you want.
+
+The easist way to implement a server is to use the gRPC style `service` in
+a `.proto` file with the messages that are used as arguments and results
+for the RPC functions.
+
+This gives you a class that you can override and provide implementations for
+the functions the service provides.
+
+For example, given the previously described `rpc_test.proto` file, it defines
+a service called `TestService`, and the output is:
+
+```c++
+namespace rpc {
+class TestServiceServer {
+public:
+  TestServiceServer(const std::string& subspace_socket) : server_(std::make_shared<subspace::RpcServer>("TestService", std::move(subspace_socket))) {}
+  virtual ~TestServiceServer() = default;
+
+  absl::Status RegisterMethods();
+
+  absl::Status Run(co::CoroutineScheduler* scheduler = nullptr) {
+    return server_->Run(scheduler);
+  }
+
+  void Stop() {
+    server_->Stop();
+  }
+
+  void SetLogLevel(const std::string& level) {
+    server_->SetLogLevel(level);
+  }
+
+protected:
+  virtual absl::StatusOr<TestResponse> TestMethod(const TestRequest& request, co::Coroutine* c = nullptr) = 0;
+  virtual absl::StatusOr<PerfResponse> PerfMethod(const PerfRequest& request, co::Coroutine* c = nullptr) = 0;
+  virtual absl::Status StreamMethod(const TestRequest& request, subspace::StreamWriter<TestResponse>& writer, co::Coroutine* c = nullptr) = 0;
+
+private:
+  std::shared_ptr<subspace::RpcServer> server_;
+};
+} // namespace rpc
+
+```
+
+This is an abstract class for which the user is expected to provide a derived class that
+implements the pure virtual functions.
+
+To provide an implementation you can do something like this:
+
+```c++
+class MyServer : public rpc::TestServiceServer {
+public:
+  MyServer(const std::string &socket) : rpc::TestServiceServer(socket) {}
+
+  absl::StatusOr<rpc::TestResponse> TestMethod(const rpc::TestRequest &request,
+                                               co::Coroutine *c) override {
+    // Implement TestMethod, returning a TestResponse.
+  }
+
+  absl::StatusOr<rpc::PerfResponse> PerfMethod(const rpc::PerfRequest &request,
+                                               co::Coroutine *c) override {
+     // Implement PerfMethod, returning a PerfResponse.
+  }
+
+  absl::Status StreamMethod(const rpc::TestRequest &request,
+                            subspace::StreamWriter<rpc::TestResponse> &writer,
+                            co::Coroutine *c) override {
+    // Stream a bunch of TestResponses to the writer.
+  }
+};
+
+```
+
+Then to create your server:
+
+```c++
+  auto server = std::make_shared<MyServer>(RpcTest::Socket());
+  auto s = server->RegisterMethods();
+  // Check 's' is ok.
+```
+Note that the creation of the server and the registration of its methods are
+separate calls because the base class is abstract and can't be created using
+a static `Create` method.
+
+To run the server, you call the `Run` function.  This can either be called
+without a coroutine pointer, in which case it will block until it is stopped, or
+if you are cool, you can use a coroutine which will allow it to run cooperatively
+with other servers in the same process.
+
+Obviously the easiest way is to run the server in a thread but you can get more
+elegant if you want.
+
+## Client
+In order to invoke methods on a service you need to create a client.  There may
+be many clients attached to a single service (server).
+
+Each client must be given a unique 64-bit number when it is created.  This would
+usually come from the process ID (call `getpid()`) or maybe a thread id obtained
+from the OS, or you could just pick a number (I like 6502 for nostalgic reasons).
+
+For our afforementioned `rpc_test.proto` file, our generated client looks like:
+
+```c++
+namespace rpc {
+class TestServiceClient {
+public:
+  TestServiceClient(uint64_t client_id, std::string subspace_socket) : client_(std::make_shared<subspace::RpcClient>("TestService", client_id, std::move(subspace_socket))) {
+  }
+  static absl::StatusOr<std::shared_ptr<TestServiceClient>> Create(uint64_t client_id, const std::string& subspace_socket, co::Coroutine* c = nullptr) {
+    auto client = std::make_shared<TestServiceClient>(client_id, subspace_socket);
+    auto status = client->Open(c);
+    if (!status.ok()) {
+      return status;
+    }
+    return client;
+  }
+
+  absl::Status Open(co::Coroutine* c = nullptr) {
+    return client_->Open(c);
+  }
+  absl::Status Close(co::Coroutine* c = nullptr) {
+    return client_->Close(c);
+  }
+  void SetLogLevel(const std::string& level) {
+    client_->SetLogLevel(level);
+  }
+
+  absl::StatusOr<TestResponse> TestMethod(const TestRequest& request, std::chrono::nanoseconds timeout, co::Coroutine* c = nullptr);
+  absl::StatusOr<TestResponse> TestMethod(const TestRequest& request, co::Coroutine* c = nullptr) {
+    return TestMethod(request, std::chrono::nanoseconds(0), c);
+  }
+  absl::StatusOr<PerfResponse> PerfMethod(const PerfRequest& request, std::chrono::nanoseconds timeout, co::Coroutine* c = nullptr);
+  absl::StatusOr<PerfResponse> PerfMethod(const PerfRequest& request, co::Coroutine* c = nullptr) {
+    return PerfMethod(request, std::chrono::nanoseconds(0), c);
+  }
+  absl::Status StreamMethod(const TestRequest& request, subspace::ResponseReceiver<TestResponse>& receiver, std::chrono::nanoseconds timeout, co::Coroutine* c = nullptr);
+  absl::Status StreamMethod(const TestRequest& request, subspace::ResponseReceiver<TestResponse>& receiver, co::Coroutine* c = nullptr) {
+    return StreamMethod(request, receiver, std::chrono::nanoseconds(0), c);
+  }
+
+
+private:
+  std::shared_ptr<subspace::RpcClient> client_;
+};
+```
+
+This is a concrete class that has a static `Create` function you can use to create it, or you can use the constructor
+and `Open` calls if you prefer.  If you are in a coroutine environment, you will need to pass a pointer to the coroutine
+if you want to avoid blocking.  The `subspace_socket` is the name of a Unix Domain Socket that the `Subspace` server
+is listening on.  This is usually `/tmp/subspace` but your environment might provide a different name.
+
+It contains a function for each RPC function defined in the service.  These are all `blocking` methods that send
+the request and wait for the response.  For each RPC there are 2 functions provided, one with a timeout and one
+without. If there is no timeout the client will wait forever for the response.  If there is a timeout, an
+error will be returned.  If you are using coroutines, the `blocking` is coroutine aware and will not block
+the coroutine scheduler.
+
+To create a client to the `TestService` service running on Subspace socket `/tmp/mysubspace` that is not in a
+coroutine environemnt:
+
+```c++
+  auto cl = rpc::TestServiceClient::Create(getpid(), "/tmp/mysubspace");
+  if (!cl.ok()) {
+    // Handle error.
+  }
+  auto client = *cl;
+```
+
+Then, to call an RPC with no timeout (and no coroutine):
+
+```c++
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::StatusOr<rpc::TestResponse> r = client->TestMethod(req);
+    // Check 'r' for ok() and use result.
+```
+
+If you want to provide a timeout (of 10 seconds say):
+
+```c++
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::StatusOr<rpc::TestResponse> r = client->TestMethod(req, 10s);
+    // Check 'r' for ok() and use result.
+```
+
+This assumes you have done the following to pick up the `10s` syntax.
+
+```c++
+#include <chrono>
+using namespace std::chrono_literals;
+
+```
+If the server doesn't respond withing 10 seconds, you will get an error.
+
+When you are done with a client you should call the `Close` function to remove
+the channels and tell the server it has gone away.  The destructor also calls `Close`
+but you should call it yourself to detect any errors.
+
+## Streaming functions
+Like `gRPC`, we provide a way for a single RPC function to result in multiple responses
+sent by the server.  This is referred to as `server streaming`.  gRPC also provides a
+`client streaming` facility but that isn't supported at time of writing.
+
+You need to implement streaming on both the client and the server.  In the `.proto`
+file you enable it by:
+
+```
+rpc StreamMethod(TestRequest) returns (stream TestResponse);
+
+```
+This says that the `StreamMethod` RPC takes a `TestRequest` argument and results in
+a stream of `TestResponse` messages.
+
+### Server stream
+On the server side your override of the pure virtual function will be called with
+an instance of `StreamWriter` templated object.  This is defined as:
+
+```c++
+template <typename Response> struct StreamWriter {
+  // Returns true if the write worked, false if the request was cancelled.
+  bool Write(const Response &res, co::Coroutine *c);
+
+  void Finish(co::Coroutine *c);
+
+  void Cancel();
+
+  bool IsCancelled() const;
+};
+```
+
+The 4 public functions are:
+
+* Write: write a response to the client
+* Finish: finish up a sequence of reponses with an empty one that terminates the stream
+* Cancel: cancel the stream from the server end
+* IsCancelled: has the client or the server cancelled this stream?
+
+Here's an example of an implementation of the `StreamMethod` that sends 200 responses.  It
+is defined inside the derived class for the service.  It checks for cancellation by the
+client.
+
+```c++
+  absl::Status StreamMethod(const rpc::TestRequest &request,
+                            subspace::StreamWriter<rpc::TestResponse> &writer,
+                            co::Coroutine *c) override {
+    constexpr int kNumResults = 200;
+    for (int i = 0; i < kNumResults; i++) {
+      if (writer.IsCancelled()) {
+        writer.Finish(c);
+        return absl::OkStatus();
+      }
+      rpc::TestResponse r;
+      r.set_message("Hello from StreamMethod part " + std::to_string(i));
+      writer.Write(r, c);
+      c->Millisleep(request.stream_period());
+    }
+
+    writer.Finish(c);
+    return absl::OkStatus();
+```
+
+Unless it is cancelled, it will send 200 results at a frequency passed in the request.
+
+### Client side
+On the client side, we provide a similar concept.  The function for the `StreamMethod` is
+defined as:
+
+```c++
+  absl::Status StreamMethod(const TestRequest& request, subspace::ResponseReceiver<TestResponse>& receiver, co::Coroutine* c = nullptr);
+```
+
+This takes a request and sends it to the server, then blocks until the server finishes sending the
+data for the stream.  Each time a response is received the `receiver` will be invoked.  This is
+defined as an instance of a templated class:
+
+```c++
+template <typename Response> class ResponseReceiver {
+public:
+  ResponseReceiver() = default;
+  virtual ~ResponseReceiver() = default;
+
+  // Called when a response is received.
+  virtual void OnResponse(const Response &response) = 0;
+
+  virtual void OnFinish() = 0;
+
+  // Called when an error occurs.
+  virtual void OnError(const absl::Status &status) = 0;
+
+  virtual void OnCancel() = 0;
+
+  bool IsCancelled() const { return cancelled_; }
+
+  absl::Status Cancel(std::chrono::nanoseconds timeout,
+                      co::Coroutine *c = nullptr);
+
+  absl::Status Cancel(co::Coroutine *c = nullptr) {
+    return Cancel(std::chrono::nanoseconds(0), c);
+  }
+};
+
+```
+
+The intention is that you provide a class derived from this and override the
+pure virtual member functions to provide your own implementation.  It's pretty
+straightforward and boiler-plate:
+
+```c++
+    class MyResponseReceiver
+        : public subspace::ResponseReceiver<rpc::TestResponse> {
+    public:
+      void OnResponse(const rpc::TestResponse &response) override {
+        // Implement reception of a response
+      }
+      void OnError(const absl::Status &status) override {
+        // Received an ereror
+      }
+      void OnCancel() override {
+        // We got cancelled.
+      }
+      void OnFinish() override {
+        // Stream is done
+      }
+    };
+
+```
+
+If you want to cancel a stream you can call 'Cancel' on the `ResponseReceiver` object and when the
+cancellation happens, the `onCancel` function will be called.  Of course, the stream may have
+finished before that occurs so don't rely on `onCancel` always being called.
+
+
+## Advanced usage
+You don't need to use the gRPC style interface to use this.  The `subspace::RpcClient` and `subspace::RpcServer`
+classes are very usable and the gRPC stuff is just a wrapper around them.
+
+Take a look at the `rpc/client/rpc_client.h` and `rpc/server/rpc_server.h` to see what those
+classes provide.
+
+I promise I will document them fully soon...
+
+## Execution model
+Unlike `gRPC`, Subspace RPC does not force you into a multithreaded environment.  Internally the
+server uses coroutines to provide cooperative multitasking but there are no internal threads
+created.  This is a BYOT model (Bring Your Own Threads), so if you insist on using threads
+you would run each server in its own thread.  When a server is executing a method it is blocking
+the server so if you want to have a parallel execution model (a server running multiple methods
+at one time), you will need to use separate servers, each in its own thread.
+
+Likewise, the client is single threaded and coroutine-aware but if you want to use threads,
+run the client in a thread.  Method invocations in a client are always blocking, if you want
+non-blocking clients, wrap the client in a thread and provide a callback yourself.
+
+This all may seem to be a bit restrictive, but this system is intended to be a simple RPC
+system built over Subspace IPC, not a full replacement for something like gRPC.  If you need
+to have the features of gRPC, I suggest you just use it and deal with the complexity.
+
+### How coroutines are used
+In the server, every session opened from a client creates a bunch of coroutines, one for each
+method that the server supports.  Each coroutine is listening on the `request` channel and
+responds on the `response` channel.  When the method is invoked, it is passed a coroutine pointer
+that can be used to cooperate with the other coroutines in the server.  If your method blocks
+(calls read or waits for a mutex or something) the whole server is blocked (it's all in a single
+thread).
+
+If you are using a threading model where the server is running in its own thread, you can ignore
+the coroutine pointer and block away, but be aware that the server will not be able to process
+another method while this is happening.
+
+Coroutines provide ways to wait for file descriptors, sleep and yield, so if you want to
+take advantage of the cooperative multitasking and enable the server to handle more than
+one method at a time, you can use these facilities.  Please take a gander at
+[my coroutine library](https://github.com/dallison/co) for details on coroutines.
+
+The main advantage of going to the effort of using coroutines is that you can completely
+avoid any multithreading pitfalls.  There is never any need to lock data since, by definition,
+only one thread can access the memory at one time.  So no mutuxes or condition variables and no
+data races.
+
+## How it works
+As the name suggests, this uses Subspace IPC for its transport.  Subspace already supports reliable
+communication (as an option) so this creates a set of publishers and subscribers for a bunch
+of channels and uses them to send and receive messages.  We use protobuf as the serialization
+mechanism for now (but maybe we can provide zero-copy in the future)
+
+When you create a service, the server creates:
+
+1. A subscriber to the channel `/rpc/SERVICE/request`
+2. A publisher to the channel `/rpc/SERVICE/response`
+
+Where `SERVICE` is the name of the service.
+
+The client then creates:
+
+1. A publisher to `/rpc/SERVICE/request`
+2. A subscriber to `/rpc/SERVICE/response`
+
+The channel parameters (slot size and number of slots) is set to something reasonable but
+can be overridden as needed.  The slot size will be increased on demand.
+
+The client opens a connection to the server by sending an 'RpcServerRequest' protobuf message
+to the `/rpc/SERVICE/request` channel containing an `RpcOpenRequest`.  These messages are
+defined as:
+
+```
+message RpcOpenRequest {}
+
+message RpcServerRequest {
+  uint64 client_id = 1;
+  int32 request_id = 2;
+  oneof request {
+    RpcOpenRequest open = 3;
+    RpcCloseRequest close = 4;
+  }
+}
+
+```
+
+The `RpcServerRequest` contains a unique client ID and a request ID specific for this request.  These
+are used to correlate the responses.
+
+The server will respond with a `RpcServerResponse` containing `RpcOpenResponse` defined as:
+
+```
+message RpcOpenResponse {
+  message RequestChannel {
+    string name = 1;     // Name of the channel.
+    int32 slot_size = 2; // Size of each slot in bytes.
+    int32 num_slots = 3; // Number of slots in the channel.
+    string type = 4;     // Type of data carried on this channel.
+  }
+
+  message ResponseChannel {
+    string name = 1; // Name of the channel.
+    string type = 2; // Type of data carried on this channel.
+  }
+  message Method {
+    string name = 1; // Name of the method to call
+    int32 id = 2;
+    RequestChannel request_channel = 3;   // Channel to send request on.
+    ResponseChannel response_channel = 4; // Channel to receive response on.
+    string cancel_channel = 5;            // To cancel streams.
+  }
+  int32 session_id = 1;        // Session ID for this server.
+  repeated Method methods = 2; // List of methods available on this server.
+  uint64 client_id = 3;        // Client that this is destined for.
+}
+
+message RpcServerResponse {
+  uint64 client_id = 1;
+  int32 request_id = 2;
+  oneof response {
+    RpcOpenResponse open = 3;
+    RpcCloseResponse close = 4;
+  }
+  string error = 5;
+}
+
+```
+This is reasonably complex but really just contains the set of methods that are supported by
+the server and information associated with them.  The important fields are:
+
+1. request_channel: information about the channel the client will use to send requests
+2. response_channel: info about the response channel
+3. id: a number identifying this method on the server.
+
+The server also returns a `session_id` which uniquely identifies the session that was
+opened.
+
+The client uses this information to create publishers and subscribers to the method
+channels.
+
+For completeness, the channel names are formatted as `/rpc/SERVICE/METHOD/request/CLIENT/SESSION` for
+the requests and (unsurprisingly) `/rpc/SERVICE/METHOD/response/CLIENT/SESSION` for the responses.
+
+Where:
+
+* SERVICE is the service name
+* METHOD is the method name
+* CLIENT is the client ID provided by the client
+* SESSION is the session ID provided by the server
+
+For example, the request channel for the `TestMethod` in `TestService` would be `/rpc/TestService/TestMethod/request/1234/1`
+for client 1234 and session 1.
+
+To invoke a method, the client sends a `RpcRequest` message to the request channel:
+
+```
+message RpcRequest {
+  int32 method = 1;
+  google.protobuf.Any argument = 2; // Data to send to the server.
+  int32 session_id = 3;             // Session ID for this request.
+  int32 request_id = 4;             // Unique ID for this request.
+  uint64 client_id = 5;             // Client ID making the request.
+}
+
+```
+In addition to identifying the session, request and client, it also contains the number of the method to
+invoke.  The numbers are assigned by the server and correspond to method name strings.
+
+The argument for the method is sent as a `google.protobuf.Any` message.
+
+The response comes back as `RpcResponse`:
+
+```
+message RpcResponse {
+  string error = 1;               // Error message if any.
+  google.protobuf.Any result = 2; // Data returned by the server.
+  int32 session_id = 3;           // Session ID for this response.
+  int32 request_id = 4;           // Unique ID for this response, matches request.
+  uint64 client_id = 5;           // Client ID making the request.
+  bool is_last = 6;               // Whether this is the last response in a stream.
+  bool is_cancelled = 7;          // Whether this response is for a cancelled request.
+}
+
+```
+If `error` is not empty there is an error.  The `result` will contain the result if there was one.
+
+Since this uses reliable channels, no messages will be dropped and the publisher may be
+blocked from sending a message if a subscriber will miss it.
+
+The performance is really good.

--- a/rpc/client/BUILD.bazel
+++ b/rpc/client/BUILD.bazel
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rpc_client",
+    srcs = [
+        "rpc_client.cc",
+    ],
+    hdrs = [
+        "rpc_client.h",
+    ],
+    deps = [
+        "//rpc/server:rpc_server",
+        "//client:subspace_client",
+        "//common:subspace_common",
+        "//proto:subspace_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@coroutines//:co",
+    ],
+)
+
+cc_test(
+    name = "client_test",
+    srcs = ["client_test.cc"],
+    data = [
+        "//server:subspace_server",
+    ],
+    deps = [
+        ":rpc_client",
+        "//rpc/server:rpc_server",
+        "//client:subspace_client",
+        "//rpc/proto:rpc_test_cc_proto",
+        "//server",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+        "@coroutines//:co",
+    ],
+)

--- a/rpc/client/client_test.cc
+++ b/rpc/client/client_test.cc
@@ -1,0 +1,517 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/hash/hash_testing.h"
+#include "absl/status/status_matchers.h"
+#include "client/client.h"
+#include "coroutine.h"
+#include "google/protobuf/any.pb.h"
+#include "rpc/client/rpc_client.h"
+#include "rpc/proto/rpc_test.pb.h"
+#include "rpc/server/rpc_server.h"
+#include "server/server.h"
+#include "toolbelt/clock.h"
+#include "toolbelt/hexdump.h"
+#include "toolbelt/pipe.h"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <inttypes.h>
+#include <memory>
+#include <signal.h>
+#include <sys/resource.h>
+#include <thread>
+
+using namespace std::chrono_literals;
+ABSL_FLAG(bool, start_server, true, "Start the subspace server");
+ABSL_FLAG(std::string, server, "", "Path to server executable");
+
+void SignalHandler(int sig) { printf("Signal %d", sig); }
+
+using Publisher = subspace::Publisher;
+using Subscriber = subspace::Subscriber;
+using Message = subspace::Message;
+using InetAddress = toolbelt::InetAddress;
+
+#define VAR(a) a##__COUNTER__
+#define EVAL_AND_ASSERT_OK(expr) EVAL_AND_ASSERT_OK2(VAR(r_), expr)
+
+#define EVAL_AND_ASSERT_OK2(result, expr)                                      \
+  ({                                                                           \
+    auto result = (expr);                                                      \
+    if (!result.ok()) {                                                        \
+      std::cerr << result.status() << std::endl;                               \
+    }                                                                          \
+    ASSERT_OK(result);                                                         \
+    std::move(*result);                                                        \
+  })
+
+#define ASSERT_OK(e) ASSERT_THAT(e, ::absl_testing::IsOk())
+
+class ClientTest : public ::testing::Test {
+public:
+  // We run one server for the duration of the whole test suite.
+  static void SetUpTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Starting Subspace server\n");
+    char socket_name_template[] = "/tmp/subspaceXXXXXX"; // NOLINT
+    ::close(mkstemp(&socket_name_template[0]));
+    socket_ = &socket_name_template[0];
+
+    // The server will write to this pipe to notify us when it
+    // has started and stopped.  This end of the pipe is blocking.
+    (void)pipe(server_pipe_);
+
+    server_ =
+        std::make_unique<subspace::Server>(scheduler_, socket_, "", 0, 0,
+                                           /*local=*/true, server_pipe_[1]);
+
+    // Start server running in a thread.
+    server_thread_ = std::thread([]() {
+      absl::Status s = server_->Run();
+      if (!s.ok()) {
+        fprintf(stderr, "Error running Subspace server: %s\n",
+                s.ToString().c_str());
+        exit(1);
+      }
+    });
+
+    // Wait for server to tell us that it's running.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+  }
+
+  static void TearDownTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Stopping Subspace server\n");
+    server_->Stop();
+
+    // Wait for server to tell us that it's stopped.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+    server_thread_.join();
+  }
+
+  void SetUp() override { signal(SIGPIPE, SIG_IGN); }
+  void TearDown() override {}
+
+  static void InitClient(subspace::Client &client) {
+    ASSERT_OK(client.Init(Socket()));
+  }
+
+  static const std::string &Socket() { return socket_; }
+
+  static subspace::Server *Server() { return server_.get(); }
+
+private:
+  static co::CoroutineScheduler scheduler_;
+  static std::string socket_;
+  static int server_pipe_[2];
+  static std::unique_ptr<subspace::Server> server_;
+  static std::thread server_thread_;
+};
+
+co::CoroutineScheduler ClientTest::scheduler_;
+std::string ClientTest::socket_ = "/tmp/subspace";
+int ClientTest::server_pipe_[2];
+std::unique_ptr<subspace::Server> ClientTest::server_;
+std::thread ClientTest::server_thread_;
+
+static std::shared_ptr<subspace::RpcServer> BuildServer() {
+  auto server = std::make_shared<subspace::RpcServer>("TestService",
+                                                      ClientTest::Socket());
+  server->SetLogLevel("info");
+
+  auto s = server->RegisterMethod<rpc::TestRequest, rpc::TestResponse>(
+      "TestMethod",
+      [](const auto &req, auto *res, co::Coroutine *) -> absl::Status {
+        std::cerr << "TestMethod called with request: " << req.DebugString()
+                  << std::endl;
+        res->set_message("Hello from TestMethod");
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  // Performance
+  s = server->RegisterMethod<rpc::PerfRequest, rpc::PerfResponse>(
+      "PerfMethod",
+      [](const auto &req, auto *res, co::Coroutine *) -> absl::Status {
+        res->set_client_send_time(req.send_time());
+        res->set_server_send_time(toolbelt::Now());
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  // Void method.
+  s = server->RegisterMethod<rpc::TestRequest>(
+      "VoidMethod", [](const auto &req, auto *) -> absl::Status {
+        std::cerr << "VoidMethod called with request: " << req.DebugString()
+                  << std::endl;
+        return absl::OkStatus();
+      });
+
+  // Error method.
+  s = server->RegisterMethod<rpc::TestRequest, rpc::TestResponse>(
+      "ErrorMethod",
+      [](const auto &req, auto *res, co::Coroutine *) -> absl::Status {
+        std::cerr << "ErrorMethod called with request: " << req.DebugString()
+                  << std::endl;
+        return absl::InternalError("Error occurred");
+      });
+  EXPECT_TRUE(s.ok());
+
+  // void error method.
+  s = server->RegisterMethod<rpc::TestRequest>(
+      "VoidErrorMethod", [](const auto &req, co::Coroutine *) -> absl::Status {
+        std::cerr << "VoidErrorMethod called with request: "
+                  << req.DebugString() << std::endl;
+        return absl::InternalError("Error occurred");
+      });
+  EXPECT_TRUE(s.ok());
+
+  s = server->RegisterMethod<rpc::TestRequest, rpc::TestResponse>(
+      "TimeoutMethod",
+      [](const auto &req, auto *res, co::Coroutine *c) -> absl::Status {
+        std::cerr << "TimeoutMethod called with request: " << req.DebugString()
+                  << std::endl;
+        c->Sleep(2);
+        res->set_message("Hello from TimeoutMethod");
+        std::cerr << "TimeoutMethod completed" << std::endl;
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  // Stream method.
+  s = server->RegisterMethod<rpc::TestRequest, rpc::TestResponse>(
+      "StreamMethod",
+      [](const auto &req, subspace::StreamWriter<rpc::TestResponse> &writer,
+         co::Coroutine *c) -> absl::Status {
+        std::cerr << "StreamMethod called with request: " << req.DebugString()
+                  << std::endl;
+
+        constexpr int kNumResults = 200;
+        for (int i = 0; i < kNumResults; i++) {
+          if (writer.IsCancelled()) {
+            std::cerr << "StreamMethod cancelled after " << i << " responses"
+                      << std::endl;
+            writer.Finish(c);
+            return absl::OkStatus();
+          }
+          rpc::TestResponse r;
+          r.set_message("Hello from StreamMethod part " + std::to_string(i));
+          writer.Write(r, c);
+          c->Millisleep(req.stream_period());
+        }
+
+        writer.Finish(c);
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  return server;
+}
+
+TEST_F(ClientTest, Typed) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 1,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    absl::StatusOr<rpc::TestResponse> resp =
+        client->Call<rpc::TestRequest, rpc::TestResponse>("TestMethod",
+                                                          test_request, c);
+    std::cerr << resp.status().ToString() << std::endl;
+    ASSERT_OK(resp);
+
+    EXPECT_EQ(resp->message(), "Hello from TestMethod");
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, TypedMethodId) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 2,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    auto TestMethodId = client->FindMethod("TestMethod");
+    ASSERT_OK(TestMethodId);
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    absl::StatusOr<rpc::TestResponse> resp =
+        client->Call<rpc::TestRequest, rpc::TestResponse>(*TestMethodId,
+                                                          test_request, c);
+    ASSERT_OK(resp);
+
+    EXPECT_EQ(resp->message(), "Hello from TestMethod");
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, TypedVoid) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 3,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    absl::Status resp =
+        client->Call<rpc::TestRequest>("VoidMethod", test_request, c);
+    ASSERT_OK(resp);
+
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, TypedError) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 4,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    absl::StatusOr<rpc::TestResponse> resp =
+        client->Call<rpc::TestRequest, rpc::TestResponse>("ErrorMethod",
+                                                          test_request, c);
+    ASSERT_FALSE(resp.ok());
+    std::cerr << "Received error: " << resp.status().ToString() << std::endl;
+    ASSERT_TRUE(absl::StrContains(resp.status().ToString(),
+                                  "INTERNAL: Error occurred"));
+
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, TypedTimeout) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 5,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    // Invoke with 1 second timeout.  The method will take 2 seconds to respond.
+    absl::StatusOr<rpc::TestResponse> resp =
+        client->Call<rpc::TestRequest, rpc::TestResponse>("TimeoutMethod",
+                                                          test_request, 1s, c);
+    ASSERT_FALSE(resp.ok());
+    std::cerr << "Received error: " << resp.status().ToString() << std::endl;
+    ASSERT_TRUE(
+        absl::StrContains(resp.status().ToString(), "INTERNAL: Timeout"));
+
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, Performance) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 6,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    auto PerfMethodId = client->FindMethod("PerfMethod");
+    ASSERT_OK(PerfMethodId);
+
+    uint64_t total_rtt = 0;
+    uint64_t total_server_time = 0;
+
+    int num_iterations = 10000;
+    for (int i = 0; i < num_iterations; i++) {
+      rpc::PerfRequest request;
+      request.set_send_time(toolbelt::Now());
+
+      absl::StatusOr<rpc::PerfResponse> resp =
+          client->Call<rpc::PerfRequest, rpc::PerfResponse>(*PerfMethodId,
+                                                            request, c);
+      ASSERT_OK(resp);
+
+      uint64_t rtt = toolbelt::Now() - request.send_time();
+      int64_t server_time = resp->server_send_time() - resp->client_send_time();
+      total_rtt += rtt;
+      total_server_time += server_time;
+    }
+    std::cerr << "RTT: " << (total_rtt / num_iterations)
+              << " ns, server time: " << (total_server_time / num_iterations)
+              << " ns" << std::endl;
+
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, TypedStream) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 7,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+
+    class MyResponseReceiver
+        : public subspace::ResponseReceiver<rpc::TestResponse> {
+    public:
+      void OnResponse(rpc::TestResponse &&response) override {
+        std::cerr << "Received response: " << response.message() << std::endl;
+        count++;
+      }
+
+      void OnError(const absl::Status &status) override {
+        std::cerr << "Received error: " << status.ToString() << std::endl;
+      }
+
+      void OnCancel() override { std::cerr << "Stream cancelled" << std::endl; }
+
+      void OnFinish() override { std::cerr << "Stream finished" << std::endl; }
+
+      int GetCount() const { return count; }
+      int count = 0;
+    };
+
+    MyResponseReceiver receiver;
+    absl::Status status = client->Call<rpc::TestRequest, rpc::TestResponse>(
+        "StreamMethod", test_request, receiver, c);
+    std::cerr << status.ToString() << std::endl;
+    ASSERT_OK(status);
+
+    ASSERT_EQ(200, receiver.GetCount());
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ClientTest, CancelStream) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto client = std::make_shared<subspace::RpcClient>("TestService", 7,
+                                                        ClientTest::Socket());
+    ASSERT_OK(client->Open(c));
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+    test_request.set_stream_period(100);
+
+    class MyResponseReceiver
+        : public subspace::ResponseReceiver<rpc::TestResponse> {
+    public:
+      void OnResponse(rpc::TestResponse &&response) override {
+        std::cerr << "Received response: " << response.message() << std::endl;
+        count++;
+        if (count == 5) {
+          std::cerr << "Cancelling stream after 5 responses" << std::endl;
+          if (auto status = Cancel(); !status.ok()) {
+            std::cerr << "Error cancelling stream: " << status.ToString()
+                      << std::endl;
+          }
+        }
+      }
+
+      void OnError(const absl::Status &status) override {
+        std::cerr << "Received error: " << status.ToString() << std::endl;
+      }
+
+      void OnCancel() override { std::cerr << "Stream cancelled" << std::endl; }
+
+      void OnFinish() override { std::cerr << "Stream finished" << std::endl; }
+
+      int GetCount() const { return count; }
+
+      int count = 0;
+    };
+
+    MyResponseReceiver receiver;
+    absl::Status status = client->Call<rpc::TestRequest, rpc::TestResponse>(
+        "StreamMethod", test_request, receiver, c);
+    std::cerr << status.ToString() << std::endl;
+    ASSERT_OK(status);
+
+    // Depending on timing we may get a one more reponse after the cancel.
+    ASSERT_LE(receiver.GetCount(), 6);
+
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  absl::ParseCommandLine(argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/rpc/client/rpc_client.cc
+++ b/rpc/client/rpc_client.cc
@@ -1,0 +1,543 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "rpc/client/rpc_client.h"
+#include "rpc/server/rpc_server.h"
+
+namespace subspace {
+
+RpcClient::RpcClient(std::string service, uint64_t client_id,
+                     std::string subspace_server_socket)
+    : service_(std::move(service)), client_id_(client_id),
+      subspace_server_socket_(std::move(subspace_server_socket)),
+      logger_("rpcclient") {}
+
+RpcClient::~RpcClient() {
+  if (session_id_ != 0) {
+    auto status = CloseService(std::chrono::nanoseconds(0), coroutine_);
+    if (!status.ok()) {
+      logger_.Log(toolbelt::LogLevel::kError, "Error closing RPC client: %s",
+                  status.ToString().c_str());
+    }
+  }
+}
+
+absl::StatusOr<int> RpcClient::FindMethod(std::string_view method) {
+  auto it = method_name_to_id_.find(method);
+  if (it == method_name_to_id_.end()) {
+    return absl::NotFoundError("Method not found");
+  }
+  return it->second;
+}
+
+absl::Status RpcClient::Open(std::chrono::nanoseconds timeout,
+                             co::Coroutine *c) {
+  if (session_id_ != 0) {
+    return absl::FailedPreconditionError("Session already initialized");
+  }
+  logger_.Log(toolbelt::LogLevel::kDebug,
+              "Initializing RPC client for service: %s", service_.c_str());
+  coroutine_ = c;
+  auto client = Client::Create(subspace_server_socket_);
+  if (!client.ok()) {
+    return absl::InternalError(absl::StrFormat("Failed to create client: %s",
+                                               client.status().ToString()));
+  }
+  client_ = std::move(*client);
+
+  return OpenService(timeout, c);
+}
+
+absl::Status RpcClient::Close(std::chrono::nanoseconds timeout,
+                              co::Coroutine *c) {
+  if (session_id_ == 0) {
+    return absl::FailedPreconditionError("Session not initialized");
+  }
+  auto status = CloseService(timeout, coroutine_);
+  if (!status.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to close service: %s", status.ToString()));
+  }
+  session_id_ = 0;
+  return absl::OkStatus();
+}
+
+absl::Status
+RpcClient::PublishServerRequest(const subspace::RpcServerRequest &req,
+                                std::chrono::nanoseconds timeout,
+                                co::Coroutine *c) {
+  uint64_t length = req.ByteSizeLong();
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    if (service_pub_->NumSubscribers() == 0) {
+      Destroy();
+      return absl::InternalError("No subscribers; is the RPC server running?");
+    }
+    buffer = service_pub_->GetMessageBuffer(int32_t(length));
+    if (!buffer.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to get message buffer: %s", buffer.status().ToString()));
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    // Can't send yet, wait and try again.
+    auto wait_status = service_pub_->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to wait for message buffer: %s", wait_status.ToString()));
+    }
+  }
+
+  if (!req.SerializeToArray(*buffer, int32_t(length))) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to serialize request: %s", buffer.status().ToString()));
+  }
+  auto pub_status = service_pub_->PublishMessage(int32_t(length));
+  if (!pub_status.ok()) {
+    return absl::InternalError(absl::StrFormat("Failed to publish request: %s",
+                                               pub_status.status().ToString()));
+  }
+  logger_.Log(toolbelt::LogLevel::kDebug, "Published RPC request: %s",
+              req.DebugString().c_str());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<subspace::RpcServerResponse>
+RpcClient::ReadServerResponse(int request_id, std::chrono::nanoseconds timeout,
+                              co::Coroutine *c) {
+  // Wait for the response and read it.
+  for (;;) {
+    auto wait_status = service_sub_->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError("Timeout waiting for response");
+    }
+    for (;;) {
+      auto m = service_sub_->ReadMessage();
+      if (!m.ok()) {
+        return absl::InternalError(absl::StrFormat("Failed to read message: %s",
+                                                   m.status().ToString()));
+      }
+      if (m->length > 0) {
+        subspace::Message msg = std::move(*m);
+        subspace::RpcServerResponse response;
+        if (!response.ParseFromArray(msg.buffer, msg.length)) {
+          return absl::InternalError("Failed to parse RPC server response");
+        }
+        if (response.client_id() == client_id_ &&
+            response.request_id() == request_id) {
+          logger_.Log(toolbelt::LogLevel::kDebug,
+                      "Received RPC server response: %s",
+                      response.DebugString().c_str());
+          return response;
+        }
+        continue;
+      }
+      break;
+    }
+  }
+}
+
+absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
+                                    co::Coroutine *c) {
+  logger_.Log(toolbelt::LogLevel::kDebug, "Opening service");
+  subspace::RpcServerRequest req;
+  req.set_client_id(client_id_);
+  int request_id = next_request_id_++;
+  req.set_request_id(request_id);
+  req.mutable_open();
+
+  auto client = subspace::Client::Create(subspace_server_socket_, service_);
+  if (!client.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to create subspace client: %s", client.status().ToString()));
+  }
+  client_ = std::move(*client);
+  std::string request_name = absl::StrFormat("/rpc/%s/request", service_);
+  logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher to channel: %s",
+              request_name.c_str());
+  auto pub = client_->CreatePublisher(request_name,
+                                      {.slot_size = kRpcRequestSlotSize,
+                                       .num_slots = kRpcRequestNumSlots,
+                                       .reliable = true,
+                                       .type = "subspace.RpcServerRequest"});
+  if (!pub.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to create request publisher: %s", pub.status().ToString()));
+  }
+  service_pub_ = std::make_shared<subspace::Publisher>(std::move(*pub));
+
+  auto sub = client_->CreateSubscriber(
+      absl::StrFormat("/rpc/%s/response", service_),
+      {.reliable = true, .type = "subspace.RpcServerResponse"});
+  if (!sub.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to create response subscriber: %s", sub.status().ToString()));
+  }
+
+  service_sub_ = std::make_shared<subspace::Subscriber>(std::move(*sub));
+
+  logger_.Log(toolbelt::LogLevel::kDebug, "Sending open request");
+  auto pub_status = PublishServerRequest(req, timeout, c);
+  if (!pub_status.ok()) {
+    return pub_status;
+  }
+
+  auto resp = ReadServerResponse(request_id, timeout, c);
+  if (!resp.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to read server response: %s", resp.status().ToString()));
+  }
+
+  subspace::RpcServerResponse response = std::move(*resp);
+  if (!response.has_open()) {
+    return absl::InternalError("RPC server response is missing open");
+  }
+  session_id_ = response.open().session_id();
+
+  // Populate the methods.
+  for (const auto &method : response.open().methods()) {
+    auto m = std::make_shared<client_internal::Method>();
+    m->name = method.name();
+    m->id = method.id();
+    m->request_type = method.request_channel().type();
+    m->response_type = method.response_channel().type();
+    m->slot_size = method.request_channel().slot_size();
+    m->num_slots = method.request_channel().num_slots();
+
+    auto pub = client_->CreatePublisher(
+        method.request_channel().name(), m->slot_size, m->num_slots,
+        {.reliable = true, .type = method.request_channel().type()});
+    if (!pub.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to create request publisher: %s", pub.status().ToString()));
+    }
+    m->request_publisher =
+        std::make_shared<subspace::Publisher>(std::move(*pub));
+
+    auto sub = client_->CreateSubscriber(
+        method.response_channel().name(),
+        {.reliable = true, .type = method.response_channel().type()});
+    if (!sub.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to create response subscriber: %s", sub.status().ToString()));
+    }
+    m->response_subscriber =
+        std::make_shared<subspace::Subscriber>(std::move(*sub));
+
+    if (!method.cancel_channel().empty()) {
+      auto cpub = client_->CreatePublisher(method.cancel_channel(),
+                                           kCancelChannelSlotSize,
+                                           kCancelChannelNumSlots,
+                                           {
+                                               .reliable = true,
+                                           });
+      if (!cpub.ok()) {
+        return absl::InternalError(absl::StrFormat(
+            "Failed to create cancel publisher: %s", cpub.status().ToString()));
+      }
+      m->cancel_publisher =
+          std::make_shared<subspace::Publisher>(std::move(*cpub));
+    }
+    method_name_to_id_[m->name] = m->id;
+    methods_[m->id] = std::move(m);
+  }
+  logger_.Log(toolbelt::LogLevel::kInfo,
+              "Opened service %s with session ID: %d", service_.c_str(),
+              session_id_);
+  return absl::OkStatus();
+}
+
+absl::Status RpcClient::CloseService(std::chrono::nanoseconds timeout,
+                                     co::Coroutine *c) {
+  if (closed_) {
+    return absl::InternalError("Client is closed");
+  }
+  subspace::RpcServerRequest req;
+  req.set_client_id(client_id_);
+  int request_id = next_request_id_++;
+  req.set_request_id(request_id);
+  req.mutable_close()->set_session_id(session_id_);
+
+  auto pub_status = PublishServerRequest(req, timeout, c);
+  if (!pub_status.ok()) {
+    return pub_status;
+  }
+
+  auto resp = ReadServerResponse(request_id, timeout, c);
+  if (!resp.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to read server response: %s", resp.status().ToString()));
+  }
+
+  subspace::RpcServerResponse response = std::move(*resp);
+  if (!response.has_close()) {
+    return absl::InternalError("RPC server response is missing close");
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<google::protobuf::Any>
+RpcClient::InvokeMethod(int method_id, const google::protobuf::Any &request,
+                        std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  if (closed_) {
+    return absl::InternalError("Client is closed");
+  }
+  if (c == nullptr) {
+    c = coroutine_;
+  }
+  auto it = methods_.find(method_id);
+  if (it == methods_.end()) {
+    return absl::NotFoundError(
+        absl::StrFormat("Method %d not found", method_id));
+  }
+
+  const auto &method = it->second;
+
+  subspace::RpcRequest req;
+  int request_id = ++next_request_id_;
+  req.set_client_id(client_id_);
+  req.set_session_id(session_id_);
+  req.set_request_id(request_id);
+  req.set_method(method_id);
+  *req.mutable_argument() = request;
+
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    if (method->request_publisher->NumSubscribers() == 0) {
+      Destroy();
+      return absl::InternalError("No subscribers; is the RPC server running?");
+    }
+    buffer = method->request_publisher->GetMessageBuffer(
+        int32_t(req.ByteSizeLong()));
+    if (!buffer.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to get message buffer: %s", buffer.status().ToString()));
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    // Can't send yet, wait and try again.
+    auto wait_status = method->request_publisher->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to wait for message buffer: %s", wait_status.ToString()));
+    }
+  }
+
+  // We can serialize and publish now.
+  uint64_t request_size = req.ByteSizeLong();
+  if (!req.SerializeToArray(*buffer, int32_t(request_size))) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to serialize request: %s", req.SerializeAsString()));
+  }
+  auto pub_status =
+      method->request_publisher->PublishMessage(int32_t(request_size));
+  if (!pub_status.ok()) {
+    return absl::InternalError(absl::StrFormat("Failed to publish request: %s",
+                                               pub_status.status().ToString()));
+  }
+
+  // Wait for the response.
+  for (;;) {
+    auto wait_status = method->response_subscriber->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Error waiting for response: %s", wait_status.ToString()));
+    }
+    for (;;) {
+      auto m = method->response_subscriber->ReadMessage();
+      if (!m.ok()) {
+        return absl::InternalError(absl::StrFormat("Failed to read message: %s",
+                                                   m.status().ToString()));
+      }
+      if (m->length > 0) {
+        subspace::Message msg = std::move(*m);
+        subspace::RpcResponse rpc_response;
+        if (!rpc_response.ParseFromArray(msg.buffer, msg.length)) {
+          return absl::InternalError("Failed to parse RPC response");
+        }
+        if (rpc_response.client_id() == client_id_ &&
+            rpc_response.request_id() == request_id &&
+            rpc_response.session_id() == session_id_) {
+          logger_.Log(toolbelt::LogLevel::kDebug, "Received RPC response: %s",
+                      rpc_response.DebugString().c_str());
+          if (!rpc_response.error().empty()) {
+            return absl::InternalError(
+                absl::StrFormat("%s", rpc_response.error()));
+          }
+          return rpc_response.result();
+        }
+        continue;
+      }
+      break;
+    }
+  }
+}
+
+absl::Status RpcClient::InvokeMethod(
+    int method_id, const google::protobuf::Any &request,
+    std::function<void(std::shared_ptr<RpcClient>, uint64_t, int, int,
+                       std::shared_ptr<client_internal::Method>,
+                       const RpcResponse *)>
+        response_handler,
+    std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  if (closed_) {
+    return absl::InternalError("Client is closed");
+  }
+  if (c == nullptr) {
+    c = coroutine_;
+  }
+  auto it = methods_.find(method_id);
+  if (it == methods_.end()) {
+    return absl::NotFoundError(
+        absl::StrFormat("Method %d not found", method_id));
+  }
+
+  const auto &method = it->second;
+
+  subspace::RpcRequest req;
+  int request_id = ++next_request_id_;
+  req.set_client_id(client_id_);
+  req.set_session_id(session_id_);
+  req.set_request_id(request_id);
+  req.set_method(method_id);
+  *req.mutable_argument() = request;
+
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    if (method->request_publisher->NumSubscribers() == 0) {
+      Destroy();
+      return absl::InternalError("No subscribers; is the RPC server running?");
+    }
+    buffer = method->request_publisher->GetMessageBuffer(
+        int32_t(req.ByteSizeLong()));
+    if (!buffer.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to get message buffer: %s", buffer.status().ToString()));
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    // Can't send yet, wait and try again.
+    auto wait_status = method->request_publisher->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Failed to wait for message buffer: %s", wait_status.ToString()));
+    }
+  }
+
+  // We can serialize and publish now.
+  uint64_t request_size = req.ByteSizeLong();
+  if (!req.SerializeToArray(*buffer, int32_t(request_size))) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to serialize request: %s", req.SerializeAsString()));
+  }
+  auto pub_status =
+      method->request_publisher->PublishMessage(int32_t(request_size));
+  if (!pub_status.ok()) {
+    return absl::InternalError(absl::StrFormat("Failed to publish request: %s",
+                                               pub_status.status().ToString()));
+  }
+  // We have sent the method invocation request.  Now we receive all the
+  // responses.
+
+  for (;;) {
+    auto wait_status = method->response_subscriber->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(absl::StrFormat(
+          "Error waiting for response: %s", wait_status.ToString()));
+    }
+    for (;;) {
+      auto m = method->response_subscriber->ReadMessage();
+      if (!m.ok()) {
+        return absl::InternalError(absl::StrFormat("Failed to read message: %s",
+                                                   m.status().ToString()));
+      }
+      if (m->length > 0) {
+        subspace::Message msg = std::move(*m);
+        subspace::RpcResponse rpc_response;
+        if (!rpc_response.ParseFromArray(msg.buffer, msg.length)) {
+          return absl::InternalError("Failed to parse RPC response");
+        }
+        if (rpc_response.client_id() == client_id_ &&
+            rpc_response.request_id() == request_id &&
+            rpc_response.session_id() == session_id_) {
+          logger_.Log(toolbelt::LogLevel::kDebug, "Received RPC response: %s",
+                      rpc_response.DebugString().c_str());
+          if (!rpc_response.error().empty()) {
+            return absl::InternalError(
+                absl::StrFormat("%s", rpc_response.error()));
+          }
+          response_handler(shared_from_this(), client_id_, session_id_,
+                           request_id, method, &rpc_response);
+          // We stop receiving response if this is the last one, cancelled or
+          // errored
+          if (rpc_response.is_last() || rpc_response.is_cancelled() ||
+              !rpc_response.error().empty()) {
+            return absl::OkStatus();
+          }
+        }
+        continue;
+      }
+      break;
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status
+RpcClient::CancelRequest(uint64_t client_id, int session_id, int request_id,
+                         std::shared_ptr<client_internal::Method> method,
+                         std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  if (closed_) {
+    return absl::InternalError("Client is closed");
+  }
+  subspace::RpcCancelRequest req;
+  req.set_client_id(client_id_);
+  req.set_session_id(session_id_);
+  req.set_request_id(request_id);
+
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    if (method->cancel_publisher->NumSubscribers() == 0) {
+      Destroy();
+      return absl::InternalError("No subscribers; is the RPC server running?");
+    }
+    buffer =
+        method->cancel_publisher->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    if (!buffer.ok()) {
+      return absl::InternalError(
+          absl::StrFormat("Failed to get message buffer for cancel: %s",
+                          buffer.status().ToString()));
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    // Can't send yet, wait and try again.
+    auto wait_status = method->cancel_publisher->Wait(timeout, c);
+    if (!wait_status.ok()) {
+      return absl::InternalError(
+          absl::StrFormat("Failed to wait for message buffer for cancel: %s",
+                          wait_status.ToString()));
+    }
+  }
+
+  // We can serialize and publish now.
+  uint64_t request_size = req.ByteSizeLong();
+  if (!req.SerializeToArray(*buffer, int32_t(request_size))) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to serialize cancel request: %s", req.SerializeAsString()));
+  }
+  auto pub_status =
+      method->cancel_publisher->PublishMessage(int32_t(request_size));
+  if (!pub_status.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to publish cancel request: %s",
+                        pub_status.status().ToString()));
+  }
+  return absl::OkStatus();
+}
+
+} // namespace subspace

--- a/rpc/client/rpc_client.h
+++ b/rpc/client/rpc_client.h
@@ -1,0 +1,431 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#pragma once
+
+#include "client/client.h"
+#include "toolbelt/logging.h"
+
+#include <chrono>
+#include <type_traits>
+#include <string_view>
+
+namespace subspace {
+
+class RpcClient;
+
+constexpr int32_t kCancelChannelSlotSize = 64;
+constexpr int32_t kCancelChannelNumSlots = 8;
+
+namespace client_internal {
+struct Method {
+  std::string name;
+  int id;
+  std::string request_type;
+  std::string response_type;
+  int32_t slot_size;
+  int32_t num_slots;
+  std::shared_ptr<subspace::Publisher> request_publisher;
+  std::shared_ptr<subspace::Subscriber> response_subscriber;
+  std::shared_ptr<subspace::Publisher> cancel_publisher;
+};
+
+template <typename Response> class ResponseReceiverBase {
+public:
+  ResponseReceiverBase() = default;
+  virtual ~ResponseReceiverBase() = default;
+
+  // Called when a response is received.
+  virtual void OnResponse(Response &&response) = 0;
+};
+
+template <> class ResponseReceiverBase<void> {
+public:
+  ResponseReceiverBase() = default;
+  virtual ~ResponseReceiverBase() = default;
+
+  // Called when a response is received.
+  virtual void OnResponse() = 0;
+};
+} // namespace client_internal
+
+template <typename Response> class ResponseReceiver : public client_internal::ResponseReceiverBase<Response> {
+public:
+  ResponseReceiver() = default;
+  ~ResponseReceiver() override = default;
+
+  // Called when a response is received.
+  // From ResponseReceiverBase:
+  //   virtual void OnResponse(Response &&response) = 0;
+  // Or, if Response == void:
+  //   virtual void OnResponse() = 0;
+
+  virtual void OnFinish() = 0;
+
+  // Called when an error occurs.
+  virtual void OnError(const absl::Status &status) = 0;
+
+  virtual void OnCancel() = 0;
+
+  bool IsCancelled() const { return cancelled_; }
+
+  absl::Status Cancel(std::chrono::nanoseconds timeout,
+                      co::Coroutine *c = nullptr);
+
+  absl::Status Cancel(co::Coroutine *c = nullptr) {
+    return Cancel(std::chrono::nanoseconds(0), c);
+  }
+
+  void SetInvokationDetails(std::shared_ptr<RpcClient> client,
+                            uint64_t client_id, int session_id, int request_id,
+                            std::shared_ptr<client_internal::Method> method) {
+    if (client_ != nullptr) {
+      return;
+    }
+    client_id_ = client_id;
+    session_id_ = session_id;
+    request_id_ = request_id;
+    method_ = method;
+    client_ = client;
+  }
+
+private:
+  bool cancelled_ = false;
+  uint64_t client_id_ = 0;
+  int session_id_ = 0;
+  int request_id_ = 0;
+  std::shared_ptr<client_internal::Method> method_ = nullptr;
+  std::shared_ptr<RpcClient> client_ = nullptr;
+};
+
+class RpcClient : public std::enable_shared_from_this<RpcClient> {
+public:
+  // Create an RPC client.  The arguments are:
+  // service: the RPC service to use - there must be an RPC server running on
+  //     this service.
+  // client_id: the ID of the client - unique per client (getpid() or
+  //     gettid() maybe)
+  // subspace_server_socket: the socket path for the subspace server
+  RpcClient(std::string service, uint64_t client_id,
+            std::string subspace_server_socket = "/tmp/subspace");
+  ~RpcClient();
+
+  // Set the logger level.  Valid levels are:
+  // verbose, debug, info, warning, error
+  void SetLogLevel(const std::string &level) { logger_.SetLogLevel(level); }
+
+  // Open the RPC client and connect to the service passed to the constructor.
+  absl::Status Open(co::Coroutine *c = nullptr) {
+    return Open(std::chrono::nanoseconds(0), c);
+  }
+  absl::Status Open(std::chrono::nanoseconds timeout,
+                    co::Coroutine *c = nullptr);
+
+  absl::Status Close(co::Coroutine *c = nullptr) {
+    return Close(std::chrono::nanoseconds(0), c);
+  }
+  absl::Status Close(std::chrono::nanoseconds timeout,
+                     co::Coroutine *c = nullptr);
+
+  absl::StatusOr<int> FindMethod(std::string_view method);
+
+  template <typename Response>
+  using CallResult = std::conditional_t<
+      std::is_same_v<void, Response>, absl::Status, absl::StatusOr<Response>>;
+
+  // Call with request and response.  A timeout will result in an error.
+  // Request type can be:
+  //  - A protobuf message type, or
+  //  - A container of bytes (with data() and size() members).
+  // Response type can be:
+  //  - A protobuf message type, or
+  //  - `void` (default if omitted) to ignore/discard the response, or
+  //  - A container of bytes (constructible from two iterators).
+  // For non-void response types, returns absl::StatusOr<Response>,
+  // otherwise, returns absl::Status.
+  template <typename Request, typename Response = void>
+  CallResult<Response> Call(int method_id, const Request &request,
+                            std::chrono::nanoseconds timeout,
+                            co::Coroutine *c = nullptr);
+
+  // Call with request and response, same as above, except this will
+  // block (the coroutine if provided) and there is no timeout.
+  template <typename Request, typename Response = void>
+  CallResult<Response> Call(int method_id, const Request &request,
+                            co::Coroutine *c = nullptr) {
+    return Call<Request, Response>(method_id, request,
+                                   std::chrono::nanoseconds(0), c);
+  }
+
+  // Call with request and response, same as above, but using the method's
+  // name rather than its id.  A timeout will result in an error.
+  template <typename Request, typename Response = void>
+  CallResult<Response>
+  Call(std::string_view method_name, const Request &request,
+       std::chrono::nanoseconds timeout, co::Coroutine *c = nullptr);
+
+  // Call with request and response, same as above, but using the method's
+  // name rather than its id.  This will block (the coroutine if provided)
+  // and there is no timeout.
+  template <typename Request, typename Response = void>
+  CallResult<Response> Call(std::string_view method_name,
+                            const Request &request,
+                            co::Coroutine *c = nullptr) {
+    return Call<Request, Response>(method_name, request,
+                                   std::chrono::nanoseconds(0), c);
+  }
+
+  // Call a streaming function.  A class derived from the ResponseReceiver
+  // interface is provided and will be used to receive responses.  This
+  // function will block until all streaming responses have been received.
+  // Request type can be:
+  //  - A protobuf message type, or
+  //  - A container of bytes (with data() and size() members).
+  // Response type can be:
+  //  - A protobuf message type, or
+  //  - `void` (default if omitted) to ignore/discard the response, or
+  //  - A container of bytes (constructible from two iterators).
+  template <typename Request, typename Response>
+  absl::Status Call(int method_id, const Request &request,
+                    ResponseReceiver<Response> &receiver,
+                    std::chrono::nanoseconds timeout,
+                    co::Coroutine *c = nullptr);
+
+  template <typename Request, typename Response>
+  absl::Status Call(const std::string &method_name, const Request &request,
+                    ResponseReceiver<Response> &receiver,
+                    std::chrono::nanoseconds timeout,
+                    co::Coroutine *c = nullptr);
+
+  template <typename Request, typename Response>
+  absl::Status Call(int method_id, const Request &request,
+                    ResponseReceiver<Response> &receiver,
+                    co::Coroutine *c = nullptr) {
+    return Call(method_id, request, receiver, std::chrono::nanoseconds(0), c);
+  }
+
+  template <typename Request, typename Response>
+  absl::Status Call(const std::string &method_name, const Request &request,
+                    ResponseReceiver<Response> &receiver,
+                    co::Coroutine *c = nullptr) {
+    return Call(method_name, request, receiver, std::chrono::nanoseconds(0), c);
+  }
+
+  absl::Status CancelRequest(uint64_t client_id, int session_id, int request_id,
+                             std::shared_ptr<client_internal::Method> method,
+                             std::chrono::nanoseconds timeout,
+                             co::Coroutine *c);
+
+private:
+  absl::Status OpenService(std::chrono::nanoseconds timeout, co::Coroutine *c);
+  absl::Status CloseService(std::chrono::nanoseconds timeout, co::Coroutine *c);
+  absl::Status PublishServerRequest(const subspace::RpcServerRequest &req,
+                                    std::chrono::nanoseconds timeout,
+                                    co::Coroutine *c = nullptr);
+  absl::StatusOr<subspace::RpcServerResponse>
+  ReadServerResponse(int request_id, std::chrono::nanoseconds timeout,
+                     co::Coroutine *c = nullptr);
+
+  // Low level method invocation functions that takes untyped protobuf.Any
+  // request and response.
+  absl::StatusOr<google::protobuf::Any>
+  InvokeMethod(int method_id, const google::protobuf::Any &request,
+               co::Coroutine *c = nullptr) {
+    return InvokeMethod(method_id, request, std::chrono::nanoseconds(0), c);
+  }
+
+  absl::StatusOr<google::protobuf::Any>
+  InvokeMethod(int method_id, const google::protobuf::Any &request,
+               std::chrono::nanoseconds timeout, co::Coroutine *c = nullptr);
+
+  absl::Status
+  InvokeMethod(int method_id, const google::protobuf::Any &request,
+               std::function<void(std::shared_ptr<RpcClient>, uint64_t, int,
+                                  int, std::shared_ptr<client_internal::Method>,
+                                  const RpcResponse *)>
+                   response_handler,
+               std::chrono::nanoseconds timeout, co::Coroutine *c = nullptr);
+
+  // This is only used for error reporting so a linear search is fine.
+  std::string MethodName(int id) const {
+    for (const auto &m : methods_) {
+      if (m.second->id == id) {
+        return m.second->name;
+      }
+    }
+    return "unknown";
+  }
+
+  void Destroy() {
+    client_.reset();
+    service_sub_.reset();
+    service_pub_.reset();
+    methods_.clear();
+    closed_ = true;
+  }
+
+  std::string service_;
+  uint64_t client_id_;
+  std::string subspace_server_socket_;
+  toolbelt::Logger logger_;
+  co::Coroutine *coroutine_ = nullptr;
+  std::shared_ptr<subspace::Client> client_;
+  absl::flat_hash_map<int, std::shared_ptr<client_internal::Method>> methods_;
+  absl::flat_hash_map<std::string_view, int> method_name_to_id_;
+  int session_id_ = 0;
+  int next_request_id_ = 0;
+  std::shared_ptr<subspace::Publisher> service_pub_;
+  std::shared_ptr<subspace::Subscriber> service_sub_;
+  bool closed_ = false;
+};
+
+// Call with request and response.  Both types must be protobuf messages.  A
+// timeout will result in an error.
+template <typename Request, typename Response>
+inline RpcClient::CallResult<Response>
+RpcClient::Call(int method_id, const Request &request,
+                std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  google::protobuf::Any any;
+  if constexpr (std::is_base_of_v<google::protobuf::Message, Request>) {
+    any.PackFrom(request);
+  } else {
+    RawMessage raw_request;
+    raw_request.set_data(request.data(), request.size());
+    any.PackFrom(raw_request);
+  }
+  auto r = InvokeMethod(method_id, any, timeout, c);
+  if (!r.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to invoke method '%s': %s", MethodName(method_id), r.status().ToString()));
+  }
+  if constexpr (std::is_base_of_v<google::protobuf::Message, Response>) {
+    Response resp;
+    if (!r->UnpackTo(&resp)) {
+      return absl::InternalError(
+          absl::StrFormat("Failed to unpack response of type %s",
+                          Response::descriptor()->full_name()));
+    }
+    return resp;
+  } else if constexpr (std::is_same_v<Response, void>) {
+    VoidMessage resp;
+    if (!r->UnpackTo(&resp)) {
+      return absl::InternalError("Failed to unpack void response");
+    }
+    return absl::OkStatus();
+  } else {
+    RawMessage resp;
+    if (!r->UnpackTo(&resp)) {
+      return absl::InternalError("Failed to unpack raw bytes response");
+    }
+    return Response(resp.data().begin(), resp.data().end());
+  }
+}
+
+// Call with request and response.  Both types must be protobuf messages.  A
+// timeout will result in an error.
+template <typename Request, typename Response>
+inline RpcClient::CallResult<Response>
+RpcClient::Call(std::string_view method_name, const Request &request,
+                std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  auto method_id = FindMethod(method_name);
+  if (!method_id.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("No such method: '%s'", method_name));
+  }
+  return Call<Request, Response>(*method_id, request, timeout, c);
+}
+
+template <typename Request, typename Response>
+inline absl::Status RpcClient::Call(int method_id, const Request &request,
+                                    ResponseReceiver<Response> &receiver,
+                                    std::chrono::nanoseconds timeout,
+                                    co::Coroutine *c) {
+  google::protobuf::Any any;
+  if constexpr (std::is_base_of_v<google::protobuf::Message, Request>) {
+    any.PackFrom(request);
+  } else {
+    RawMessage raw_request;
+    raw_request.set_data(request.data(), request.size());
+    any.PackFrom(raw_request);
+  }
+  any.PackFrom(request);
+  auto status = InvokeMethod(
+      method_id, any,
+      [&receiver](std::shared_ptr<RpcClient> client, uint64_t client_id,
+                  int session_id, int request_id,
+                  std::shared_ptr<client_internal::Method> method,
+                  const RpcResponse *response) {
+        // For cancellation we need to store the IDs for the outgoing request.
+        receiver.SetInvokationDetails(client, client_id, session_id, request_id,
+                                      method);
+        if (response->is_cancelled()) {
+          receiver.OnCancel();
+        } else if (!response->error().empty()) {
+          receiver.OnError(absl::InternalError(response->error()));
+        } else if (response->is_last() && !response->has_result()) {
+          receiver.OnFinish();
+        } else {
+          if constexpr (std::is_base_of_v<google::protobuf::Message, Response>) {
+            Response resp;
+            if (!response->result().UnpackTo(&resp)) {
+              receiver.OnError(absl::InternalError(
+                  absl::StrFormat("Failed to unpack response of type %s",
+                                  Response::descriptor()->full_name())));
+            } else {
+              receiver.OnResponse(std::move(resp));
+            }
+          } else if constexpr (std::is_same_v<Response, void>) {
+            VoidMessage resp;
+            if (!response->result().UnpackTo(&resp)) {
+              receiver.OnError(absl::InternalError("Failed to unpack void response"));
+            } else {
+              receiver.OnResponse();
+            }
+          } else {
+            RawMessage resp;
+            if (!response->result().UnpackTo(&resp)) {
+              receiver.OnError(absl::InternalError("Failed to unpack raw bytes response"));
+            } else {
+              receiver.OnResponse(Response(resp.data().begin(), resp.data().end()));
+            }
+          }
+        }
+      },
+      timeout, c);
+  if (!status.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to invoke method: %s", status.ToString()));
+  }
+  return absl::OkStatus();
+}
+
+template <typename Request, typename Response>
+inline absl::Status
+RpcClient::Call(const std::string &method_name, const Request &request,
+                ResponseReceiver<Response> &receiver,
+                std::chrono::nanoseconds timeout, co::Coroutine *c) {
+  auto method_id = FindMethod(method_name);
+  if (!method_id.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("No such method: '%s'", method_name));
+  }
+  return Call(*method_id, request, receiver, timeout, c);
+}
+
+template <typename Response>
+inline absl::Status
+ResponseReceiver<Response>::Cancel(std::chrono::nanoseconds timeout,
+                                   co::Coroutine *c) {
+  if (IsCancelled()) {
+    return absl::OkStatus();
+  }
+  if (auto status = client_->CancelRequest(client_id_, session_id_, request_id_,
+                                           method_, timeout, c);
+      !status.ok()) {
+    return status;
+  }
+  cancelled_ = true;
+  return absl::OkStatus();
+}
+} // namespace subspace

--- a/rpc/example/BUILD.bazel
+++ b/rpc/example/BUILD.bazel
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_test(
+    name = "server",
+    srcs = ["server.cc"],
+    data = [
+        "//server:subspace_server",
+    ],
+    deps = [
+        "//rpc/proto:rpc_test_cc_proto",
+        "//rpc/proto:rpc_test_subspace_rpc_server",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "client",
+    srcs = ["client.cc"],
+    data = [
+        "//server:subspace_server",
+    ],
+    deps = [
+        "//rpc/proto:rpc_test_cc_proto",
+        "//rpc/proto:rpc_test_subspace_rpc_client",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/rpc/example/client.cc
+++ b/rpc/example/client.cc
@@ -1,0 +1,133 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "rpc/proto/rpc_test.pb.h"
+#include "rpc/proto/rpc_test.subspace.rpc_client.h"
+#include "toolbelt/clock.h"
+#include <chrono>
+#include <inttypes.h>
+#include <memory>
+#include <signal.h>
+
+ABSL_FLAG(std::string, subspace_socket, "/tmp/subspace",
+          "Subspace server socket name");
+ABSL_FLAG(std::string, method, "TestMethod", "Method to call");
+ABSL_FLAG(std::string, log_level, "info",
+          "Log level (debug, info, warn, error)");
+ABSL_FLAG(int, perf_iterations, 1000,
+          "Number of iterations for PerfMethod");
+static absl::Status
+InvokeTestMethod(std::shared_ptr<rpc::TestServiceClient> client) {
+  rpc::TestRequest req;
+  req.set_message("this is a test");
+  auto r = client->TestMethod(req);
+  if (!r.ok()) {
+    return r.status();
+  }
+  std::cout << "Response: " << r->DebugString() << std::endl;
+  return absl::OkStatus();
+}
+
+static absl::Status
+InvokePerfMethod(std::shared_ptr<rpc::TestServiceClient> client) {
+  int num_iterations = absl::GetFlag(FLAGS_perf_iterations);
+  uint64_t total_rtt = 0;
+  uint64_t total_server_time = 0;
+  for (int i = 0; i < num_iterations; i++) {
+    rpc::PerfRequest req;
+    req.set_send_time(toolbelt::Now());
+    auto r = client->PerfMethod(req);
+    if (!r.ok()) {
+      return r.status();
+    }
+    uint64_t rtt = toolbelt::Now() - req.send_time();
+    uint64_t server_time = r->server_send_time() - r->client_send_time();
+    total_rtt += rtt;
+    total_server_time += server_time;
+  }
+  uint64_t rtt = total_rtt / num_iterations;
+  uint64_t server_time = total_server_time / num_iterations;
+  std::cout << "RTT: " << rtt << " ns, Server time: " << server_time << " ns"
+            << std::endl;
+  return absl::OkStatus();
+}
+
+static absl::Status
+InvokeStreamMethod(std::shared_ptr<rpc::TestServiceClient> client) {
+  rpc::TestRequest req;
+  req.set_message("this is a test");
+  req.set_stream_period(10); // 10ms between responses
+
+  class MyResponseReceiver
+      : public subspace::ResponseReceiver<rpc::TestResponse> {
+  public:
+    void OnResponse(rpc::TestResponse &&response) override {
+      std::cerr << "Received response: " << response.message() << std::endl;
+      count++;
+    }
+    void OnError(const absl::Status &status) override {
+      std::cerr << "Received error: " << status.ToString() << std::endl;
+    }
+    void OnCancel() override { std::cerr << "Stream cancelled" << std::endl; }
+    void OnFinish() override { std::cerr << "Stream finished" << std::endl; }
+    int GetCount() const { return count; }
+    int count = 0;
+  };
+
+  MyResponseReceiver receiver;
+  absl::Status status = client->StreamMethod(req, receiver);
+  if (!status.ok()) {
+    return status;
+  }
+
+  std::cout << "Received " << receiver.GetCount() << " responses" << std::endl;
+  return absl::OkStatus();
+}
+
+int main(int argc, char **argv) {
+  absl::ParseCommandLine(argc, argv);
+  std::string socket = absl::GetFlag(FLAGS_subspace_socket);
+  auto cl = rpc::TestServiceClient::Create(getpid(), socket);
+  if (!cl.ok()) {
+    fprintf(stderr, "Error creating client: %s\n",
+            cl.status().ToString().c_str());
+    return 1;
+  }
+  auto client = *cl;
+  client->SetLogLevel(absl::GetFlag(FLAGS_log_level));
+  std::string method = absl::GetFlag(FLAGS_method);
+  if (method == "test") {
+    auto status = InvokeTestMethod(client);
+    if (!status.ok()) {
+      fprintf(stderr, "Error invoking TestMethod: %s\n",
+              status.ToString().c_str());
+      return 1;
+    }
+  } else if (method == "stream") {
+    auto status = InvokeStreamMethod(client);
+    if (!status.ok()) {
+      fprintf(stderr, "Error invoking StreamMethod: %s\n",
+              status.ToString().c_str());
+      return 1;
+    }
+  } else if (method == "perf") {
+    auto status = InvokePerfMethod(client);
+    if (!status.ok()) {
+      fprintf(stderr, "Error invoking PerfMethod: %s\n",
+              status.ToString().c_str());
+      return 1;
+    }
+  } else {
+    fprintf(stderr, "Unknown method: %s\n", method.c_str());
+    return 1;
+  }
+  auto status = client->Close();
+  if (!status.ok()) {
+    fprintf(stderr, "Error closing client: %s\n", status.ToString().c_str());
+    return 1;
+  }
+  return 0;
+}

--- a/rpc/example/server.cc
+++ b/rpc/example/server.cc
@@ -1,0 +1,90 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "rpc/proto/rpc_test.pb.h"
+#include "rpc/proto/rpc_test.subspace.rpc_server.h"
+#include "toolbelt/clock.h"
+#include <chrono>
+#include <inttypes.h>
+#include <memory>
+#include <signal.h>
+
+ABSL_FLAG(std::string, subspace_socket, "/tmp/subspace",
+          "Subspace server socket name");
+ABSL_FLAG(std::string, log_level, "info",
+          "Log level (debug, info, warn, error)");
+
+class TestServer : public rpc::TestServiceServer {
+public:
+  TestServer(const std::string &socket) : rpc::TestServiceServer(socket) {}
+  absl::StatusOr<rpc::TestResponse> TestMethod(const rpc::TestRequest &request,
+                                               co::Coroutine *c) override {
+    rpc::TestResponse response;
+    response.set_message("Hello from TestMethod");
+    return response;
+  }
+  absl::StatusOr<rpc::PerfResponse> PerfMethod(const rpc::PerfRequest &request,
+                                               co::Coroutine *c) override {
+    rpc::PerfResponse res;
+    res.set_client_send_time(request.send_time());
+    res.set_server_send_time(toolbelt::Now());
+    return res;
+  }
+  absl::Status StreamMethod(const rpc::TestRequest &request,
+                            subspace::StreamWriter<rpc::TestResponse> &writer,
+                            co::Coroutine *c) override {
+    std::cerr << "StreamMethod called with request: " << request.DebugString()
+              << std::endl;
+    constexpr int kNumResults = 200;
+    for (int i = 0; i < kNumResults; i++) {
+      if (writer.IsCancelled()) {
+        std::cerr << "StreamMethod cancelled after " << i << " responses"
+                  << std::endl;
+        writer.Finish(c);
+        return absl::OkStatus();
+      }
+      rpc::TestResponse r;
+      r.set_message("Hello from StreamMethod part " + std::to_string(i));
+      writer.Write(r, c);
+      c->Millisleep(request.stream_period());
+    }
+
+    writer.Finish(c);
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<rpc::TestResponse> ErrorMethod(const rpc::TestRequest &request,
+                                                co::Coroutine *c) override {
+    return absl::InternalError("Error occurred");
+  }
+
+  absl::StatusOr<rpc::TestResponse>
+  TimeoutMethod(const rpc::TestRequest &request, co::Coroutine *c) override {
+    c->Sleep(2);
+    rpc::TestResponse response;
+    response.set_message("Hello from TestMethod");
+    return response;
+  }
+};
+
+int main(int argc, char **argv) {
+  absl::ParseCommandLine(argc, argv);
+
+  TestServer server(absl::GetFlag(FLAGS_subspace_socket));
+  server.SetLogLevel(absl::GetFlag(FLAGS_log_level));
+  auto reg_status = server.RegisterMethods();
+  if (!reg_status.ok()) {
+    fprintf(stderr, "Error registering methods: %s\n",
+            reg_status.ToString().c_str());
+    return 1;
+  }
+  fprintf(stderr, "Starting server...\n");
+  auto status = server.Run();
+  if (!status.ok()) {
+    fprintf(stderr, "Error starting server: %s\n", status.ToString().c_str());
+    return 1;
+  }
+}

--- a/rpc/idl_compiler/BUILD.bazel
+++ b/rpc/idl_compiler/BUILD.bazel
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rpc_lib",
+    srcs = [
+        "gen.cc",
+        "service_gen.cc",
+    ],
+    hdrs = [
+        "gen.h",
+        "service_gen.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_protobuf//:protoc_lib",
+    ],
+)
+
+cc_binary(
+    name = "subspace_rpc",
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        ":rpc_lib",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_protobuf//:protoc_lib",
+    ],
+)
+
+sh_binary(
+    name = "run_protoc",
+    srcs = [
+        "run_protoc.sh",
+    ],
+    data = [
+        ":subspace_rpc",
+        "//rpc/proto:rpc_test_proto",
+        "@com_google_protobuf//:protoc",
+    ],
+)

--- a/rpc/idl_compiler/gen.cc
+++ b/rpc/idl_compiler/gen.cc
@@ -1,0 +1,289 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "rpc/idl_compiler/gen.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_split.h"
+#include <filesystem>
+#include <fstream>
+
+namespace subspace {
+
+static void
+WriteToZeroCopyStream(const std::string &data,
+                      google::protobuf::io::ZeroCopyOutputStream *stream) {
+  // Write to the stream that protobuf wants
+  void *data_buffer;
+  int size;
+  size_t offset = 0;
+  while (offset < data.size()) {
+    stream->Next(&data_buffer, &size);
+    int to_copy = std::min(size, static_cast<int>(data.size() - offset));
+    std::memcpy(data_buffer, data.data() + offset, to_copy);
+    offset += to_copy;
+    stream->BackUp(size - to_copy);
+  }
+}
+
+static std::string GeneratedFilename(const std::filesystem::path &package_name,
+                                     const std::filesystem::path &target_name,
+                                     std::string filename) {
+  size_t virtual_imports = filename.find("_virtual_imports/");
+  if (virtual_imports != std::string::npos) {
+    // This is something like:
+    // bazel-out/darwin_arm64-dbg/bin/external/com_google_protobuf/_virtual_imports/any_proto/google/protobuf/any.proto
+    filename = filename.substr(virtual_imports + sizeof("_virtual_imports/"));
+    // Remove the first directory.
+    filename = filename.substr(filename.find('/') + 1);
+  }
+  return package_name / target_name / filename;
+}
+
+bool CodeGenerator::Generate(
+    const google::protobuf::FileDescriptor *file, const std::string &parameter,
+    google::protobuf::compiler::GeneratorContext *generator_context,
+    std::string *error) const {
+
+  // The options for the compiler are passed in the --subspace_rpc_out parameter
+  // as a comma separated list of key=value pairs, followed by a colon
+  // and then the output directory.
+  std::vector<std::pair<std::string, std::string>> options;
+  google::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
+
+  for (auto option : options) {
+    std::cerr << "option " << option.first << "=" << option.second
+              << "\n";
+    if (option.first == "add_namespace") {
+      added_namespace_ = option.second;
+    } else if (option.first == "package_name") {
+      package_name_ = option.second;
+    } else if (option.first == "target_name") {
+      target_name_ = option.second;
+    }
+  }
+
+  Generator gen(file, added_namespace_, package_name_, target_name_);
+
+  if (!GenerateClient(file, gen, generator_context, error)) {
+    *error = "Failed to generate client code";
+    return false;
+  }
+
+  if (!GenerateServer(file, gen, generator_context, error)) {
+    *error = "Failed to generate server code";
+    return false;
+  }
+
+  return true;
+}
+
+bool CodeGenerator::GenerateClient(
+    const google::protobuf::FileDescriptor *file, Generator &gen,
+    google::protobuf::compiler::GeneratorContext *generator_context,
+    std::string *error) const {
+  std::string filename =
+      GeneratedFilename(package_name_, target_name_, file->name());
+
+  std::filesystem::path hp(filename);
+  hp.replace_extension(".subspace.rpc_client.h");
+  std::cerr << "Generating " << hp << "\n";
+
+  // There appears to be no way to get anything other than a
+  // ZeorCopyOutputStream from the GeneratorContext.  We want to use
+  // std::ofstream to write the file, so we'll write to a stringstream and then
+  // copy the data to the file.
+  std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> header_output(
+      generator_context->Open(hp.string()));
+
+  std::filesystem::create_directories(hp.parent_path());
+
+  if (header_output == nullptr) {
+    std::cerr << "Failed to open " << hp << " for writing\n";
+    *error = absl::StrFormat("Failed to open %s for writing", hp.string());
+    return false;
+  }
+  std::stringstream header_stream;
+  gen.GenerateClientHeaders(header_stream);
+
+  std::filesystem::path cp(filename);
+  cp.replace_extension(".subspace.rpc_client.cc");
+  std::cerr << "Generating " << cp << "\n";
+
+  std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> source_output(
+      generator_context->Open(cp.string()));
+  if (source_output == nullptr) {
+    *error = absl::StrFormat("Failed to open %s for writing", cp.string());
+    return false;
+  }
+  std::stringstream source_stream;
+  gen.GenerateClientSources(source_stream);
+
+  // Write to the streams that protobuf wants
+  WriteToZeroCopyStream(header_stream.str(), header_output.get());
+  WriteToZeroCopyStream(source_stream.str(), source_output.get());
+
+  return true;
+}
+
+bool CodeGenerator::GenerateServer(
+    const google::protobuf::FileDescriptor *file, Generator &gen,
+    google::protobuf::compiler::GeneratorContext *generator_context,
+    std::string *error) const {
+  std::string filename =
+      GeneratedFilename(package_name_, target_name_, file->name());
+
+  std::filesystem::path hp(filename);
+  hp.replace_extension(".subspace.rpc_server.h");
+  std::cerr << "Generating " << hp << "\n";
+
+  // There appears to be no way to get anything other than a
+  // ZeorCopyOutputStream from the GeneratorContext.  We want to use
+  // std::ofstream to write the file, so we'll write to a stringstream and then
+  // copy the data to the file.
+  std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> header_output(
+      generator_context->Open(hp.string()));
+
+  std::filesystem::create_directories(hp.parent_path());
+
+  if (header_output == nullptr) {
+    std::cerr << "Failed to open " << hp << " for writing\n";
+    *error = absl::StrFormat("Failed to open %s for writing", hp.string());
+    return false;
+  }
+  std::stringstream header_stream;
+  gen.GenerateServerHeaders(header_stream);
+
+  std::filesystem::path cp(filename);
+  cp.replace_extension(".subspace.rpc_server.cc");
+  std::cerr << "Generating " << cp << "\n";
+
+  std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> source_output(
+      generator_context->Open(cp.string()));
+  if (source_output == nullptr) {
+    *error = absl::StrFormat("Failed to open %s for writing", cp.string());
+    return false;
+  }
+  std::stringstream source_stream;
+  gen.GenerateServerSources(source_stream);
+
+  // Write to the streams that protobuf wants
+  WriteToZeroCopyStream(header_stream.str(), header_output.get());
+  WriteToZeroCopyStream(source_stream.str(), source_output.get());
+
+  return true;
+}
+
+void Generator::OpenNamespace(std::ostream &os) {
+  std::vector<std::string> parts = absl::StrSplit(file_->package(), '.');
+  for (const auto &part : parts) {
+    os << "namespace " << part << " {\n";
+  }
+  if (!added_namespace_.empty()) {
+    os << "namespace " << added_namespace_ << " {\n";
+  }
+}
+
+void Generator::CloseNamespace(std::ostream &os) {
+  if (!added_namespace_.empty()) {
+    os << "} // namespace " << added_namespace_ << "\n";
+  }
+  std::vector<std::string> parts = absl::StrSplit(file_->package(), '.');
+  for (const auto &part : parts) {
+    os << "} // namespace " << part << "\n";
+  }
+}
+
+Generator::Generator(const google::protobuf::FileDescriptor *file,
+                     const std::string &ns, const std::string &pn,
+                     const std::string &tn)
+    : file_(file), added_namespace_(ns), package_name_(pn), target_name_(tn) {
+  for (int i = 0; i < file->service_count(); i++) {
+    service_gens_.push_back(std::make_unique<ServiceGenerator>(
+        file->service(i), added_namespace_, file->package()));
+  }
+}
+
+void Generator::GenerateClientHeaders(std::ostream &os) {
+  os << "#pragma once\n";
+  std::string main_base =
+      GeneratedFilename("", "", file_->name());
+  std::filesystem::path cpp_header(main_base);
+  cpp_header.replace_extension(".pb.h");
+
+  os << "#include \"rpc/client/rpc_client.h\"\n";
+  os << "#include \"" << cpp_header.string() << "\"\n";
+  for (int i = 0; i < file_->dependency_count(); i++) {
+    std::string base = GeneratedFilename(package_name_, target_name_,
+                                         file_->dependency(i)->name());
+    std::filesystem::path p(base);
+    p.replace_extension(".subspace.rpc_client.h");
+    os << "#include \"" << p.string() << "\"\n";
+  }
+
+  OpenNamespace(os);
+
+  for (auto &msg_gen : service_gens_) {
+    msg_gen->GenerateClientHeader(os);
+  }
+
+  CloseNamespace(os);
+}
+
+void Generator::GenerateClientSources(std::ostream &os) {
+  std::filesystem::path p(
+      GeneratedFilename(package_name_, target_name_, file_->name()));
+  p.replace_extension(".subspace.rpc_client.h");
+  os << "#include \"" << p.string() << "\"\n";
+
+  OpenNamespace(os);
+
+  for (auto &svc_gen : service_gens_) {
+    svc_gen->GenerateClientSource(os);
+  }
+
+  CloseNamespace(os);
+}
+
+void Generator::GenerateServerHeaders(std::ostream &os) {
+  os << "#pragma once\n";
+  std::string main_base =
+      GeneratedFilename("", "", file_->name());
+  std::filesystem::path cpp_header(main_base);
+  cpp_header.replace_extension(".pb.h");
+
+  os << "#include \"rpc/server/rpc_server.h\"\n";
+  os << "#include \"" << cpp_header.string() << "\"\n";
+  for (int i = 0; i < file_->dependency_count(); i++) {
+    std::string base = GeneratedFilename(package_name_, target_name_,
+                                         file_->dependency(i)->name());
+    std::filesystem::path p(base);
+    p.replace_extension(".subspace.rpc_client.h");
+    os << "#include \"" << p.string() << "\"\n";
+  }
+
+  OpenNamespace(os);
+
+  for (auto &msg_gen : service_gens_) {
+    msg_gen->GenerateServerHeader(os);
+  }
+
+  CloseNamespace(os);
+}
+
+void Generator::GenerateServerSources(std::ostream &os) {
+  std::filesystem::path p(
+      GeneratedFilename(package_name_, target_name_, file_->name()));
+  p.replace_extension(".subspace.rpc_server.h");
+  os << "#include \"" << p.string() << "\"\n";
+
+  OpenNamespace(os);
+
+  for (auto &svc_gen : service_gens_) {
+    svc_gen->GenerateServerSource(os);
+  }
+
+  CloseNamespace(os);
+}
+
+} // namespace subspace

--- a/rpc/idl_compiler/gen.h
+++ b/rpc/idl_compiler/gen.h
@@ -1,0 +1,68 @@
+// Copyright 2024 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#pragma once
+
+#include "absl/status/status.h"
+#include "google/protobuf/compiler/code_generator.h"
+#include "google/protobuf/compiler/plugin.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+
+#include "rpc/idl_compiler/service_gen.h"
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace subspace {
+
+class Generator;
+
+class CodeGenerator : public google::protobuf::compiler::CodeGenerator {
+public:
+  CodeGenerator() = default;
+  bool Generate(const google::protobuf::FileDescriptor *file,
+                const std::string &parameter,
+                google::protobuf::compiler::GeneratorContext *generator_context,
+                std::string *error) const override;
+
+  uint64_t GetSupportedFeatures() const override {
+    return FEATURE_PROTO3_OPTIONAL;
+  }
+
+  bool GenerateClient(const google::protobuf::FileDescriptor *file, Generator& gen, google::protobuf::compiler::GeneratorContext *generator_context,
+    std::string *error) const;
+  bool GenerateServer(const google::protobuf::FileDescriptor *file, Generator& gen, google::protobuf::compiler::GeneratorContext *generator_context,
+    std::string *error) const;
+
+  mutable std::string added_namespace_;
+  mutable std::string package_name_;
+  mutable std::string target_name_;
+};
+
+class Generator {
+public:
+  Generator(const google::protobuf::FileDescriptor *file, const std::string &ns,
+            const std::string &pn, const std::string &tn);
+
+
+  void GenerateClientHeaders(std::ostream &os);
+  void GenerateClientSources(std::ostream &os);
+
+   void GenerateServerHeaders(std::ostream &os);
+  void GenerateServerSources(std::ostream &os);
+
+private:
+  void OpenNamespace(std::ostream &os);
+  void CloseNamespace(std::ostream &os);
+
+  const google::protobuf::FileDescriptor *file_;
+  std::vector<std::unique_ptr<ServiceGenerator>> service_gens_;
+  const std::string &added_namespace_;
+  const std::string &package_name_;
+  const std::string &target_name_;
+};
+
+} // namespace subspace

--- a/rpc/idl_compiler/main.cc
+++ b/rpc/idl_compiler/main.cc
@@ -1,0 +1,14 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "google/protobuf/compiler/code_generator.h"
+#include "google/protobuf/compiler/plugin.h"
+#include "rpc/idl_compiler/gen.h"
+
+
+int main(int argc, char *argv[]) {
+  std::cerr << "subspace rpc compiler running\n";
+  subspace::CodeGenerator generator;
+  return google::protobuf::compiler::PluginMain(argc, argv, &generator);
+}

--- a/rpc/idl_compiler/run_protoc.sh
+++ b/rpc/idl_compiler/run_protoc.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+../protobuf+/protoc \
+    --plugin=protoc-gen-subspace_rpc=rpc/idl_compiler/subspace_rpc \
+    rpc/proto/rpc_test.proto \
+    --subspace_rpc_out=/tmp

--- a/rpc/idl_compiler/service_gen.cc
+++ b/rpc/idl_compiler/service_gen.cc
@@ -1,0 +1,249 @@
+// Copyright 2024 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "rpc/idl_compiler/service_gen.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_replace.h"
+#include <algorithm>
+#include <cassert>
+#include <ctype.h>
+
+namespace subspace {
+void ServiceGenerator::GenerateClientHeader(std::ostream &os) {
+  // Client side class.
+  os << "class " << service_->name() << "Client {\n";
+  os << "public:\n";
+  os << "  " << service_->name()
+     << "Client(uint64_t client_id, std::string "
+        "subspace_socket) : client_(std::make_shared<subspace::RpcClient>(\""
+     << service_->name()
+     << "\", client_id, "
+        "std::move(subspace_socket))) {\n";
+  os << "  }\n";
+  os << "  static absl::StatusOr<std::shared_ptr<" << service_->name()
+     << "Client>> Create(uint64_t client_id, const std::string& "
+        "subspace_socket, co::Coroutine* c = nullptr) "
+        "{\n";
+  os << "    auto client = std::make_shared<" << service_->name()
+     << "Client>(client_id, subspace_socket);\n";
+  os << "    auto status = client->Open(c);\n";
+  os << "    if (!status.ok()) {\n";
+  os << "      return status;\n";
+  os << "    }\n";
+  os << "    return client;\n";
+  os << "  }\n";
+  os << "  absl::Status Open(co::Coroutine* c = nullptr) {\n";
+  os << "    return client_->Open(c);\n";
+  os << "  }\n";
+  os << "  absl::Status Close(co::Coroutine* c = nullptr) {\n";
+  os << "    return client_->Close(c);\n";
+  os << "  }\n";
+  os << "  absl::Status Close(std::chrono::nanoseconds timeout, co::Coroutine* "
+        "c = nullptr) {\n";
+  os << "    return client_->Close(timeout, c);\n";
+  os << "  }\n";
+  os << "  void SetLogLevel(const std::string& level) {\n";
+  os << "    client_->SetLogLevel(level);\n";
+  os << "  }\n";
+  os << "\n";
+  for (int i = 0; i < service_->method_count(); i++) {
+    const auto *method = service_->method(i);
+    GenerateMethodClientHeader(method, os);
+  }
+  os << "\n";
+  os << "private:\n";
+  os << "  friend class " << service_->name() << "Server;\n";
+  os << "\n";
+  for (int i = 0; i < service_->method_count(); i++) {
+    const auto *method = service_->method(i);
+    os << "  static constexpr int k" << absl::StrCat(method->name(), "Id")
+       << " = " << i << ";\n";
+  }
+  os << "  std::shared_ptr<subspace::RpcClient> client_;\n";
+  os << "};\n";
+
+  os << "\n\n";
+}
+
+void ServiceGenerator::GenerateServerHeader(std::ostream &os) {
+  // Server side class.
+  os << "class " << service_->name() << "Server {\n";
+  os << "public:\n";
+  os << "  " << service_->name()
+     << "Server(const std::string& "
+        "subspace_socket) : server_(std::make_shared<subspace::RpcServer>(\""
+     << service_->name() << "\", std::move(subspace_socket))) {}\n";
+  os << "  virtual ~" << service_->name() << "Server() = default;\n";
+  os << "\n";
+  os << "  absl::Status RegisterMethods();\n";
+  os << "\n";
+  os << "  absl::Status Run(co::CoroutineScheduler* scheduler = nullptr) {\n";
+  os << "    return server_->Run(scheduler);\n";
+  os << "  }\n";
+  os << "\n";
+  os << "  void Stop() {\n";
+  os << "    server_->Stop();\n";
+  os << "  }\n";
+  os << "\n";
+  os << "  void SetLogLevel(const std::string& level) {\n";
+  os << "    server_->SetLogLevel(level);\n";
+  os << "  }\n";
+  os << "\n";
+  os << "  void DumpCoroutines() {\n";
+  os << "    server_->Scheduler()->Show();\n";
+  os << "  }\n";
+  os << "\n";
+  os << "protected:\n";
+  for (int i = 0; i < service_->method_count(); i++) {
+    const auto *method = service_->method(i);
+    GenerateMethodServerHeader(method, os);
+  }
+  os << "\n";
+  os << "private:\n";
+  os << "  std::shared_ptr<subspace::RpcServer> server_;\n";
+  os << "};\n";
+}
+
+void ServiceGenerator::GenerateClientSource(std::ostream &os) {
+  // Client side method definitions.
+  for (int i = 0; i < service_->method_count(); i++) {
+    const auto *method = service_->method(i);
+    GenerateMethodClientSource(method, os);
+  }
+}
+
+void ServiceGenerator::GenerateServerSource(std::ostream &os) {
+  // Method registrations.
+  os << "\n";
+  GenerateServerMethodRegistrations(os);
+}
+
+void ServiceGenerator::GenerateServerMethodRegistrations(std::ostream &os) {
+  os << "absl::Status " << service_->name() << "Server::RegisterMethods() {\n";
+  for (int i = 0; i < service_->method_count(); i++) {
+    const auto *method = service_->method(i);
+
+    if (method->server_streaming()) {
+      // Streaming method.
+      os << "  {\n";
+      os << "   auto status = server_->RegisterMethod<"
+         << method->input_type()->name() << ", "
+         << method->output_type()->name() << ">(\"" << method->name()
+         << "\", [this](const auto &req, subspace::StreamWriter<"
+         << method->output_type()->name()
+         << "> &writer, co::Coroutine *c) -> absl::Status {\n";
+      os << "      return this->" << method->name() << "(req, writer, c);\n";
+      os << "    }, {.id=" << i << "});\n";
+      os << "    if (!status.ok()) {\n";
+      os << "      return status;\n";
+      os << "    }\n";
+      os << "  }\n";
+      continue;
+    }
+
+    os << "  {\n";
+    os << "   auto status = server_->RegisterMethod<"
+       << method->input_type()->name() << ", " << method->output_type()->name()
+       << ">(\"" << method->name()
+       << "\", [this](const auto &req, auto *res, co::Coroutine *c) -> "
+          "absl::Status {\n";
+    os << "      auto s = this->" << method->name() << "(req, c);\n";
+    os << "      if (!s.ok()) {\n";
+    os << "        return s.status();\n";
+    os << "      }\n";
+    os << "      *res = std::move(s.value());\n";
+    os << "      return absl::OkStatus();\n";
+    os << "    }, {.id=" << i << "});\n";
+    os << "    if (!status.ok()) {\n";
+    os << "      return status;\n";
+    os << "    }\n";
+    os << "  }\n";
+  }
+  os << "  return absl::OkStatus();\n";
+  os << "}\n";
+}
+
+void ServiceGenerator::GenerateMethodClientHeader(
+    const google::protobuf::MethodDescriptor *method, std::ostream &os) {
+  std::string method_name = method->name();
+  if (method->server_streaming()) {
+    // Streaming method.
+    os << "  absl::Status " << method_name << "(";
+    os << "const " << method->input_type()->name() << "& request";
+    os << ", subspace::ResponseReceiver<" << method->output_type()->name()
+       << ">& receiver";
+    os << ", std::chrono::nanoseconds timeout, co::Coroutine* c = nullptr";
+    os << ");\n";
+    os << "  absl::Status " << method_name << "(";
+    os << "const " << method->input_type()->name() << "& request";
+    os << ", subspace::ResponseReceiver<" << method->output_type()->name()
+       << ">& receiver";
+    os << ", co::Coroutine* c = nullptr";
+    os << ") {\n";
+    os << "    return " << method_name
+       << "(request, receiver, std::chrono::nanoseconds(0), c);\n";
+    os << "  }\n";
+    return;
+  }
+  os << "  absl::StatusOr<" << method->output_type()->name() << "> "
+     << method_name << "(";
+  os << "const " << method->input_type()->name() << "& request";
+  os << ", std::chrono::nanoseconds timeout, co::Coroutine* c = nullptr";
+  os << ");\n";
+  os << "  absl::StatusOr<" << method->output_type()->name() << "> "
+     << method_name << "(";
+  os << "const " << method->input_type()->name() << "& request";
+  os << ", co::Coroutine* c = nullptr";
+  os << ") {\n";
+  os << "    return " << method_name
+     << "(request, std::chrono::nanoseconds(0), c);\n";
+  os << "  }\n";
+}
+
+void ServiceGenerator::GenerateMethodClientSource(
+    const google::protobuf::MethodDescriptor *method, std::ostream &os) {
+  std::string method_name = method->name();
+  if (method->server_streaming()) {
+    // Streaming method.
+    os << "absl::Status " << service_->name() << "Client::" << method_name
+       << "(const " << method->input_type()->name()
+       << "& request, subspace::ResponseReceiver<"
+       << method->output_type()->name()
+       << ">& receiver, std::chrono::nanoseconds timeout, co::Coroutine* c) "
+          "{\n";
+    os << "  return client_->Call<" << method->input_type()->name() << ", "
+       << method->output_type()->name() << ">(k" << method_name
+       << "Id, request, receiver, timeout, c);\n";
+    os << "}\n";
+    return;
+  }
+  os << "absl::StatusOr<" << method->output_type()->name() << "> "
+     << service_->name() << "Client::" << method_name << "(const "
+     << method->input_type()->name()
+     << "& request, std::chrono::nanoseconds timeout, co::Coroutine* c) {\n";
+  os << "  return client_->Call<" << method->input_type()->name() << ", "
+     << method->output_type()->name() << ">(k" << method_name
+     << "Id, request, timeout, c);\n";
+  os << "}\n";
+}
+
+void ServiceGenerator::GenerateMethodServerHeader(
+    const google::protobuf::MethodDescriptor *method, std::ostream &os) {
+  if (method->server_streaming()) {
+    // Streaming method.
+    os << "  virtual absl::Status " << method->name() << "(const "
+       << method->input_type()->name() << "& request, subspace::StreamWriter<"
+       << method->output_type()->name()
+       << ">& writer, co::Coroutine* c = nullptr) = 0;\n";
+    return;
+  }
+  os << "  virtual absl::StatusOr<" << method->output_type()->name() << "> "
+     << method->name() << "(const " << method->input_type()->name()
+     << "& request, co::Coroutine* c = nullptr) = 0;\n";
+}
+
+void ServiceGenerator::GenerateMethodServerSource(
+    const google::protobuf::MethodDescriptor *method, std::ostream &os) {}
+
+} // namespace subspace

--- a/rpc/idl_compiler/service_gen.h
+++ b/rpc/idl_compiler/service_gen.h
@@ -1,0 +1,49 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#pragma once
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "google/protobuf/descriptor.h"
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace subspace {
+class ServiceGenerator {
+public:
+  ServiceGenerator(const google::protobuf::ServiceDescriptor *service,
+                   const std::string &added_namespace,
+                   const std::string &package_name)
+      : service_(service), added_namespace_(added_namespace),
+        package_name_(package_name) {}
+
+  void GenerateClientHeader(std::ostream &os);
+  void GenerateClientSource(std::ostream &os);
+
+  void GenerateServerHeader(std::ostream &os);
+  void GenerateServerSource(std::ostream &os);
+  
+private:
+  void GenerateServerMethodRegistrations(std::ostream &os);
+  void
+  GenerateMethodClientHeader(const google::protobuf::MethodDescriptor *method,
+                             std::ostream &os);
+  void
+  GenerateMethodClientSource(const google::protobuf::MethodDescriptor *method,
+                             std::ostream &os);
+  void
+  GenerateMethodServerHeader(const google::protobuf::MethodDescriptor *method,
+                             std::ostream &os);
+  void
+  GenerateMethodServerSource(const google::protobuf::MethodDescriptor *method,
+                             std::ostream &os);
+  const google::protobuf::ServiceDescriptor *service_;
+  std::string added_namespace_;
+  std::string package_name_;
+};
+
+} // namespace subspace

--- a/rpc/proto/BUILD.bazel
+++ b/rpc/proto/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("//:rpc/subspace_rpc_library.bzl", "subspace_rpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "rpc_test_proto",
+    srcs = ["rpc_test.proto"],
+)
+
+cc_proto_library(
+    name = "rpc_test_cc_proto",
+    deps = [":rpc_test_proto"],
+)
+
+# Generates both client and server:
+# :rpc_test_subspace_rpc_client
+# :rpc_test_subspace_rpc_server
+
+subspace_rpc_library(
+    name = "rpc_test_subspace_rpc",
+    deps = [
+        ":rpc_test_proto",
+    ],
+)

--- a/rpc/proto/rpc_test.proto
+++ b/rpc/proto/rpc_test.proto
@@ -1,0 +1,34 @@
+// Copyright 025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+syntax = "proto3";
+
+package rpc;
+
+message TestRequest {
+  string message = 1;
+  int32 stream_period = 2;    // In milliseconds
+}
+
+message TestResponse {
+  string message = 1;
+  int32 foo = 2;
+}
+
+message PerfRequest {
+  uint64 send_time = 1;
+}
+
+message PerfResponse {
+  uint64 client_send_time = 1;   // Time sent by client.
+  uint64 server_send_time = 2;   // Time sent by server.
+}
+
+service TestService {
+  rpc TestMethod(TestRequest) returns (TestResponse);
+  rpc PerfMethod(PerfRequest) returns (PerfResponse);
+  rpc StreamMethod(TestRequest) returns (stream TestResponse);
+  rpc ErrorMethod(TestRequest) returns (TestResponse);
+  rpc TimeoutMethod(TestRequest) returns (TestResponse);
+}

--- a/rpc/server/BUILD.bazel
+++ b/rpc/server/BUILD.bazel
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rpc_server",
+    srcs = [
+        "rpc_server.cc",
+    ],
+    hdrs = [
+        "rpc_server.h",
+
+    ],
+    deps = [
+        "//common:subspace_common",
+        "//client:subspace_client",
+        "//proto:subspace_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@coroutines//:co",
+    ],
+)
+
+cc_test(
+    name = "server_test",
+    srcs = ["server_test.cc"],
+    data = [
+        "//server:subspace_server",
+    ],
+    deps = [
+        ":rpc_server",
+        "//client:subspace_client",
+        "//server",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+        "@coroutines//:co",
+        "//rpc/proto:rpc_test_cc_proto",
+    ],
+)
+

--- a/rpc/server/rpc_server.cc
+++ b/rpc/server/rpc_server.cc
@@ -1,0 +1,874 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "rpc/server/rpc_server.h"
+#include "proto/subspace.pb.h"
+#include <inttypes.h>
+#include <stdio.h>
+
+namespace subspace {
+
+using Method = internal::Method;
+using Session = internal::Session;
+using MethodInstance = internal::MethodInstance;
+using AnyStreamWriter = internal::AnyStreamWriter;
+
+RpcServer::RpcServer(std::string service_name,
+                     std::string subspace_server_socket)
+    : name_(std::move(service_name)),
+      subspace_server_socket_(std::move(subspace_server_socket)),
+      logger_("rpcserver") {
+  logger_.Log(toolbelt::LogLevel::kInfo, "RpcServer created for service: %s",
+              name_.c_str());
+  auto p = toolbelt::Pipe::Create();
+  if (!p.ok()) {
+    logger_.Log(toolbelt::LogLevel::kError, "Failed to create interrupt pipe");
+    return;
+  }
+  interrupt_pipe_ = std::move(*p);
+}
+
+void RpcServer::Stop() {
+  running_ = false;
+  interrupt_pipe_.Close();
+}
+
+absl::Status RpcServer::RegisterMethod(
+    const std::string &method, const std::string &request_type,
+    const std::string &response_type,
+    std::function<absl::Status(const google::protobuf::Any &,
+                               google::protobuf::Any *, co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  if (methods_.find(method) != methods_.end()) {
+    return absl::AlreadyExistsError("Method already registered: " + method);
+  }
+
+  methods_[method] = std::make_shared<Method>(
+      this, method, request_type, response_type, options.slot_size,
+      options.num_slots, std::move(callback),
+      options.id == -1 ? ++next_method_id_ : options.id);
+  return absl::OkStatus();
+}
+
+// Register void method.
+absl::Status RpcServer::RegisterMethod(
+    const std::string &method, const std::string &request_type,
+    std::function<absl::Status(const google::protobuf::Any &, co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  if (methods_.find(method) != methods_.end()) {
+    return absl::AlreadyExistsError("Method already registered: " + method);
+  }
+  methods_[method] = std::make_shared<Method>(
+      this, method, request_type, "subspace.VoidMessage", options.slot_size,
+      options.num_slots,
+      [callback](const google::protobuf::Any &req, google::protobuf::Any *res,
+                 co::Coroutine *c) {
+        auto status = callback(req, c);
+        if (!status.ok()) {
+          return status;
+        }
+        // The response for this void method is a VoidMessage packed
+        // into a google.protobuf.Any.
+        res->PackFrom(VoidMessage());
+        return absl::OkStatus();
+      },
+      options.id == -1 ? ++next_method_id_ : options.id);
+  return absl::OkStatus();
+}
+
+absl::Status RpcServer::RegisterMethod(
+    const std::string &method,
+    std::function<absl::Status(const std::vector<char> &, std::vector<char> *,
+                               co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  return RegisterMethod<RawMessage, RawMessage>(
+      method,
+      [callback = std::move(callback)](const RawMessage &req, RawMessage *res,
+                                       co::Coroutine *c) -> absl::Status {
+        std::vector<char> request(req.data().begin(), req.data().end());
+        std::vector<char> response;
+        auto status = callback(request, &response, c);
+        if (!status.ok()) {
+          return status;
+        }
+        res->set_data(response.data(), response.size());
+        return absl::OkStatus();
+      },
+      std::move(options));
+}
+
+absl::Status RpcServer::RegisterMethod(
+    const std::string &method,
+    std::function<absl::Status(const absl::Span<const char> &,
+                               std::vector<char> *, co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  return RegisterMethod<RawMessage, RawMessage>(
+      method,
+      [callback = std::move(callback)](const RawMessage &req, RawMessage *res,
+                                       co::Coroutine *c) -> absl::Status {
+        const absl::Span<const char> request(req.data().data(),
+                                             req.data().size());
+        std::vector<char> response;
+        auto status = callback(request, &response, c);
+        if (!status.ok()) {
+          return status;
+        }
+        // This is still a copy.
+        res->set_data(response.data(), response.size());
+        return absl::OkStatus();
+      },
+      std::move(options));
+}
+
+absl::Status RpcServer::RegisterMethod(
+    const std::string &method, const std::string &request_type,
+    const std::string &response_type,
+    std::function<absl::Status(const google::protobuf::Any &, AnyStreamWriter &,
+                               co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  if (methods_.find(method) != methods_.end()) {
+    return absl::AlreadyExistsError("Method already registered: " + method);
+  }
+
+  methods_[method] = std::make_shared<Method>(
+      this, method, request_type, response_type, options.slot_size,
+      options.num_slots, std::move(callback),
+      options.id == -1 ? ++next_method_id_ : options.id);
+  return absl::OkStatus();
+}
+
+absl::Status RpcServer::CreateChannels() {
+  auto client = subspace::Client::Create(subspace_server_socket_, name_);
+  if (!client.ok()) {
+    return client.status();
+  }
+  client_ = std::move(*client);
+  std::string request_name = absl::StrFormat("/rpc/%s/request", name_);
+  logger_.Log(toolbelt::LogLevel::kDebug, "Creating subscriber for %s",
+              request_name.c_str());
+  auto receiver = client_->CreateSubscriber(
+      request_name, {.reliable = true,
+                     .type = "subspace.RpcServerRequest",
+                     .max_active_messages = 1});
+  if (!receiver.ok()) {
+    return receiver.status();
+  }
+  request_receiver_ =
+      std::make_shared<subspace::Subscriber>(std::move(*receiver));
+
+  std::string response_name = absl::StrFormat("/rpc/%s/response", name_);
+  logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher for %s",
+              response_name.c_str());
+  auto publisher = client_->CreatePublisher(
+      response_name, {.slot_size = kRpcResponseSlotSize,
+                      .num_slots = kRpcResponseNumSlots,
+                      .reliable = true,
+                      .type = "subspace.RpcServerResponse"});
+  if (!publisher.ok()) {
+    return publisher.status();
+  }
+  response_publisher_ =
+      std::make_shared<subspace::Publisher>(std::move(*publisher));
+  return absl::OkStatus();
+}
+
+absl::Status RpcServer::Run(co::CoroutineScheduler *scheduler) {
+  if (scheduler != nullptr) {
+    scheduler_ = scheduler;
+  } else {
+    scheduler_ = &local_scheduler_;
+  }
+  scheduler_->SetCompletionCallback(
+      [this](co::Coroutine *c) { coroutines_.erase(c); });
+
+  absl::Status status = CreateChannels();
+  if (!status.ok()) {
+    return status;
+  }
+
+  running_ = true;
+  AddCoroutine(std::make_unique<co::Coroutine>(
+      *scheduler_,
+      [server = shared_from_this()](co::Coroutine *c) {
+        ListenerCoroutine(server, c);
+      },
+      "RPC listener"));
+
+  // Block and run the scheduler if we are not given one.  If we are given
+  // a scheduler, it wil be run by the caller.
+  if (scheduler == nullptr) {
+    scheduler_->Run();
+  }
+
+  return absl::OkStatus();
+}
+
+void RpcServer::ListenerCoroutine(std::shared_ptr<RpcServer> server,
+                                  co::Coroutine *c) {
+  while (server->running_) {
+    auto fd =
+        server->request_receiver_->Wait(server->interrupt_pipe_.ReadFd(), c);
+
+    if (!fd.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error waiting for request: %s",
+                          fd.status().ToString().c_str());
+      continue;
+    }
+    if (*fd == server->interrupt_pipe_.ReadFd().Fd()) {
+      break;
+    }
+
+    for (;;) {
+      server->logger_.Log(toolbelt::LogLevel::kVerboseDebug,
+                          "Incoming message in server");
+      absl::StatusOr<subspace::Message> msg =
+          server->request_receiver_->ReadMessage();
+      if (!msg.ok()) {
+        break;
+      }
+      if (msg->length == 0) {
+        break;
+      }
+      if (auto status =
+              server->HandleIncomingRpcServerRequest(std::move(*msg), c);
+          !status.ok()) {
+        // Log error but keep going.
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error handling RPC request: %s",
+                            status.ToString().c_str());
+      }
+    }
+  }
+}
+
+absl::Status RpcServer::HandleIncomingRpcServerRequest(subspace::Message msg,
+                                                       co::Coroutine *c) {
+  subspace::RpcServerRequest request;
+  if (!request.ParseFromArray(msg.buffer, msg.length)) {
+    return absl::InvalidArgumentError("Failed to parse RpcRequest");
+  }
+  logger_.Log(toolbelt::LogLevel::kDebug, "Received RPC request: %s",
+              request.DebugString().c_str());
+
+  subspace::RpcServerResponse response;
+  response.set_client_id(request.client_id());
+  response.set_request_id(request.request_id());
+  switch (request.request_case()) {
+  case subspace::RpcServerRequest::kOpen: {
+    if (auto status = HandleOpen(request.client_id(), request.open(),
+                                 response.mutable_open(), c);
+        !status.ok()) {
+      response.set_error(status.ToString());
+    }
+    break;
+  }
+  case subspace::RpcServerRequest::kClose: {
+    if (auto status = HandleClose(request.client_id(), request.close(),
+                                  response.mutable_close(), c);
+        !status.ok()) {
+      response.set_error(status.ToString());
+    }
+    break;
+  }
+  default:
+    response.set_error("Unknown request type");
+    break;
+  }
+
+  // Publish the response
+  return PublishRpcServerResponse(response, c);
+}
+
+absl::Status
+RpcServer::PublishRpcServerResponse(const subspace::RpcServerResponse &response,
+                                    co::Coroutine *c) {
+  uint64_t length = response.ByteSizeLong();
+  // This is a reliable publisher so we keep trying to publish until we can.
+  for (;;) {
+    absl::StatusOr<void *> buffer =
+        response_publisher_->GetMessageBuffer(length);
+    if (!buffer.ok()) {
+      return buffer.status();
+    }
+    if (*buffer == nullptr) {
+      // Buffer is not ready, wait and try again.
+      auto status = response_publisher_->Wait(interrupt_pipe_.ReadFd(), c);
+      if (!status.ok()) {
+        return status.status();
+      }
+      if (*status == interrupt_pipe_.ReadFd().Fd()) {
+        return absl::OkStatus();
+      }
+    }
+
+    // We got a buffer, fill it in and send it.
+    if (!response.SerializeToArray(*buffer, length)) {
+      return absl::InternalError("Failed to serialize RpcServerResponse");
+    }
+    auto result = response_publisher_->PublishMessage(length);
+    if (!result.ok()) {
+      return result.status();
+    }
+    logger_.Log(toolbelt::LogLevel::kDebug, "Published RPC response: %s",
+                response.DebugString().c_str());
+    return absl::OkStatus();
+  }
+}
+
+absl::Status RpcServer::HandleOpen(uint64_t client_id,
+                                   const subspace::RpcOpenRequest &request,
+                                   subspace::RpcOpenResponse *response,
+                                   co::Coroutine *c) {
+  logger_.Log(toolbelt::LogLevel::kDebug,
+              "Handling Open request from client %" PRId64 ", %s", client_id,
+              request.DebugString().c_str());
+
+  auto s = CreateSession(client_id);
+  if (!s.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to create session: %s", s.status().ToString()));
+  }
+  auto session = *s;
+  response->set_session_id(session->session_id);
+
+  for (auto &[id, method] : session->methods) {
+    auto *m = response->add_methods();
+    m->set_name(method->method->name);
+    m->set_id(id);
+    auto *req = m->mutable_request_channel();
+    req->set_name(absl::StrFormat("%s/%d/%d", method->method->request_channel,
+                                  client_id, session->session_id));
+    req->set_type(method->method->request_type);
+    req->set_slot_size(method->method->slot_size);
+    req->set_num_slots(method->method->num_slots);
+
+    auto *res = m->mutable_response_channel();
+    res->set_name(absl::StrFormat("%s/%d/%d", method->method->response_channel,
+                                  client_id, session->session_id));
+    res->set_type(method->method->response_type);
+
+    if (method->method->IsStreaming()) {
+      m->set_cancel_channel(absl::StrFormat("%s/%d/%d",
+                                            method->method->cancel_channel,
+                                            client_id, session->session_id));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RpcServer::HandleClose(uint64_t client_id,
+                                    const subspace::RpcCloseRequest &request,
+                                    subspace::RpcCloseResponse *response,
+                                    co::Coroutine *c) {
+  logger_.Log(toolbelt::LogLevel::kDebug,
+              "Handling Close request from client %" PRId64 ", %s", client_id,
+              request.DebugString().c_str());
+  auto it = sessions_.find(request.session_id());
+  if (it == sessions_.end()) {
+    return absl::NotFoundError("Session not found");
+  }
+  auto session = it->second;
+  // Clean up session resources here.
+  sessions_.erase(session->session_id);
+  logger_.Log(toolbelt::LogLevel::kDebug, "Closed session: %d",
+              session->session_id);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::shared_ptr<Session>>
+RpcServer::CreateSession(uint64_t client_id) {
+  auto session = std::make_shared<Session>();
+  session->session_id = ++next_session_id_;
+  session->client_id = client_id;
+  for (auto &[name, method] : methods_) {
+    auto method_instance = std::make_shared<MethodInstance>();
+    method_instance->method = method;
+
+    absl::StatusOr<subspace::Subscriber> sub = client_->CreateSubscriber(
+        absl::StrFormat("%s/%d/%d", method->request_channel, session->client_id,
+                        session->session_id),
+        {.reliable = true, .type = method->request_type});
+    if (!sub.ok()) {
+      logger_.Log(toolbelt::LogLevel::kError,
+                  "Failed to create subscriber for method %s: %s",
+                  method->name.c_str(), sub.status().ToString().c_str());
+      return sub.status();
+    }
+    method_instance->request_subscriber =
+        std::make_shared<subspace::Subscriber>(std::move(*sub));
+
+    absl::StatusOr<subspace::Publisher> pub = client_->CreatePublisher(
+        absl::StrFormat("%s/%d/%d", method->response_channel,
+                        session->client_id, session->session_id),
+        {.slot_size = method->slot_size,
+         .num_slots = method->num_slots,
+         .reliable = true,
+         .type = method->response_type});
+    if (!pub.ok()) {
+      logger_.Log(toolbelt::LogLevel::kError,
+                  "Failed to create publisher for method %s: %s",
+                  method->name.c_str(), pub.status().ToString().c_str());
+      return pub.status();
+    }
+    method_instance->response_publisher =
+        std::make_shared<subspace::Publisher>(std::move(*pub));
+
+    // For a streaming method we create a cancel channel subscriber.
+    if (method->IsStreaming()) {
+      absl::StatusOr<subspace::Subscriber> cancel_sub =
+          client_->CreateSubscriber(
+              absl::StrFormat("%s/%d/%d", method->cancel_channel,
+                              session->client_id, session->session_id),
+              {.reliable = true, .type = "subspace.RpcCancelRequest"});
+      if (!cancel_sub.ok()) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to create cancel subscriber for method %s: %s",
+                    method->name.c_str(),
+                    cancel_sub.status().ToString().c_str());
+        return cancel_sub.status();
+      }
+      method_instance->cancel_subscriber =
+          std::make_shared<subspace::Subscriber>(std::move(*cancel_sub));
+    }
+
+    session->methods.insert({method->id, method_instance});
+
+    AddCoroutine(std::make_unique<co::Coroutine>(
+        *scheduler_,
+        [server = shared_from_this(), session,
+         method_instance](co::Coroutine *c) {
+          if (method_instance->method->IsStreaming()) {
+            SessionStreamingMethodCoroutine(std::move(server), session,
+                                            method_instance, c);
+          } else {
+            SessionMethodCoroutine(std::move(server), session, method_instance,
+                                   c);
+          }
+        },
+        absl::StrFormat("Session %d Method %s", session->session_id,
+                        method->name.c_str())));
+  }
+  sessions_[session->session_id] = session;
+  logger_.Log(toolbelt::LogLevel::kDebug, "Created session: %d",
+              session->session_id);
+  return session;
+}
+
+absl::Status RpcServer::DestroySession(int session_id) {
+  // Clean up session resources here.
+  sessions_.erase(session_id);
+  return absl::OkStatus();
+}
+
+void RpcServer::SessionMethodCoroutine(
+    std::shared_ptr<RpcServer> server, std::shared_ptr<Session> session,
+    std::shared_ptr<MethodInstance> method_instance, co::Coroutine *c) {
+  while (server->running_) {
+    auto s = method_instance->request_subscriber->Wait(
+        server->interrupt_pipe_.ReadFd(), c);
+    if (!s.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error waiting for request: %s",
+                          s.status().ToString().c_str());
+      return;
+    }
+    if (*s == server->interrupt_pipe_.ReadFd().Fd()) {
+      break;
+    }
+    subspace::RpcRequest request;
+    bool request_ok = false;
+    for (;;) {
+      auto m = method_instance->request_subscriber->ReadMessage();
+      if (!m.ok()) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error reading message for method %s: %s",
+                            method_instance->method->name.c_str(),
+                            m.status().ToString().c_str());
+        break;
+      }
+      if (m->length == 0) {
+        // No message, continue waiting.
+        break;
+      }
+      if (!request.ParseFromArray(m->buffer, m->length)) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error parsing request for method %s: %s",
+                            method_instance->method->name.c_str(),
+                            m.status().ToString().c_str());
+        continue;
+      }
+      if (request.session_id() == session->session_id) {
+        request_ok = true;
+        break;
+      }
+    }
+    if (!request_ok) {
+      continue;
+    }
+
+    subspace::RpcResponse response;
+    response.set_session_id(session->session_id);
+    response.set_request_id(request.request_id());
+    response.set_client_id(request.client_id());
+    auto *result = response.mutable_result();
+    server->logger_.Log(toolbelt::LogLevel::kDebug, "Calling method %s",
+                        method_instance->method->name.c_str());
+    absl::Status method_status =
+        method_instance->method->callback(request.argument(), result, c);
+    if (!method_status.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error executing method %s: %s",
+                          method_instance->method->name.c_str(),
+                          method_status.ToString().c_str());
+      response.set_error(absl::StrFormat("Error executing method %s: %s",
+                                         method_instance->method->name,
+                                         method_status.ToString()));
+    }
+
+    uint64_t length = response.ByteSizeLong();
+    absl::StatusOr<void *> buffer;
+    for (;;) {
+      buffer = method_instance->response_publisher->GetMessageBuffer(
+          int32_t(length));
+      if (!buffer.ok()) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error getting buffer for method %s: %s",
+                            method_instance->method->name.c_str(),
+                            buffer.status().ToString().c_str());
+        response.set_error(absl::StrFormat(
+            "Error getting buffer for method %s: %s",
+            method_instance->method->name, buffer.status().ToString()));
+        return;
+      }
+      if (*buffer != nullptr) {
+        break;
+      }
+      if (!server->interrupt_pipe_.ReadFd().Valid()) {
+        return;
+      }
+      // Buffer is not ready, wait and try again.
+      auto status = method_instance->response_publisher->Wait(
+          server->interrupt_pipe_.ReadFd(), c);
+      if (!status.ok()) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error waiting for buffer: %s",
+                            status.status().ToString().c_str());
+        return;
+      }
+      if (*status == server->interrupt_pipe_.ReadFd().Fd()) {
+        return;
+      }
+    }
+    // We got a buffer, fill it in and send it.
+    if (!response.SerializeToArray(*buffer, length)) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error serializing response for method %s",
+                          method_instance->method->name.c_str());
+      break;
+    }
+    server->logger_.Log(
+        toolbelt::LogLevel::kDebug, "Publishing response for method %s: %s",
+        method_instance->method->name.c_str(), response.DebugString().c_str());
+    auto pub_result =
+        method_instance->response_publisher->PublishMessage(length);
+    if (!pub_result.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error publishing response for method %s: %s",
+                          method_instance->method->name.c_str(),
+                          pub_result.status().ToString().c_str());
+    }
+    server->logger_.Log(toolbelt::LogLevel::kDebug,
+                        "Published response for method %s",
+                        method_instance->method->name.c_str());
+  }
+}
+
+void RpcServer::SessionStreamingMethodCoroutine(
+    std::shared_ptr<RpcServer> server, std::shared_ptr<Session> session,
+    std::shared_ptr<MethodInstance> method_instance, co::Coroutine *c) {
+  while (server->running_) {
+    auto s = method_instance->request_subscriber->Wait(
+        server->interrupt_pipe_.ReadFd(), c);
+    if (!s.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error waiting for request: %s",
+                          s.status().ToString().c_str());
+      return;
+    }
+    if (*s == server->interrupt_pipe_.ReadFd().Fd()) {
+      break;
+    }
+    subspace::RpcRequest request;
+    bool request_ok = false;
+    for (;;) {
+      auto m = method_instance->request_subscriber->ReadMessage();
+      if (!m.ok()) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error reading message for method %s: %s",
+                            method_instance->method->name.c_str(),
+                            m.status().ToString().c_str());
+        break;
+      }
+      if (m->length == 0) {
+        // No message, continue waiting.
+        break;
+      }
+      if (!request.ParseFromArray(m->buffer, m->length)) {
+        server->logger_.Log(toolbelt::LogLevel::kError,
+                            "Error parsing request for method %s: %s",
+                            method_instance->method->name.c_str(),
+                            m.status().ToString().c_str());
+        continue;
+      }
+      if (request.session_id() == session->session_id) {
+        request_ok = true;
+        break;
+      }
+    }
+    if (!request_ok) {
+      continue;
+    }
+
+    server->logger_.Log(toolbelt::LogLevel::kDebug, "Calling method %s",
+                        method_instance->method->name.c_str());
+
+    AnyStreamWriter writer(server, session, method_instance, request);
+
+    // Start a coroutine to read the cancellation channel and cancel the
+    // StreamWriter if a cancellation request is received.
+    server->AddCoroutine(std::make_unique<co::Coroutine>(
+        *server->scheduler_, [server, session, method_instance, &writer,
+                              &request](co::Coroutine *c) {
+          toolbelt::FileDescriptor interrupt(
+              dup(server->interrupt_pipe_.ReadFd().Fd()));
+          while (!writer.IsCancelled()) {
+            auto s = method_instance->cancel_subscriber->Wait(interrupt, c);
+            if (!s.ok()) {
+              server->logger_.Log(toolbelt::LogLevel::kError,
+                                  "Error waiting for cancel: %s",
+                                  s.status().ToString().c_str());
+              return;
+            }
+            if (*s == interrupt.Fd()) {
+              break;
+            }
+            bool request_ok = false;
+            while (!request_ok) {
+              auto msg = method_instance->cancel_subscriber->ReadMessage();
+              if (!msg.ok()) {
+                server->logger_.Log(toolbelt::LogLevel::kError,
+                                    "Error reading cancel message: %s",
+                                    msg.status().ToString().c_str());
+                continue;
+              }
+              if (msg->length == 0) {
+                // No message, continue waiting.
+                break;
+              }
+              RpcCancelRequest cancel;
+              if (!cancel.ParseFromArray(msg->buffer, msg->length)) {
+                server->logger_.Log(toolbelt::LogLevel::kError,
+                                    "Error parsing cancel message: %s",
+                                    msg.status().ToString().c_str());
+                continue;
+              }
+              if (cancel.session_id() == session->session_id &&
+                  cancel.request_id() == request.request_id()) {
+                request_ok = true;
+                break;
+              }
+            }
+            if (request_ok) {
+              writer.Cancel();
+            }
+          }
+        }));
+
+    // Call the method and pass it StreamWriter that will be called to send back
+    // a response to the client.
+    absl::Status method_status =
+        method_instance->method->stream_callback(request.argument(), writer, c);
+    // If the method fails, we need to send an error response.
+    if (!method_status.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error executing method %s: %s",
+                          method_instance->method->name.c_str(),
+                          method_status.ToString().c_str());
+      SendRpcError(server, session, method_instance, request,
+                   absl::StrFormat("Error executing method %s: %s",
+                                   method_instance->method->name,
+                                   method_status.ToString()),
+                   c);
+    }
+  }
+}
+
+void RpcServer::SendRpcError(std::shared_ptr<RpcServer> server,
+                             std::shared_ptr<Session> session,
+                             std::shared_ptr<MethodInstance> method_instance,
+                             const RpcRequest &request,
+                             const std::string &error, co::Coroutine *c) {
+  subspace::RpcResponse response;
+  response.set_session_id(session->session_id);
+  response.set_request_id(request.request_id());
+  response.set_client_id(request.client_id());
+  response.set_error(error);
+
+  uint64_t length = response.ByteSizeLong();
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    buffer =
+        method_instance->response_publisher->GetMessageBuffer(int32_t(length));
+    if (!buffer.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error getting buffer for error in method %s: %s",
+                          method_instance->method->name.c_str(),
+                          buffer.status().ToString().c_str());
+      response.set_error(absl::StrFormat(
+          "Error getting buffer for error in method %s: %s",
+          method_instance->method->name, buffer.status().ToString()));
+      return;
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    if (!server->interrupt_pipe_.ReadFd().Valid()) {
+      return;
+    }
+    // Buffer is not ready, wait and try again.
+    auto status = method_instance->response_publisher->Wait(
+        server->interrupt_pipe_.ReadFd(), c);
+    if (!status.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error waiting for buffer: %s",
+                          status.status().ToString().c_str());
+      return;
+    }
+    if (*status == server->interrupt_pipe_.ReadFd().Fd()) {
+      return;
+    }
+  }
+  // We got a buffer, fill it in and send it.
+  if (!response.SerializeToArray(*buffer, length)) {
+    server->logger_.Log(toolbelt::LogLevel::kError,
+                        "Error serializing response for method %s",
+                        method_instance->method->name.c_str());
+    return;
+  }
+
+  auto pub_result = method_instance->response_publisher->PublishMessage(length);
+  if (!pub_result.ok()) {
+    server->logger_.Log(toolbelt::LogLevel::kError,
+                        "Error publishing error response for method %s: %s",
+                        method_instance->method->name.c_str(),
+                        pub_result.status().ToString().c_str());
+  }
+}
+
+void RpcServer::SendStreamRpcResponse(
+    std::shared_ptr<RpcServer> server, std::shared_ptr<Session> session,
+    std::shared_ptr<MethodInstance> method_instance, const RpcRequest &request,
+    std::unique_ptr<google::protobuf::Any> result, bool is_last,
+    bool is_cancelled, co::Coroutine *c) {
+  // Send response back to the client each time this is called
+  subspace::RpcResponse response;
+  response.set_session_id(session->session_id);
+  response.set_request_id(request.request_id());
+  response.set_client_id(request.client_id());
+  if (result != nullptr) {
+    response.set_allocated_result(result.release());
+  }
+  response.set_is_last(is_last);
+  response.set_is_cancelled(is_cancelled);
+
+  uint64_t length = response.ByteSizeLong();
+  absl::StatusOr<void *> buffer;
+  for (;;) {
+    buffer =
+        method_instance->response_publisher->GetMessageBuffer(int32_t(length));
+    if (!buffer.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error getting buffer for method %s: %s",
+                          method_instance->method->name.c_str(),
+                          buffer.status().ToString().c_str());
+      response.set_error(absl::StrFormat(
+          "Error getting buffer for method %s: %s",
+          method_instance->method->name, buffer.status().ToString()));
+      return;
+    }
+    if (*buffer != nullptr) {
+      break;
+    }
+    if (!server->interrupt_pipe_.ReadFd().Valid()) {
+      return;
+    }
+    // Buffer is not ready, wait and try again.
+    auto status = method_instance->response_publisher->Wait(
+        server->interrupt_pipe_.ReadFd(), c);
+    if (!status.ok()) {
+      server->logger_.Log(toolbelt::LogLevel::kError,
+                          "Error waiting for buffer: %s",
+                          status.status().ToString().c_str());
+      return;
+    }
+    if (*status == server->interrupt_pipe_.ReadFd().Fd()) {
+      return;
+    }
+  }
+  // We got a buffer, fill it in and send it.
+  if (!response.SerializeToArray(*buffer, length)) {
+    server->logger_.Log(toolbelt::LogLevel::kError,
+                        "Error serializing response for method %s",
+                        method_instance->method->name.c_str());
+    return;
+  }
+  server->logger_.Log(
+      toolbelt::LogLevel::kDebug, "Publishing response for method %s: %s",
+      method_instance->method->name.c_str(), response.DebugString().c_str());
+  auto pub_result = method_instance->response_publisher->PublishMessage(length);
+  if (!pub_result.ok()) {
+    server->logger_.Log(toolbelt::LogLevel::kError,
+                        "Error publishing response for method %s: %s",
+                        method_instance->method->name.c_str(),
+                        pub_result.status().ToString().c_str());
+  }
+  server->logger_.Log(toolbelt::LogLevel::kDebug,
+                      "Published response for ˝method %s",
+                      method_instance->method->name.c_str());
+}
+
+namespace internal {
+bool AnyStreamWriter::Write(std::unique_ptr<google::protobuf::Any> res,
+                            co::Coroutine *c) {
+  if (IsCancelled()) {
+    return false;
+  }
+  RpcServer::SendStreamRpcResponse(server, session, method_instance, request,
+                                   std::move(res), false, IsCancelled(), c);
+  return true;
+}
+
+void AnyStreamWriter::Finish(co::Coroutine *c) {
+  RpcServer::SendStreamRpcResponse(server, session, method_instance, request,
+                                   nullptr, true, IsCancelled(), c);
+}
+
+void Method::MakeChannelNames(RpcServer *server) {
+  request_channel =
+      absl::StrFormat("/rpc/%s/%s/request", server->Name(), this->name);
+  response_channel =
+      absl::StrFormat("/rpc/%s/%s/response", server->Name(), this->name);
+  if (IsStreaming()) {
+    cancel_channel =
+        absl::StrFormat("/rpc/%s/%s/cancel", server->Name(), this->name);
+  }
+}
+} // namespace internal
+} // namespace subspace

--- a/rpc/server/rpc_server.h
+++ b/rpc/server/rpc_server.h
@@ -1,0 +1,427 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#pragma once
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/span.h"
+#include "client/client.h"
+#include "coroutine.h"
+#include "google/protobuf/any.pb.h"
+#include "toolbelt/logging.h"
+#include "toolbelt/pipe.h"
+
+namespace subspace {
+
+// Slot parameters for requests and responses for the open/close requests.
+constexpr int32_t kRpcRequestSlotSize = 128;
+constexpr int32_t kRpcResponseSlotSize = 128;
+constexpr int32_t kRpcRequestNumSlots = 100;
+constexpr int32_t kRpcResponseNumSlots = 100;
+
+// Default slot parameters for method invocation requests.  The slot size
+// can be expanded if the request is bigger.
+constexpr int32_t kDefaultMethodSlotSize = 256;
+constexpr int32_t kDefaultMethodNumSlots = 100;
+
+class RpcServer;
+
+namespace internal {
+
+struct Session;
+struct MethodInstance;
+
+struct AnyStreamWriter {
+  AnyStreamWriter(std::shared_ptr<RpcServer> server,
+                  std::shared_ptr<Session> session,
+                  std::shared_ptr<MethodInstance> method_instance,
+                  const RpcRequest &request)
+      : server(std::move(server)), session(std::move(session)),
+        method_instance(std::move(method_instance)), request(request) {}
+
+  // Returns true if the write worked, false if the request was cancelled.
+  bool Write(std::unique_ptr<google::protobuf::Any> res, co::Coroutine *c);
+  void Finish(co::Coroutine *c);
+
+  void Cancel() { is_cancelled = true; }
+
+  bool IsCancelled() const { return is_cancelled; }
+
+  std::shared_ptr<RpcServer> server;
+  std::shared_ptr<Session> session;
+  std::shared_ptr<MethodInstance> method_instance;
+  const RpcRequest &request;
+  bool is_cancelled = false;
+};
+
+struct Method {
+  Method(RpcServer *server, std::string name, std::string request_type,
+         std::string response_type, int32_t slot_size, int32_t num_slots,
+         std::function<absl::Status(const google::protobuf::Any &,
+                                    google::protobuf::Any *, co::Coroutine *)>
+             callback,
+         int id)
+      : name(std::move(name)), request_type(std::move(request_type)),
+        response_type(std::move(response_type)), slot_size(slot_size),
+        num_slots(num_slots), callback(std::move(callback)), id(id) {
+    MakeChannelNames(server);
+  }
+  // Streaming method constructor.
+  Method(
+      RpcServer *server, std::string name, std::string request_type,
+      std::string response_type, int32_t slot_size, int32_t num_slots,
+      std::function<absl::Status(const google::protobuf::Any &,
+                                 internal::AnyStreamWriter &, co::Coroutine *)>
+          callback,
+      int id)
+      : name(std::move(name)), request_type(std::move(request_type)),
+        response_type(std::move(response_type)), slot_size(slot_size),
+        num_slots(num_slots), stream_callback(std::move(callback)), id(id) {
+    MakeChannelNames(server);
+  }
+
+  void MakeChannelNames(RpcServer *server);
+
+  bool IsStreaming() const { return stream_callback != nullptr; }
+
+  std::string name;
+  std::string request_type;
+  std::string response_type;
+  int32_t slot_size;
+  int32_t num_slots;
+  // Callback for normal, non-streaming method that is called and returns a
+  // single result.
+  std::function<absl::Status(const google::protobuf::Any &,
+                             google::protobuf::Any *, co::Coroutine *)>
+      callback;
+  // Callback for a streaming method that produces multiple responses.
+  std::function<absl::Status(const google::protobuf::Any &,
+                             internal::AnyStreamWriter &, co::Coroutine *)>
+      stream_callback;
+  std::string request_channel;
+  std::string response_channel;
+  std::string cancel_channel;
+  int id;
+};
+
+struct MethodInstance {
+  std::shared_ptr<Method> method;
+  std::shared_ptr<subspace::Subscriber> request_subscriber;
+  std::shared_ptr<subspace::Publisher> response_publisher;
+  std::shared_ptr<subspace::Subscriber> cancel_subscriber;
+};
+
+struct Session {
+  int session_id;
+  uint64_t client_id;
+  absl::flat_hash_map<int, std::shared_ptr<MethodInstance>> methods;
+};
+
+} // namespace internal
+
+template <typename Response> struct StreamWriter {
+  // Returns true if the write worked, false if the request was cancelled.
+  bool Write(const Response &res, co::Coroutine *c) {
+    auto any = std::make_unique<google::protobuf::Any>();
+    any->PackFrom(res);
+    return writer->Write(std::move(any), c);
+  }
+
+  void Finish(co::Coroutine *c) { writer->Finish(c); }
+
+  void Cancel() { writer->Cancel(); }
+
+  bool IsCancelled() const { return writer->IsCancelled(); }
+
+  void SetWriter(internal::AnyStreamWriter *writer) { this->writer = writer; }
+  internal::AnyStreamWriter *writer;
+};
+
+struct MethodOptions {
+  int32_t slot_size = kDefaultMethodSlotSize;
+  int32_t num_slots = kDefaultMethodNumSlots;
+  int id = -1;
+};
+
+class RpcServer : public std::enable_shared_from_this<RpcServer> {
+public:
+  RpcServer(std::string service_name,
+            std::string subspace_server_socket = "/tmp/subspace");
+
+  ~RpcServer() = default;
+
+  void SetLogLevel(const std::string &level) { logger_.SetLogLevel(level); }
+
+  void SetStartingSessionId(int session_id) { next_session_id_ = session_id; }
+
+  // Run the server.  If you pass a coroutine scheduler this will use it
+  // and the function will not block.  If you don't pass a scheduler
+  // the server will use its own internal scheduler and this function will
+  // block until the server is stopped (the Stop call).
+  //
+  // If you are using this in threaded application (most common probably),
+  // just omit the scheduler argument and the thread will run the server.
+  //
+  // There is no use of threads inside the server itself.
+  absl::Status Run(co::CoroutineScheduler *scheduler = nullptr);
+
+  // Stop the server running.  This will signal a stop and will return
+  // immediately.
+  void Stop();
+
+  // Register a method that takes a request and produces a response.  The
+  // default channel parameters (slot size and number of slots) will be used.
+
+  // Register a method that takes a request and produces a response.  You
+  // specify the slot size and number of slots for the channels.
+  template <typename Request, typename Response>
+  absl::Status RegisterMethod(
+      const std::string &method,
+      std::function<absl::Status(const Request &, Response *, co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  // Type void method with slot parameters.
+  template <typename Request>
+  absl::Status RegisterMethod(
+      const std::string &method,
+      std::function<absl::Status(const Request &, co::Coroutine *)> callback,
+      MethodOptions &&options = {});
+
+  // Method that takes a raw message and returns a raw message.
+  // NOTE: this will make a copy of the request into a vector<char>.  For a more
+  // efficient version that doesn't copy, use the version below that takes a
+  // span.
+  absl::Status RegisterMethod(
+      const std::string &method,
+      std::function<absl::Status(const std::vector<char> &, std::vector<char> *,
+                                 co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  absl::Status RegisterMethod(
+      const std::string &method,
+      std::function<absl::Status(const absl::Span<const char> &,
+                                 std::vector<char> *, co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  // Server streaming methods.  These take in a single request and produce
+  // multiple responses.
+  template <typename Request, typename Response>
+  absl::Status RegisterMethod(
+      const std::string &method,
+      std::function<absl::Status(const Request &, StreamWriter<Response> &,
+                                 co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  absl::Status UnregisterMethod(const std::string &method) {
+    auto it = methods_.find(method);
+    if (it == methods_.end()) {
+      return absl::NotFoundError("Method not found: " + method);
+    }
+    methods_.erase(it);
+    return absl::OkStatus();
+  }
+
+  const std::string &Name() const { return name_; }
+
+  // These methods are non-templated and take google::protobuf::Any arguments
+  // and responses.  They are notionally private but we need to access them
+  // for the server test unit test.
+
+  // Method with a request and response.
+  absl::Status RegisterMethod(
+      const std::string &method, const std::string &request_type,
+      const std::string &response_type,
+      std::function<absl::Status(const google::protobuf::Any &,
+                                 google::protobuf::Any *, co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  absl::Status
+  RegisterMethod(const std::string &method, const std::string &request_type,
+                 std::function<absl::Status(const google::protobuf::Any &,
+                                            co::Coroutine *)>
+                     callback,
+                 MethodOptions &&options = {});
+
+  // Streaming method.
+  absl::Status RegisterMethod(
+      const std::string &method, const std::string &request_type,
+      const std::string &response_type,
+      std::function<absl::Status(const google::protobuf::Any &,
+                                 internal::AnyStreamWriter &, co::Coroutine *)>
+          callback,
+      MethodOptions &&options = {});
+
+  // For debugging we might need to get hold of the scheduler.
+  co::CoroutineScheduler *Scheduler() { return scheduler_; }
+
+private:
+  friend struct internal::AnyStreamWriter;
+
+  absl::Status CreateChannels();
+  void AddCoroutine(std::unique_ptr<co::Coroutine> coroutine) {
+    coroutines_.insert(std::move(coroutine));
+  }
+  static void ListenerCoroutine(std::shared_ptr<RpcServer> server,
+                                co::Coroutine *c);
+
+  absl::Status HandleIncomingRpcServerRequest(subspace::Message msg,
+                                              co::Coroutine *c);
+  absl::Status HandleOpen(uint64_t client_id,
+                          const subspace::RpcOpenRequest &request,
+                          subspace::RpcOpenResponse *response,
+                          co::Coroutine *c);
+  absl::Status HandleClose(uint64_t client_id,
+                           const subspace::RpcCloseRequest &request,
+                           subspace::RpcCloseResponse *response,
+                           co::Coroutine *c);
+  absl::Status
+  PublishRpcServerResponse(const subspace::RpcServerResponse &response,
+                           co::Coroutine *c);
+
+  absl::StatusOr<std::shared_ptr<internal::Session>>
+  CreateSession(uint64_t client_id);
+  absl::Status DestroySession(int session_id);
+
+  static void SessionMethodCoroutine(
+      std::shared_ptr<RpcServer> server,
+      std::shared_ptr<internal::Session> session,
+      std::shared_ptr<internal::MethodInstance> method_instance,
+      co::Coroutine *c);
+
+  static void SessionStreamingMethodCoroutine(
+      std::shared_ptr<RpcServer> server,
+      std::shared_ptr<internal::Session> session,
+      std::shared_ptr<internal::MethodInstance> method_instance,
+      co::Coroutine *c);
+
+  static void SendStreamRpcResponse(
+      std::shared_ptr<RpcServer> server,
+      std::shared_ptr<internal::Session> session,
+      std::shared_ptr<internal::MethodInstance> method_instance,
+      const RpcRequest &request, std::unique_ptr<google::protobuf::Any> result,
+      bool is_last, bool is_cancelled, co::Coroutine *c);
+  static void
+  SendRpcError(std::shared_ptr<RpcServer> server,
+               std::shared_ptr<internal::Session> session,
+               std::shared_ptr<internal::MethodInstance> method_instance,
+               const RpcRequest &request, const std::string &error,
+               co::Coroutine *c);
+
+  std::string name_;
+  std::string subspace_server_socket_;
+  co::CoroutineScheduler local_scheduler_;
+  co::CoroutineScheduler *scheduler_;
+  std::shared_ptr<Client> client_;
+  absl::flat_hash_map<std::string, std::shared_ptr<internal::Method>> methods_;
+  toolbelt::Logger logger_;
+  toolbelt::Pipe interrupt_pipe_;
+
+  std::shared_ptr<subspace::Subscriber> request_receiver_;
+  std::shared_ptr<subspace::Publisher> response_publisher_;
+  absl::flat_hash_set<std::unique_ptr<co::Coroutine>> coroutines_;
+  bool running_ = false;
+  int32_t next_session_id_ = 0; // Next session ID.
+  int next_method_id_ = 0;      // Next method ID.
+  absl::flat_hash_map<int32_t, std::shared_ptr<internal::Session>> sessions_;
+};
+
+template <typename Request, typename Response>
+inline absl::Status RpcServer::RegisterMethod(
+    const std::string &method,
+    std::function<absl::Status(const Request &, Response *, co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  auto request_descriptor = Request::descriptor();
+  auto response_descriptor = Response::descriptor();
+
+  return RegisterMethod(
+      method, request_descriptor->full_name(), response_descriptor->full_name(),
+      [method, callback = std::move(callback), request_descriptor](
+          const google::protobuf::Any &req, google::protobuf::Any *res,
+          co::Coroutine *c) -> absl::Status {
+        if (!req.Is<Request>()) {
+          return absl::InvalidArgumentError(absl::StrFormat(
+              "Invalid argment type for %s: need %s got %s", method,
+              request_descriptor->full_name().c_str(), req.type_url().c_str()));
+        }
+        Request request;
+        if (!req.UnpackTo(&request)) {
+          return absl::InvalidArgumentError("Failed to unpack request");
+        }
+        Response response;
+        auto status = callback(request, &response, c);
+        if (!status.ok()) {
+          return status;
+        }
+        res->PackFrom(response);
+        return absl::OkStatus();
+      },
+      std::move(options));
+}
+
+template <typename Request>
+inline absl::Status RpcServer::RegisterMethod(
+    const std::string &method,
+    std::function<absl::Status(const Request &, co::Coroutine *)> callback,
+    MethodOptions &&options) {
+  auto request_descriptor = Request::descriptor();
+
+  return RegisterMethod(
+      method, request_descriptor->full_name(),
+      [method, callback = std::move(callback), request_descriptor](
+          const google::protobuf::Any &req, co::Coroutine *c) -> absl::Status {
+        if (!req.Is<Request>()) {
+          return absl::InvalidArgumentError(absl::StrFormat(
+              "Invalid argment type for %s: need %s got %s", method,
+              request_descriptor->full_name().c_str(), req.type_url().c_str()));
+        }
+        Request request;
+        if (!req.UnpackTo(&request)) {
+          return absl::InvalidArgumentError("Failed to unpack request");
+        }
+        return callback(request, c);
+      },
+      std::move(options));
+}
+
+template <typename Request, typename Response>
+inline absl::Status RpcServer::RegisterMethod(
+    const std::string &method,
+    std::function<absl::Status(const Request &, StreamWriter<Response> &,
+                               co::Coroutine *)>
+        callback,
+    MethodOptions &&options) {
+  auto request_descriptor = Request::descriptor();
+  auto response_descriptor = Response::descriptor();
+
+  StreamWriter<Response> typed_writer;
+  return RegisterMethod(
+      method, request_descriptor->full_name(), response_descriptor->full_name(),
+      [method, callback = std::move(callback), request_descriptor,
+       typed_writer](const google::protobuf::Any &req,
+                     internal::AnyStreamWriter &writer,
+                     co::Coroutine *c) mutable -> absl::Status {
+        if (!req.Is<Request>()) {
+          return absl::InvalidArgumentError(absl::StrFormat(
+              "Invalid argment type for %s: need %s got %s", method,
+              request_descriptor->full_name().c_str(), req.type_url().c_str()));
+        }
+        Request request;
+        if (!req.UnpackTo(&request)) {
+          return absl::InvalidArgumentError("Failed to unpack request");
+        }
+        typed_writer.SetWriter(&writer);
+        auto status = callback(request, typed_writer, c);
+        if (!status.ok()) {
+          return status;
+        }
+        return absl::OkStatus();
+      },
+      std::move(options));
+}
+} // namespace subspace

--- a/rpc/server/server_test.cc
+++ b/rpc/server/server_test.cc
@@ -1,0 +1,879 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/hash/hash_testing.h"
+#include "absl/status/status_matchers.h"
+#include "client/client.h"
+#include "coroutine.h"
+#include "google/protobuf/any.pb.h"
+#include "rpc/proto/rpc_test.pb.h"
+#include "rpc/server/rpc_server.h"
+#include "server/server.h"
+#include "toolbelt/clock.h"
+#include "toolbelt/hexdump.h"
+#include "toolbelt/pipe.h"
+#include <gtest/gtest.h>
+#include <inttypes.h>
+#include <memory>
+#include <signal.h>
+#include <sys/resource.h>
+#include <thread>
+
+ABSL_FLAG(bool, start_server, true, "Start the subspace server");
+ABSL_FLAG(std::string, server, "", "Path to server executable");
+
+void SignalHandler(int sig) { printf("Signal %d", sig); }
+
+using Publisher = subspace::Publisher;
+using Subscriber = subspace::Subscriber;
+using Message = subspace::Message;
+using InetAddress = toolbelt::InetAddress;
+
+#define VAR(a) a##__COUNTER__
+#define EVAL_AND_ASSERT_OK(expr) EVAL_AND_ASSERT_OK2(VAR(r_), expr)
+
+#define EVAL_AND_ASSERT_OK2(result, expr)                                      \
+  ({                                                                           \
+    auto result = (expr);                                                      \
+    if (!result.ok()) {                                                        \
+      std::cerr << result.status() << std::endl;                               \
+    }                                                                          \
+    ASSERT_OK(result);                                                         \
+    std::move(*result);                                                        \
+  })
+
+#define ASSERT_OK(e) ASSERT_THAT(e, ::absl_testing::IsOk())
+
+class ServerTest : public ::testing::Test {
+public:
+  // We run one server for the duration of the whole test suite.
+  static void SetUpTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Starting Subspace server\n");
+    char socket_name_template[] = "/tmp/subspaceXXXXXX"; // NOLINT
+    ::close(mkstemp(&socket_name_template[0]));
+    socket_ = &socket_name_template[0];
+
+    // The server will write to this pipe to notify us when it
+    // has started and stopped.  This end of the pipe is blocking.
+    (void)pipe(server_pipe_);
+
+    server_ =
+        std::make_unique<subspace::Server>(scheduler_, socket_, "", 0, 0,
+                                           /*local=*/true, server_pipe_[1]);
+
+    // Start server running in a thread.
+    server_thread_ = std::thread([]() {
+      absl::Status s = server_->Run();
+      if (!s.ok()) {
+        fprintf(stderr, "Error running Subspace server: %s\n",
+                s.ToString().c_str());
+        exit(1);
+      }
+    });
+
+    // Wait for server to tell us that it's running.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+  }
+
+  static void TearDownTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Stopping Subspace server\n");
+    server_->Stop();
+
+    // Wait for server to tell us that it's stopped.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+    server_thread_.join();
+  }
+
+  void SetUp() override { signal(SIGPIPE, SIG_IGN); }
+  void TearDown() override {}
+
+  static void InitClient(subspace::Client &client) {
+    ASSERT_OK(client.Init(Socket()));
+  }
+
+  static const std::string &Socket() { return socket_; }
+
+  static subspace::Server *Server() { return server_.get(); }
+
+private:
+  static co::CoroutineScheduler scheduler_;
+  static std::string socket_;
+  static int server_pipe_[2];
+  static std::unique_ptr<subspace::Server> server_;
+  static std::thread server_thread_;
+};
+
+co::CoroutineScheduler ServerTest::scheduler_;
+std::string ServerTest::socket_ = "/tmp/subspace";
+int ServerTest::server_pipe_[2];
+std::unique_ptr<subspace::Server> ServerTest::server_;
+std::thread ServerTest::server_thread_;
+
+static int next_session = 1;
+static std::shared_ptr<subspace::RpcServer> BuildServer() {
+  auto server = std::make_shared<subspace::RpcServer>("TestService",
+                                                      ServerTest::Socket());
+
+  server->SetLogLevel("debug");
+  server->SetStartingSessionId(next_session++);
+
+  auto s = server->RegisterMethod(
+      "TestMethod", "subspace.TestRequest", "subspace.TestResponse",
+      [](const google::protobuf::Any &req, google::protobuf::Any *res,
+         co::Coroutine *) -> absl::Status {
+        std::cerr << "TestMethod called with request: " << req.DebugString()
+                  << std::endl;
+        rpc::TestResponse r;
+        r.set_message("Hello from TestMethod");
+        res->PackFrom(r);
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  // Void method.
+  s = server->RegisterMethod(
+      "VoidMethod", "subspace.TestRequest",
+      [](const google::protobuf::Any &req, co::Coroutine *) -> absl::Status {
+        std::cerr << "VoidMethod called with request: " << req.DebugString()
+                  << std::endl;
+        return absl::OkStatus();
+      });
+
+  // Error method.
+  s = server->RegisterMethod(
+      "ErrorMethod", "subspace.TestRequest", "subspace.TestResponse",
+      [](const google::protobuf::Any &req, google::protobuf::Any *res,
+         co::Coroutine *) -> absl::Status {
+        std::cerr << "ErrorMethod called with request: " << req.DebugString()
+                  << std::endl;
+        return absl::InternalError("Error occurred");
+      });
+  EXPECT_TRUE(s.ok());
+
+  // void error method.
+  s = server->RegisterMethod(
+      "VoidErrorMethod", "subspace.TestRequest",
+      [](const google::protobuf::Any &req, co::Coroutine *) -> absl::Status {
+        std::cerr << "VoidErrorMethod called with request: "
+                  << req.DebugString() << std::endl;
+        return absl::InternalError("Error occurred");
+      });
+  EXPECT_TRUE(s.ok());
+
+  // Stream method.
+  s = server->RegisterMethod(
+      "StreamMethod", "subspace.TestRequest", "subspace.TestResponse",
+      [](const google::protobuf::Any &req,
+         subspace::internal::AnyStreamWriter &writer,
+         co::Coroutine *c) -> absl::Status {
+        rpc::TestRequest test;
+        if (!req.UnpackTo(&test)) {
+          return absl::InvalidArgumentError("Failed to unpack request");
+        }
+        std::cerr << "StreamMethod called with request: " << req.DebugString()
+                  << std::endl;
+        constexpr int kNumResults = 200;
+        for (int i = 0; i < kNumResults; i++) {
+          if (writer.IsCancelled()) {
+            std::cerr << "StreamMethod cancelled after " << i << " responses"
+                      << std::endl;
+            writer.Finish(c);
+            return absl::OkStatus();
+          }
+          rpc::TestResponse r;
+          r.set_message("Hello from StreamMethod part " + std::to_string(i));
+          auto res = std::make_unique<google::protobuf::Any>();
+          res->PackFrom(r);
+          writer.Write(std::move(res), c);
+          c->Millisleep(test.stream_period());
+        }
+
+        writer.Finish(c);
+        return absl::OkStatus();
+      });
+  EXPECT_TRUE(s.ok());
+
+  return server;
+}
+
+struct ServerContext {
+  std::shared_ptr<subspace::Client> client;
+  std::shared_ptr<subspace::Publisher> pub;
+  std::shared_ptr<subspace::Subscriber> sub;
+  uint64_t client_id;
+  int session_id;
+};
+
+static uint64_t next_client_id = 1;
+static int next_request_id = 1;
+
+static void Open(std::shared_ptr<subspace::RpcServer> server,
+                 subspace::RpcServerResponse &response, ServerContext &ctx,
+                 co::Coroutine *c) {
+  subspace::RpcServerRequest req;
+  ctx.client_id = next_client_id++;
+  req.set_client_id(ctx.client_id);
+
+  int request_id = next_request_id++;
+  req.set_request_id(request_id);
+  req.mutable_open();
+
+  subspace::Client client;
+  ServerTest::InitClient(client);
+  ctx.client = std::make_shared<subspace::Client>(std::move(client));
+
+  auto pub = ctx.client->CreatePublisher(
+      "/rpc/TestService/request", 1024, 10,
+      {.reliable = true, .type = "subspace.RpcServerRequest"});
+  ASSERT_OK(pub);
+
+  ctx.pub = std::make_shared<subspace::Publisher>(std::move(*pub));
+  auto sub = ctx.client->CreateSubscriber(
+      "/rpc/TestService/response",
+      {.reliable = true, .type = "subspace.RpcServerResponse"});
+  ASSERT_OK(sub);
+
+  ctx.sub = std::make_shared<subspace::Subscriber>(std::move(*sub));
+
+  auto buffer = ctx.pub->GetMessageBuffer(1024);
+  ASSERT_OK(buffer);
+  ASSERT_NE(nullptr, *buffer);
+  ASSERT_TRUE(req.SerializeToArray(*buffer, 1024));
+  ASSERT_OK(ctx.pub->PublishMessage(int(req.ByteSizeLong())));
+
+  subspace::Message msg;
+  for (;;) {
+    ASSERT_OK(ctx.sub->Wait(c));
+    for (;;) {
+      auto m = ctx.sub->ReadMessage();
+      ASSERT_OK(m);
+      if (m->length > 0) {
+        msg = std::move(*m);
+        ASSERT_TRUE(response.ParseFromArray(msg.buffer, msg.length));
+        if (response.client_id() == ctx.client_id &&
+            response.request_id() == request_id && response.has_open()) {
+          ctx.session_id = response.open().session_id();
+          return;
+        }
+      }
+    }
+  }
+}
+
+static void Close(std::shared_ptr<subspace::RpcServer> server,
+                  ServerContext &ctx, co::Coroutine *c) {
+  subspace::RpcServerRequest req;
+  req.set_client_id(ctx.client_id);
+
+  int request_id = next_request_id++;
+  req.set_request_id(request_id);
+  req.mutable_close()->set_session_id(ctx.session_id);
+
+  auto buffer = ctx.pub->GetMessageBuffer(256);
+  ASSERT_OK(buffer);
+  ASSERT_TRUE(req.SerializeToArray(*buffer, 1024));
+  ASSERT_OK(ctx.pub->PublishMessage(int(req.ByteSizeLong())));
+
+  subspace::Message msg;
+  for (;;) {
+    std::cerr << "waiting for close\n";
+    ASSERT_OK(ctx.sub->Wait(c));
+    for (;;) {
+      auto m = ctx.sub->ReadMessage();
+      ASSERT_OK(m);
+      if (m->length > 0) {
+        msg = std::move(*m);
+        subspace::RpcServerResponse response;
+        ASSERT_TRUE(response.ParseFromArray(msg.buffer, msg.length));
+        if (response.client_id() == ctx.client_id &&
+            response.request_id() == request_id && response.has_close()) {
+          std::cerr << "Received close response: " << response.DebugString()
+                    << std::endl;
+          return;
+        }
+      }
+    }
+  }
+}
+
+static const subspace::RpcOpenResponse::Method *
+FindMethod(const subspace::RpcOpenResponse &response, const std::string &name) {
+  for (auto &method : response.methods()) {
+    if (method.name() == name) {
+      return &method;
+    }
+  }
+  return nullptr;
+}
+
+TEST_F(ServerTest, Open) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    Close(server, ctx, c);
+
+    server->Stop();
+  });
+
+  scheduler.Run();
+  std::cerr << "Server stopped" << std::endl;
+  std::cerr << "Server use count: " << server.use_count() << std::endl;
+}
+
+TEST_F(ServerTest, OpenAndCallNoResponseRead) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the TestRequest method in the response.
+    auto *method = FindMethod(response.open(), "TestMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    std::cerr << "creating pub " << method->request_channel().name()
+              << std::endl;
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    std::cerr << "publishing " << req.DebugString();
+    std::cerr << "request channel: " << method->request_channel().name()
+              << std::endl;
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_NE(nullptr, *buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+    Close(server, ctx, c);
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, OpenAndCall) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the TestRequest method in the response.
+    auto *method = FindMethod(response.open(), "TestMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    std::cerr << "subscribing to " << method->response_channel().name()
+              << std::endl;
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    std::cerr << "publishing " << req.DebugString();
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+
+    subspace::Message msg;
+    bool done = false;
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        std::cerr << "message length: " << m->length << std::endl;
+        if (m->length > 0) {
+          msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          std::cerr << "received message " << rpc_response.DebugString()
+                    << std::endl;
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            std::cerr << "Received RPC response: " << rpc_response.DebugString()
+                      << std::endl;
+
+            rpc::TestResponse response_message;
+            rpc_response.result().UnpackTo(&response_message);
+            std::cerr << "Received RPC result: "
+                      << response_message.DebugString() << std::endl;
+            done = true;
+            break;
+          }
+          continue;
+        }
+        break;
+      }
+    }
+
+    Close(server, ctx, c);
+
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, CallVoidMethod) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the TestRequest method in the response.
+    auto *method = FindMethod(response.open(), "VoidMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, void world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    std::cerr << "publishing " << req.DebugString();
+    std::cerr << "request channel: " << method->request_channel().name()
+              << std::endl;
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+    bool done = false;
+    subspace::Message msg;
+
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        if (m->length > 0) {
+          msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          std::cerr << "received message " << rpc_response.DebugString() << " "
+                    << rpc_response.client_id() << " " << ctx.client_id
+                    << std::endl;
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            std::cerr << "Received RPC response: " << rpc_response.DebugString()
+                      << std::endl;
+
+            rpc::TestResponse response_message;
+            rpc_response.result().UnpackTo(&response_message);
+            std::cerr << "Received RPC result: "
+                      << response_message.DebugString() << std::endl;
+            done = true;
+            break;
+          }
+          continue;
+        }
+        break;
+      }
+    }
+    Close(server, ctx, c);
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, CallError) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the TestRequest method in the response.
+    auto *method = FindMethod(response.open(), "ErrorMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, error world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    std::cerr << "publishing " << req.DebugString();
+    std::cerr << "request channel: " << method->request_channel().name()
+              << std::endl;
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+
+    subspace::Message msg;
+
+    bool done = false;
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        if (m->length > 0) {
+          msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            std::cerr << "Received RPC response: " << rpc_response.DebugString()
+                      << std::endl;
+
+            rpc::TestResponse response_message;
+            rpc_response.result().UnpackTo(&response_message);
+            std::cerr << "Received RPC result: "
+                      << response_message.DebugString() << std::endl;
+            EXPECT_EQ(
+                "Error executing method ErrorMethod: INTERNAL: Error occurred",
+                rpc_response.error());
+            done = true;
+            break;
+          }
+          continue;
+        }
+        break;
+      }
+    }
+    Close(server, ctx, c);
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, Stream) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the StreamMethod in the response.
+    auto *method = FindMethod(response.open(), "StreamMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    std::cerr << "subscribing to " << method->response_channel().name()
+              << std::endl;
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    std::cerr << "publishing " << req.DebugString();
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+
+    bool done = false;
+    int num_results = 0;
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        std::cerr << "message length: " << m->length << std::endl;
+        if (m->length > 0) {
+          subspace::Message msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          std::cerr << "received message " << rpc_response.DebugString()
+                    << std::endl;
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            std::cerr << "Received RPC response: " << rpc_response.DebugString()
+                      << std::endl;
+
+            rpc::TestResponse response_message;
+            rpc_response.result().UnpackTo(&response_message);
+            std::cerr << "Received RPC result: "
+                      << response_message.DebugString() << std::endl;
+            num_results++;
+            if (rpc_response.is_last()) {
+              done = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+    }
+
+    ASSERT_EQ(201, num_results);
+    Close(server, ctx, c);
+
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, CancelStream) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+    std::cerr << "Received response: " << response.DebugString() << std::endl;
+
+    // Find the StreamMethod in the response.
+    auto *method = FindMethod(response.open(), "StreamMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, world!");
+    test_request.set_stream_period(100);
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    auto cancel_pub = client.CreatePublisher(method->cancel_channel(), 64, 10,
+                                             {.reliable = true});
+    ASSERT_OK(cancel_pub);
+
+    std::cerr << "subscribing to " << method->response_channel().name()
+              << std::endl;
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    std::cerr << "publishing " << req.DebugString();
+    // This is a reliable publisher but we are guaranteed to be able to send.
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+
+    bool done = false;
+    int num_results = 0;
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        std::cerr << "message length: " << m->length << std::endl;
+        if (m->length > 0) {
+          subspace::Message msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          std::cerr << "received message " << rpc_response.DebugString()
+                    << std::endl;
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            std::cerr << "Received RPC response: " << rpc_response.DebugString()
+                      << std::endl;
+
+            rpc::TestResponse response_message;
+            rpc_response.result().UnpackTo(&response_message);
+            std::cerr << "Received RPC result: "
+                      << response_message.DebugString() << std::endl;
+            num_results++;
+            if (num_results == 5) {
+              // Send a cancel message
+              auto buffer = cancel_pub->GetMessageBuffer(64);
+              ASSERT_OK(buffer);
+              subspace::RpcCancelRequest cancel;
+              cancel.set_client_id(ctx.client_id);
+              cancel.set_request_id(request_id);
+              cancel.set_session_id(response.open().session_id());
+              ASSERT_TRUE(
+                  cancel.SerializeToArray(*buffer, cancel.ByteSizeLong()));
+              ASSERT_OK(cancel_pub->PublishMessage(int(cancel.ByteSizeLong())));
+            }
+            if (rpc_response.is_cancelled()) {
+              done = true;
+              break;
+            }
+          }
+          continue;
+        }
+        break;
+      }
+    }
+
+    ASSERT_EQ(6, num_results);
+    Close(server, ctx, c);
+
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  absl::ParseCommandLine(argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/rpc/subspace_rpc_library.bzl
+++ b/rpc/subspace_rpc_library.bzl
@@ -1,0 +1,279 @@
+"""
+This module provides a rule to generate subspace_rpc message files from proto_library targets.
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+MessageInfo = provider(fields = ["direct_sources", "transitive_sources", "cpp_outputs"])
+
+def _subspace_rpc_action(
+        ctx,
+        direct_sources,
+        transitive_sources,
+        out_dir,
+        package_name,
+        outputs,
+        add_namespace,
+        target_name):
+    # The protobuf compiler allow plugins to get arguments specified in the --plugin_out
+    # argument.  The args are passed as a comma separated list of key=value pairs followed
+    # by a colon and the output directory.
+    options_and_out_dir = ""
+    if add_namespace != "":
+        options_and_out_dir = "--subspace_rpc_out=add_namespace={},package_name={},target_name={}:{}".format(add_namespace, package_name, target_name, out_dir)
+    else:
+        options_and_out_dir = "--subspace_rpc_out=package_name={},target_name={}:{}".format(package_name, target_name, out_dir)
+
+    inputs = depset(direct = direct_sources, transitive = transitive_sources)
+
+    import_paths = []
+    for s in transitive_sources:
+        for f in s.to_list():
+            if not f.is_source:
+                index = f.path.find("_virtual_imports")
+                if index != -1:
+                    # Go to first slash after _virtual_imports/
+                    slash = f.path.find("/", index + 17)
+                    import_paths.append("-I" + f.path[:slash])
+
+    plugin, _, plugin_manifests = ctx.resolve_command(tools = [ctx.attr.subspace_rpc_plugin])
+    plugin_arg = "--plugin=protoc-gen-subspace_rpc={}".format(ctx.executable.subspace_rpc_plugin.path)
+
+    args = ctx.actions.args()
+    args.add(plugin_arg)
+    args.add(options_and_out_dir)
+    args.add_all(inputs)
+    args.add_all(import_paths)
+    args.add("-I.")
+
+    ctx.actions.run(
+        inputs = inputs,
+        tools = plugin,
+        input_manifests = plugin_manifests,
+        executable = ctx.executable.protoc,
+        outputs = outputs,
+        arguments = [args],
+        progress_message = "Generating subspace_rpc message files %s" % ctx.label,
+        mnemonic = "Phaser",
+    )
+
+# This aspect generates the MessageInfo provider containing the files we
+# will generate from running the Phaser plugin.
+def _subspace_rpc_aspect_impl(target, _ctx):
+    direct_sources = []
+    transitive_sources = depset()
+    cpp_outputs = []
+
+    def add_output(base):
+        cpp_outputs.append(paths.replace_extension(base, ".subspace.rpc_client.cc"))
+        cpp_outputs.append(paths.replace_extension(base, ".subspace.rpc_client.h"))
+        cpp_outputs.append(paths.replace_extension(base, ".subspace.rpc_server.cc"))
+        cpp_outputs.append(paths.replace_extension(base, ".subspace.rpc_server.h"))
+
+    if ProtoInfo in target:
+        transitive_sources = target[ProtoInfo].transitive_sources
+        for s in transitive_sources.to_list():
+            direct_sources.append(s)
+            file_path = s.short_path
+            if "_virtual_imports" in file_path:
+                # For a file that is not in this package, we need to generate the
+                # output in our package.
+                # The path looks like:
+                # ../com_google_protobuf/_virtual_imports/any_proto/google/protobuf/any.proto
+                # We want to declare the file as:ƒ
+                # google/protobuf/any.subspace_rpc.cc
+                v = file_path.split("_virtual_imports/")
+
+                # Remove the first directory of v[1] to get the path relative to the package.
+                file_path = v[1].split("/", 1)[1]
+            add_output(file_path)
+
+    return [MessageInfo(
+        direct_sources = direct_sources,
+        transitive_sources = transitive_sources,
+        cpp_outputs = cpp_outputs,
+    )]
+
+subspace_rpc_aspect = aspect(
+    attr_aspects = ["deps"],
+    provides = [MessageInfo],
+    implementation = _subspace_rpc_aspect_impl,
+)
+
+# The subspace_rpc rule runs the Subspace RPC plugin from the protoc compiler.
+# The deps for the rule are proto_libraries that contain the protobuf files.
+def _subspace_rpc_impl(ctx):
+    outputs = []
+
+    direct_sources = []
+    transitive_sources = []
+    cpp_outputs = []
+    package_name = ctx.attr.package_name
+    for dep in ctx.attr.deps:
+        dep_outs = []
+        for out in dep[MessageInfo].cpp_outputs:
+            out_name = ctx.attr.target_name + "/" + out
+            out_file = ctx.actions.declare_file(out_name)
+            dep_outs.append(out_file)
+
+            # If we are creating a header file in our package, we need to create a symlink to it.
+            # This is because the header file will be something like
+            # subspace_rpc/testdata/subspace_rpc/testdata/Test.subspace.rpc_client.h
+            # but we want to be able to do:
+            # #include "subspace_rpc/testdata/Test.subspace.rpc_client.h"
+            # so we create the symlink:
+            # Test.subspace.rpc_client.h -> subspace_rpc/testdata/subspace_rpc/testdata/Test.subspace.rpc_client.h
+            if out_file.extension == "h":
+                prefix = paths.join(ctx.attr.target_name, package_name)
+                symlink_name = out_file.short_path[len(prefix) + 1:]
+                if symlink_name.startswith(package_name):
+                    # Header is in our package, remove the package name.
+                    # If the header is outside our package (like google/protobuf/any.h),
+                    # we don't want to create a symlink to it becuase it's in
+                    # the right place already.
+                    symlink_name = symlink_name[len(package_name) + 1:]
+                    symlink = ctx.actions.declare_file(symlink_name)
+                    ctx.actions.symlink(output = symlink, target_file = out_file)
+                    dep_outs.append(symlink)
+            cpp_outputs.append(out_file)
+
+        direct_sources += dep[MessageInfo].direct_sources
+        transitive_sources.append(dep[MessageInfo].transitive_sources)
+        outputs += dep_outs
+
+    _subspace_rpc_action(
+        ctx,
+        direct_sources,
+        transitive_sources,
+        ctx.bin_dir.path,
+        ctx.attr.package_name,
+        cpp_outputs,
+        ctx.attr.add_namespace,
+        ctx.attr.target_name,
+    )
+
+    return [DefaultInfo(files = depset(outputs))]
+
+_subspace_rpc_gen = rule(
+    attrs = {
+        "protoc": attr.label(
+            executable = True,
+            default = Label("@com_google_protobuf//:protoc"),
+            cfg = "exec",
+        ),
+        "subspace_rpc_plugin": attr.label(
+            executable = True,
+            default = Label("//rpc/idl_compiler:subspace_rpc"),
+            cfg = "exec",
+        ),
+        "deps": attr.label_list(
+            aspects = [subspace_rpc_aspect],
+        ),
+        "add_namespace": attr.string(),
+        "package_name": attr.string(),
+        "target_name": attr.string(),
+    },
+    implementation = _subspace_rpc_impl,
+)
+
+def get_rpc_extension(filename):
+    """
+    Returns the file extension from a given filename or path.
+    Returns an empty string if no extension is found.
+    """
+    parts = filename.split(".")
+    if len(parts) > 2:
+        return ".".join(parts[-2:])
+    else:
+        return ""
+
+def _split_files_impl(ctx):
+    files = []
+    for file in ctx.files.deps:
+        ext = get_rpc_extension(file.basename)
+        if ext == ctx.attr.ext:
+            files.append(file)
+
+    return [DefaultInfo(files = depset(files))]
+
+_split_files = rule(
+    attrs = {
+        "deps": attr.label_list(mandatory = True),
+        "ext": attr.string(mandatory = True),
+    },
+    implementation = _split_files_impl,
+)
+
+def subspace_rpc_library(name, deps = [], add_namespace = ""):
+    """
+    Generate a cc_libary for protobuf files specified in deps.
+
+    Args:
+        name: name
+        deps: proto_libraries that contain the protobuf files
+        deps: dependencies
+        runtime: label for subspace_rpc runtime.
+        add_namespace: add given namespace to the message output
+    """
+    all_files = name + "_files"
+
+    _subspace_rpc_gen(
+        name = all_files,
+        deps = deps,
+        add_namespace = add_namespace,
+        package_name = native.package_name(),
+        target_name = name,
+    )
+
+    client_srcs = name + "_client_srcs"
+    _split_files(
+        name = client_srcs,
+        ext = "rpc_client.cc",
+        deps = [all_files],
+    )
+    client_deps = ["//rpc/client:rpc_client"]
+
+    client_hdrs = name + "_client_hdrs"
+    _split_files(
+        name = client_hdrs,
+        ext = "rpc_client.h",
+        deps = [all_files],
+    )
+
+    libdeps = []
+    for dep in deps:
+        if dep.endswith("_proto"):
+            cc_proto = dep.replace("_proto", "_cc_proto")
+            libdeps.append(cc_proto)
+
+    client_name = name + "_client"
+    native.cc_library(
+        name = client_name,
+        srcs = [client_srcs],
+        hdrs = [client_hdrs],
+        deps = libdeps + client_deps
+    )
+
+    server_srcs = name + "_server_srcs"
+    _split_files(
+        name = server_srcs,
+        ext = "rpc_server.cc",
+        deps = [all_files],
+    )
+
+    server_hdrs = name + "_server_hdrs"
+    _split_files(
+        name = server_hdrs,
+        ext = "rpc_server.h",
+        deps = [all_files],
+    )
+
+    server_deps = ["//rpc/server:rpc_server"]
+
+    server_name = name + "_server"
+    native.cc_library(
+        name = server_name,
+        srcs = [server_srcs],
+        hdrs = [server_hdrs],
+        deps = libdeps + server_deps,
+    )

--- a/rpc/test/BUILD.bazel
+++ b/rpc/test/BUILD.bazel
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_test(
+    name = "rpc_test",
+    srcs = ["rpc_test.cc"],
+    data = [
+        "//server:subspace_server",
+    ],
+    deps = [
+        "//rpc/proto:rpc_test_cc_proto",
+        "//rpc/proto:rpc_test_subspace_rpc_client",
+        "//rpc/proto:rpc_test_subspace_rpc_server",
+        "//server",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+        "@coroutines//:co",
+    ],
+)

--- a/rpc/test/rpc_test.cc
+++ b/rpc/test/rpc_test.cc
@@ -1,0 +1,336 @@
+// Copyright 2025 David Allison
+// All Rights Reserved
+// See LICENSE file for licensing information.
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/hash/hash_testing.h"
+#include "absl/status/status_matchers.h"
+#include "client/client.h"
+#include "coroutine.h"
+#include "google/protobuf/any.pb.h"
+#include "rpc/proto/rpc_test.pb.h"
+#include "rpc/proto/rpc_test.subspace.rpc_client.h"
+#include "rpc/proto/rpc_test.subspace.rpc_server.h"
+#include "server/server.h"
+#include "toolbelt/clock.h"
+#include "toolbelt/hexdump.h"
+#include "toolbelt/pipe.h"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <inttypes.h>
+#include <memory>
+#include <signal.h>
+#include <sys/resource.h>
+#include <thread>
+
+ABSL_FLAG(bool, start_server, true, "Start the subspace server");
+ABSL_FLAG(std::string, server, "", "Path to server executable");
+
+void SignalHandler(int sig) { printf("Signal %d", sig); }
+
+using Publisher = subspace::Publisher;
+using Subscriber = subspace::Subscriber;
+using Message = subspace::Message;
+using InetAddress = toolbelt::InetAddress;
+
+using namespace std::chrono_literals;
+
+#define VAR(a) a##__COUNTER__
+#define EVAL_AND_ASSERT_OK(expr) EVAL_AND_ASSERT_OK2(VAR(r_), expr)
+
+#define EVAL_AND_ASSERT_OK2(result, expr)                                      \
+  ({                                                                           \
+    auto result = (expr);                                                      \
+    if (!result.ok()) {                                                        \
+      std::cerr << result.status() << std::endl;                               \
+    }                                                                          \
+    ASSERT_OK(result);                                                         \
+    std::move(*result);                                                        \
+  })
+
+#define ASSERT_OK(e) ASSERT_THAT(e, ::absl_testing::IsOk())
+
+class RpcTest : public ::testing::Test {
+public:
+  // We run one server for the duration of the whole test suite.
+  static void SetUpTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Starting Subspace server\n");
+    char socket_name_template[] = "/tmp/subspaceXXXXXX"; // NOLINT
+    ::close(mkstemp(&socket_name_template[0]));
+    socket_ = &socket_name_template[0];
+
+    // The server will write to this pipe to notify us when it
+    // has started and stopped.  This end of the pipe is blocking.
+    (void)pipe(server_pipe_);
+
+    server_ =
+        std::make_unique<subspace::Server>(scheduler_, socket_, "", 0, 0,
+                                           /*local=*/true, server_pipe_[1]);
+
+    // Start server running in a thread.
+    server_thread_ = std::thread([]() {
+      absl::Status s = server_->Run();
+      if (!s.ok()) {
+        fprintf(stderr, "Error running Subspace server: %s\n",
+                s.ToString().c_str());
+        exit(1);
+      }
+    });
+
+    // Wait for server to tell us that it's running.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+  }
+
+  static void TearDownTestSuite() {
+    if (!absl::GetFlag(FLAGS_start_server)) {
+      return;
+    }
+    printf("Stopping Subspace server\n");
+    server_->Stop();
+
+    // Wait for server to tell us that it's stopped.
+    char buf[8];
+    (void)::read(server_pipe_[0], buf, 8);
+    server_thread_.join();
+  }
+
+  void SetUp() override { signal(SIGPIPE, SIG_IGN); }
+  void TearDown() override {}
+
+  static void InitClient(subspace::Client &client) {
+    ASSERT_OK(client.Init(Socket()));
+  }
+
+  static const std::string &Socket() { return socket_; }
+
+  static subspace::Server *Server() { return server_.get(); }
+
+private:
+  static co::CoroutineScheduler scheduler_;
+  static std::string socket_;
+  static int server_pipe_[2];
+  static std::unique_ptr<subspace::Server> server_;
+  static std::thread server_thread_;
+};
+
+co::CoroutineScheduler RpcTest::scheduler_;
+std::string RpcTest::socket_ = "/tmp/subspace";
+int RpcTest::server_pipe_[2];
+std::unique_ptr<subspace::Server> RpcTest::server_;
+std::thread RpcTest::server_thread_;
+
+
+class MyServer : public rpc::TestServiceServer {
+public:
+  MyServer(const std::string &socket) : rpc::TestServiceServer(socket) {}
+
+  absl::StatusOr<rpc::TestResponse> TestMethod(const rpc::TestRequest &request,
+                                               co::Coroutine *c) override {
+    std::cerr << "TestMethod called with request: " << request.DebugString()
+              << std::endl;
+    rpc::TestResponse response;
+    response.set_message("Hello from TestMethod");
+    return response;
+  }
+
+  absl::StatusOr<rpc::PerfResponse> PerfMethod(const rpc::PerfRequest &request,
+                                               co::Coroutine *c) override {
+    rpc::PerfResponse res;
+    res.set_client_send_time(request.send_time());
+    res.set_server_send_time(toolbelt::Now());
+    return res;
+  }
+
+  absl::Status StreamMethod(const rpc::TestRequest &request,
+                            subspace::StreamWriter<rpc::TestResponse> &writer,
+                            co::Coroutine *c) override {
+    std::cerr << "StreamMethod called with request: " << request.DebugString()
+              << std::endl;
+    constexpr int kNumResults = 200;
+    for (int i = 0; i < kNumResults; i++) {
+      if (writer.IsCancelled()) {
+        std::cerr << "StreamMethod cancelled after " << i << " responses"
+                  << std::endl;
+        writer.Finish(c);
+        return absl::OkStatus();
+      }
+      rpc::TestResponse r;
+      r.set_message("Hello from StreamMethod part " + std::to_string(i));
+      writer.Write(r, c);
+      c->Millisleep(request.stream_period());
+    }
+
+    writer.Finish(c);
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<rpc::TestResponse> ErrorMethod(const rpc::TestRequest &request,
+                                                co::Coroutine *c) override {
+    return absl::InternalError("Error occurred");
+  }
+
+  absl::StatusOr<rpc::TestResponse>
+  TimeoutMethod(const rpc::TestRequest &request, co::Coroutine *c) override {
+    c->Sleep(2);
+    rpc::TestResponse response;
+    response.set_message("Hello from TestMethod");
+    return response;
+  }
+};
+
+static MyServer* server_instance = nullptr;
+static void SigQuit(int sig) {
+  if (server_instance != nullptr) {
+    std::cerr << "Signal " << sig << " received, dumping coroutines"
+              << std::endl;
+    server_instance->DumpCoroutines();
+  }
+  signal(SIGQUIT, SIG_DFL);
+  raise(SIGQUIT);
+}
+
+static std::shared_ptr<MyServer> BuildServer(const std::string& log_level="info") {
+  auto server = std::make_shared<MyServer>(RpcTest::Socket());
+  server->SetLogLevel(log_level);
+  auto s = server->RegisterMethods();
+  EXPECT_TRUE(s.ok());
+  server_instance = server.get();
+  signal(SIGQUIT, SigQuit);
+  return server;
+}
+
+TEST_F(RpcTest, Basic) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto cl = rpc::TestServiceClient::Create(getpid(), RpcTest::Socket(), c);
+    ASSERT_OK(cl);
+    auto client = *cl;
+    client->SetLogLevel("info");
+
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::StatusOr<rpc::TestResponse> r = client->TestMethod(req, c);
+    std::cerr << r.status().ToString() << std::endl;
+    ASSERT_OK(r);
+
+    EXPECT_EQ(r->message(), "Hello from TestMethod");
+    ASSERT_OK(client->Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(RpcTest, Stream) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    rpc::TestServiceClient client(getpid(), RpcTest::Socket());
+    client.SetLogLevel("info");
+
+    ASSERT_OK(client.Open(c));
+
+    class MyResponseReceiver
+        : public subspace::ResponseReceiver<rpc::TestResponse> {
+    public:
+      void OnResponse(rpc::TestResponse &&response) override {
+        std::cerr << "Received response: " << response.message() << std::endl;
+        count++;
+      }
+      void OnError(const absl::Status &status) override {
+        std::cerr << "Received error: " << status.ToString() << std::endl;
+      }
+      void OnCancel() override { std::cerr << "Stream cancelled" << std::endl; }
+      void OnFinish() override { std::cerr << "Stream finished" << std::endl; }
+      int GetCount() const { return count; }
+      int count = 0;
+    };
+
+    MyResponseReceiver receiver;
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::Status status = client.StreamMethod(req, receiver, c);
+    absl::StatusOr<rpc::TestResponse> r = client.TestMethod(req, c);
+    std::cerr << r.status().ToString() << std::endl;
+    ASSERT_OK(r);
+
+    ASSERT_EQ(200, receiver.GetCount());
+    ASSERT_OK(client.Close(c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(RpcTest, Error) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto cl = rpc::TestServiceClient::Create(getpid(), RpcTest::Socket(), c);
+    ASSERT_OK(cl);
+    auto client = *cl;
+    client->SetLogLevel("info");
+
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::StatusOr<rpc::TestResponse> r = client->ErrorMethod(req, c);
+    std::cerr << r.status().ToString() << std::endl;
+    ASSERT_FALSE(r.ok());
+    EXPECT_TRUE(
+        absl::StrContains(r.status().ToString(), "INTERNAL: Error occurred"));
+    ASSERT_OK(client->Close(2s, c));
+    std::cerr << "Stopping server\n";
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(RpcTest, Timeout) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    auto cl = rpc::TestServiceClient::Create(getpid(), RpcTest::Socket(), c);
+    ASSERT_OK(cl);
+    auto client = *cl;
+    client->SetLogLevel("info");
+
+    rpc::TestRequest req;
+    req.set_message("this is a test");
+    absl::StatusOr<rpc::TestResponse> r = client->TimeoutMethod(req, 1s, c);
+    std::cerr << r.status().ToString() << std::endl;
+    ASSERT_FALSE(r.ok());
+    EXPECT_TRUE(
+        absl::StrContains(r.status().ToString(), "INTERNAL: Error waiting for response: INTERNAL: Timeout"));
+    ASSERT_OK(client->Close(2s, c));
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  absl::ParseCommandLine(argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixed a couple of compilation issues on clang/libc++ and gcc

GCC doesn't accept out-of-order delegated initializers.
And clang-libc++ breaks because of <vector> header missing.

I also added a poll in the concurrency test, but it doesn't solve the issue reported in https://github.com/dallison/subspace/issues/31