### PR TITLE
A few minor fixes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -100,8 +100,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -186,7 +186,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
+        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/client/client_channel.h
+++ b/client/client_channel.h
@@ -36,40 +36,8 @@
 // For a reliable publisher, the publisher should wait for its
 // event if it fails to get a buffer to send a message.  The
 // subscribers will trigger the event when they have read all
-// the aviailable messages.
+// the available messages.
 //
-// The naive approach to get this working is for the publisher
-// to trigger the subscribers events for every message it sends, but
-// this would mean a write to a pipe every time a message is
-// sent.  That's a system call and takes some time.
-// Instead we take the approach that the publisher only triggers when
-// it publishes a message immediately after a message that has been
-// seen by a subscriber.  In other words, if a publisher is publishing
-// a bunch of messages at once, only the first one will result in
-// the subscribers being triggered.  All the other messages are
-// buffered ahead for the subscriber to pick up when it starts
-// reading.
-//
-// Practically, this means that the publisher will notify the
-// subscriber if the last message in the active list before
-// it adds a new one has the kMessageSeen flag set (has been
-// seen by a subscriber).  If the publisher is publishing slowly
-// it will trigger the subscribers for every message.
-//
-// For reliable publisher triggers, the naive design would trigger
-// the publisher every time it reads a message.  The better
-// approach is for the subscriber to only trigger
-// the event when it has finished reading all the messages that
-// are available.  When the publisher receives the event it can then
-// fill up all the slots that have been read before it runs out
-// of slots again (if it's going fast).
-//
-// Using this strategy, we limit the number of event triggers and
-// thus improve the latency of the system by eliminating unnecessary
-// system calls to write to a pipe or eventfd.
-//
-// As of time of writing, the latency for a message on the same
-// computer using shared memory is about 0.25 microseconds on a Mac M1.
 
 namespace subspace {
 

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -139,7 +139,6 @@ bool Channel::AtomicIncRefCount(MessageSlot *slot, bool reliable, int inc,
                                 uint64_t ordinal, int vchan_id, bool retire,
                                 std::function<void()> retire_callback) {
   for (;;) {
-    CheckReload();
     uint64_t ref = slot->refs.load(std::memory_order_relaxed);
     if ((ref & kPubOwned) != 0) {
       return false;

--- a/rpc/client/rpc_client.h
+++ b/rpc/client/rpc_client.h
@@ -77,7 +77,7 @@ public:
     return Cancel(std::chrono::nanoseconds(0), c);
   }
 
-  void SetInvokationDetails(std::shared_ptr<RpcClient> client,
+  void SetInvocationDetails(std::shared_ptr<RpcClient> client,
                             uint64_t client_id, int session_id, int request_id,
                             std::shared_ptr<client_internal::Method> method) {
     if (client_ != nullptr) {
@@ -357,7 +357,7 @@ inline absl::Status RpcClient::Call(int method_id, const Request &request,
                   std::shared_ptr<client_internal::Method> method,
                   const RpcResponse *response) {
         // For cancellation we need to store the IDs for the outgoing request.
-        receiver.SetInvokationDetails(client, client_id, session_id, request_id,
+        receiver.SetInvocationDetails(client, client_id, session_id, request_id,
                                       method);
         if (response->is_cancelled()) {
           receiver.OnCancel();

--- a/rpc/example/client.cc
+++ b/rpc/example/client.cc
@@ -14,7 +14,7 @@
 
 ABSL_FLAG(std::string, subspace_socket, "/tmp/subspace",
           "Subspace server socket name");
-ABSL_FLAG(std::string, method, "TestMethod", "Method to call");
+ABSL_FLAG(std::string, method, "test", "Method to call");
 ABSL_FLAG(std::string, log_level, "info",
           "Log level (debug, info, warn, error)");
 ABSL_FLAG(int, perf_iterations, 1000,

--- a/server/client_handler.cc
+++ b/server/client_handler.cc
@@ -241,6 +241,8 @@ void ClientHandler::HandleCreatePublisher(
     response->set_error(publisher.status().ToString());
     return;
   }
+  server_->SendChannelDirectory();
+
   response->set_channel_id(channel->GetChannelId());
   response->set_type(channel->Type());
   response->set_vchan_id(channel->GetVirtualChannelId());
@@ -402,6 +404,7 @@ void ClientHandler::HandleCreateSubscriber(
     }
     sub = *subscriber;
   }
+  server_->SendChannelDirectory();
   channel->RegisterSubscriber(sub->GetId(), channel->GetVirtualChannelId(),
                               req.subscriber_id() == -1);
 

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -316,6 +316,7 @@ void ServerChannel::RemoveUser(Server *server, int user_id) {
   if (IsEmpty()) {
     server->RemoveChannel(this);
   }
+  server->SendChannelDirectory();
 }
 
 void ServerChannel::RemoveAllUsersFor(ClientHandler *handler) {
@@ -506,6 +507,7 @@ void ServerChannel::GetChannelInfo(subspace::ChannelInfo *info) {
   CountUsers(num_pubs, num_subs);
   info->set_num_pubs(num_pubs);
   info->set_num_subs(num_subs);
+
   info->set_is_reliable(IsReliable());
   if (IsVirtual()) {
     info->set_is_virtual(true);

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -225,11 +225,11 @@ public:
 
   virtual int SlotSize() const {
     if (ccb_->num_buffers == 0) {
-      return last_known_slot_size_; // No buffers, no slots.
+      return last_known_slot_size_;
     }
     uint64_t size = bcb_->sizes[ccb_->num_buffers - 1];
     if (size == 0) {
-      return last_known_slot_size_; // No slots.
+      return last_known_slot_size_;
     }
     last_known_slot_size_ = BufferSizeToSlotSize(size);
     return last_known_slot_size_;

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -174,6 +174,10 @@ public:
     AddUserId(id);
   }
 
+  void SetLastKnownSlotSize(int32_t slot_size) {
+    last_known_slot_size_ = slot_size;
+  }
+
   virtual bool IsMux() const { return false; }
   virtual int GetVirtualChannelId() const { return -1; }
   virtual int GetChannelId() const { return Channel::GetChannelId(); }
@@ -221,13 +225,14 @@ public:
 
   virtual int SlotSize() const {
     if (ccb_->num_buffers == 0) {
-      return 0; // No buffers, no slots.
+      return last_known_slot_size_; // No buffers, no slots.
     }
     uint64_t size = bcb_->sizes[ccb_->num_buffers - 1];
     if (size == 0) {
-      return 0; // No slots.
+      return last_known_slot_size_; // No slots.
     }
-    return BufferSizeToSlotSize(size);
+    last_known_slot_size_ = BufferSizeToSlotSize(size);
+    return last_known_slot_size_;
   }
 
   virtual int NumSlots() const { return Channel::NumSlots(); }
@@ -309,6 +314,7 @@ protected:
   SharedMemoryFds shared_memory_fds_;
   bool is_virtual_ = false;
   int session_id_;
+  mutable int32_t last_known_slot_size_ = 0;
 };
 
 class VirtualChannel;


### PR DESCRIPTION
Fixes a few things:

1. Removes call to CheckReload from AtomicIntRefCount as it's racy
2. Brings back the ChannelDirectory and ChannelStats channels published from server.  These were accidentally commented out and nobody noticed.  Probably nobody is using them.  Adds a test for the Channel Directory.
3. Fixes a couple of typos in the RPC
4. Improves channel directory publishing to be more accurate when publishers and subscribers are created/deleted.