### PR TITLE
Add free CreatePublisher/CreateSubscriber convenience functions

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -1297,6 +1297,36 @@ private:
   std::shared_ptr<ClientImpl> impl_;
 };
 
+// Convenience functions to create a client and publisher/subscriber in one step.
+// The Publisher and Subscriber objects hold a shared_ptr to the ClientImpl
+// internally, so the client stays alive as long as the returned object does.
+
+inline absl::StatusOr<Publisher>
+CreatePublisher(const std::string &channel_name,
+                const PublisherOptions &opts = PublisherOptions(),
+                const std::string &server_socket = "/tmp/subspace",
+                const std::string &client_name = "",
+                const co::Coroutine *c = nullptr) {
+  auto client_or = Client::Create(server_socket, client_name, c);
+  if (!client_or.ok()) {
+    return client_or.status();
+  }
+  return (*client_or)->CreatePublisher(channel_name, opts);
+}
+
+inline absl::StatusOr<Subscriber>
+CreateSubscriber(const std::string &channel_name,
+                 const SubscriberOptions &opts = SubscriberOptions(),
+                 const std::string &server_socket = "/tmp/subspace",
+                 const std::string &client_name = "",
+                 const co::Coroutine *c = nullptr) {
+  auto client_or = Client::Create(server_socket, client_name, c);
+  if (!client_or.ok()) {
+    return client_or.status();
+  }
+  return (*client_or)->CreateSubscriber(channel_name, opts);
+}
+
 } // namespace subspace
 
 #endif // _xCLIENT_CLIENT_H

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -4658,6 +4658,66 @@ TEST_F(ClientTest, ResizeCallbackReturnsError) {
   ASSERT_OK(pub.UnregisterResizeCallback());
 }
 
+// ---------------------------------------------------------------------------
+// Free function CreatePublisher / CreateSubscriber convenience helpers.
+// ---------------------------------------------------------------------------
+
+TEST_F(ClientTest, FreeCreatePublisher) {
+  auto pub_or = subspace::CreatePublisher(
+      "free_pub", {.slot_size = 256, .num_slots = 10}, Socket());
+  ASSERT_OK(pub_or);
+  auto pub = std::move(*pub_or);
+  ASSERT_EQ(256, pub.SlotSize());
+  ASSERT_EQ(10, pub.NumSlots());
+}
+
+TEST_F(ClientTest, FreeCreateSubscriber) {
+  // Need a publisher first so the channel exists with concrete slots.
+  subspace::Client client;
+  InitClient(client);
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("free_sub", 256, 10));
+
+  auto sub_or = subspace::CreateSubscriber("free_sub", {}, Socket());
+  ASSERT_OK(sub_or);
+  auto sub = std::move(*sub_or);
+  ASSERT_EQ(256, sub.SlotSize());
+}
+
+TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {
+  auto pub_or = subspace::CreatePublisher(
+      "free_rt", {.slot_size = 256, .num_slots = 10}, Socket());
+  ASSERT_OK(pub_or);
+  auto pub = std::move(*pub_or);
+
+  auto sub_or = subspace::CreateSubscriber("free_rt", {}, Socket());
+  ASSERT_OK(sub_or);
+  auto sub = std::move(*sub_or);
+
+  auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer(256));
+  memcpy(buf, "hello", 5);
+  auto pub_msg = pub.PublishMessage(5);
+  ASSERT_OK(pub_msg);
+
+  auto read_msg = sub.ReadMessage();
+  ASSERT_OK(read_msg);
+  ASSERT_EQ(5, read_msg->length);
+  ASSERT_EQ(0, memcmp(read_msg->buffer, "hello", 5));
+}
+
+TEST_F(ClientTest, FreeCreatePublisherBadSocket) {
+  auto pub_or = subspace::CreatePublisher(
+      "bad_pub", {.slot_size = 256, .num_slots = 10},
+      "/tmp/no_such_subspace_socket");
+  ASSERT_FALSE(pub_or.ok());
+}
+
+TEST_F(ClientTest, FreeCreateSubscriberBadSocket) {
+  auto sub_or = subspace::CreateSubscriber(
+      "bad_sub", {}, "/tmp/no_such_subspace_socket");
+  ASSERT_FALSE(sub_or.ok());
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   absl::ParseCommandLine(argc, argv);

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -4681,7 +4681,16 @@ TEST_F(ClientTest, FreeCreateSubscriber) {
   auto sub_or = subspace::CreateSubscriber("free_sub", {}, Socket());
   ASSERT_OK(sub_or);
   auto sub = std::move(*sub_or);
-  ASSERT_EQ(256, sub.SlotSize());
+
+  // Verify the subscriber works by publishing and reading a message.
+  auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer(256));
+  memcpy(buf, "test", 4);
+  ASSERT_OK(pub.PublishMessage(4));
+
+  auto msg = sub.ReadMessage();
+  ASSERT_OK(msg);
+  ASSERT_EQ(4, msg->length);
+  ASSERT_EQ(0, memcmp(msg->buffer, "test", 4));
 }
 
 TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {

--- a/shadow/shadow.cc
+++ b/shadow/shadow.cc
@@ -122,6 +122,7 @@ void Shadow::ClientCoroutine(
 
 absl::Status Shadow::HandleEvent(const ShadowEvent &event,
                                  std::vector<toolbelt::FileDescriptor> &fds) {
+  std::lock_guard<std::mutex> lock(mutex_);
   switch (event.event_case()) {
   case ShadowEvent::kInit:
     return HandleInit(event.init(), fds);
@@ -336,6 +337,7 @@ Shadow::SendEvent(toolbelt::UnixSocket &socket, const ShadowEvent &event,
 }
 
 absl::Status Shadow::SendStateDump(toolbelt::UnixSocket &socket) {
+  std::lock_guard<std::mutex> lock(mutex_);
   // 1. Send the header.
   {
     ShadowEvent event;

--- a/shadow/shadow.h
+++ b/shadow/shadow.h
@@ -84,7 +84,7 @@ public:
   // holding the mutex, so the caller must not call back into Shadow methods
   // that also lock the mutex.
   template <typename F>
-  auto WithChannels(F &&f) const -> decltype(f(channels_)) {
+  auto WithChannels(F &&f) const {
     std::lock_guard<std::mutex> lock(mutex_);
     return f(channels_);
   }

--- a/shadow/shadow.h
+++ b/shadow/shadow.h
@@ -12,6 +12,7 @@
 #include "toolbelt/fd.h"
 #include "toolbelt/logging.h"
 #include "toolbelt/sockets.h"
+#include <mutex>
 #include <string>
 
 namespace subspace {
@@ -70,11 +71,22 @@ public:
   absl::Status Run();
   void Stop();
 
-  uint64_t GetSessionId() const { return session_id_; }
-  const toolbelt::FileDescriptor &GetScbFd() const { return scb_fd_; }
+  uint64_t GetSessionId() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return session_id_;
+  }
+  const toolbelt::FileDescriptor &GetScbFd() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return scb_fd_;
+  }
 
-  const absl::flat_hash_map<std::string, ShadowChannel> &GetChannels() const {
-    return channels_;
+  // Thread-safe access to the channels map.  The callback is invoked while
+  // holding the mutex, so the caller must not call back into Shadow methods
+  // that also lock the mutex.
+  template <typename F>
+  auto WithChannels(F &&f) const -> decltype(f(channels_)) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return f(channels_);
   }
 
   void SetLogLevel(const std::string &level) { logger_.SetLogLevel(level); }
@@ -110,6 +122,7 @@ private:
   std::string socket_name_;
   uint64_t session_id_ = 0;
   toolbelt::FileDescriptor scb_fd_;
+  mutable std::mutex mutex_;
   absl::flat_hash_map<std::string, ShadowChannel> channels_;
   toolbelt::Logger logger_;
   toolbelt::UnixSocket listen_socket_;

--- a/shadow/shadow_test.cc
+++ b/shadow/shadow_test.cc
@@ -152,18 +152,20 @@ TEST_F(ShadowTest, ShadowReceivesCreateChannel) {
   ASSERT_THAT(pub, IsOk());
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    auto &channels = GetShadow()->GetChannels();
-    auto it = channels.find("shadow_test_chan1");
-    return it != channels.end() && it->second.ccb_fd.Valid();
+    return GetShadow()->WithChannels([](auto &channels) {
+      auto it = channels.find("shadow_test_chan1");
+      return it != channels.end() && it->second.ccb_fd.Valid();
+    });
   }));
 
-  auto &channels = GetShadow()->GetChannels();
-  auto it = channels.find("shadow_test_chan1");
-  ASSERT_NE(it, channels.end());
-  EXPECT_EQ(it->second.slot_size, 256);
-  EXPECT_EQ(it->second.num_slots, 4);
-  EXPECT_TRUE(it->second.ccb_fd.Valid());
-  EXPECT_TRUE(it->second.bcb_fd.Valid());
+  GetShadow()->WithChannels([](auto &channels) {
+    auto it = channels.find("shadow_test_chan1");
+    ASSERT_NE(it, channels.end());
+    EXPECT_EQ(it->second.slot_size, 256);
+    EXPECT_EQ(it->second.num_slots, 4);
+    EXPECT_TRUE(it->second.ccb_fd.Valid());
+    EXPECT_TRUE(it->second.bcb_fd.Valid());
+  });
 }
 
 TEST_F(ShadowTest, ShadowReceivesAddPublisher) {
@@ -174,19 +176,21 @@ TEST_F(ShadowTest, ShadowReceivesAddPublisher) {
   ASSERT_THAT(pub, IsOk());
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    auto &channels = GetShadow()->GetChannels();
-    auto it = channels.find("shadow_test_chan2");
-    return it != channels.end() && it->second.publishers.size() == 1;
+    return GetShadow()->WithChannels([](auto &channels) {
+      auto it = channels.find("shadow_test_chan2");
+      return it != channels.end() && it->second.publishers.size() == 1;
+    });
   }));
 
-  auto &channels = GetShadow()->GetChannels();
-  auto it = channels.find("shadow_test_chan2");
-  ASSERT_NE(it, channels.end());
-  EXPECT_EQ(it->second.publishers.size(), 1u);
+  GetShadow()->WithChannels([](auto &channels) {
+    auto it = channels.find("shadow_test_chan2");
+    ASSERT_NE(it, channels.end());
+    EXPECT_EQ(it->second.publishers.size(), 1u);
 
-  auto &pub_entry = it->second.publishers.begin()->second;
-  EXPECT_TRUE(pub_entry.poll_fd.Valid());
-  EXPECT_TRUE(pub_entry.trigger_fd.Valid());
+    auto &pub_entry = it->second.publishers.begin()->second;
+    EXPECT_TRUE(pub_entry.poll_fd.Valid());
+    EXPECT_TRUE(pub_entry.trigger_fd.Valid());
+  });
 }
 
 TEST_F(ShadowTest, ShadowReceivesAddSubscriber) {
@@ -199,20 +203,22 @@ TEST_F(ShadowTest, ShadowReceivesAddSubscriber) {
   ASSERT_THAT(sub, IsOk());
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    auto &channels = GetShadow()->GetChannels();
-    auto it = channels.find("shadow_test_chan3");
-    return it != channels.end() && it->second.subscribers.size() == 1;
+    return GetShadow()->WithChannels([](auto &channels) {
+      auto it = channels.find("shadow_test_chan3");
+      return it != channels.end() && it->second.subscribers.size() == 1;
+    });
   }));
 
-  auto &channels = GetShadow()->GetChannels();
-  auto it = channels.find("shadow_test_chan3");
-  ASSERT_NE(it, channels.end());
-  EXPECT_EQ(it->second.publishers.size(), 1u);
-  EXPECT_EQ(it->second.subscribers.size(), 1u);
+  GetShadow()->WithChannels([](auto &channels) {
+    auto it = channels.find("shadow_test_chan3");
+    ASSERT_NE(it, channels.end());
+    EXPECT_EQ(it->second.publishers.size(), 1u);
+    EXPECT_EQ(it->second.subscribers.size(), 1u);
 
-  auto &sub_entry = it->second.subscribers.begin()->second;
-  EXPECT_TRUE(sub_entry.trigger_fd.Valid());
-  EXPECT_TRUE(sub_entry.poll_fd.Valid());
+    auto &sub_entry = it->second.subscribers.begin()->second;
+    EXPECT_TRUE(sub_entry.trigger_fd.Valid());
+    EXPECT_TRUE(sub_entry.poll_fd.Valid());
+  });
 }
 
 TEST_F(ShadowTest, ShadowReceivesRemovePublisher) {
@@ -224,14 +230,17 @@ TEST_F(ShadowTest, ShadowReceivesRemovePublisher) {
     ASSERT_THAT(pub, IsOk());
 
     ASSERT_TRUE(WaitForShadowState([]() {
-      auto &channels = GetShadow()->GetChannels();
-      auto it = channels.find("shadow_test_chan4");
-      return it != channels.end() && it->second.publishers.size() == 1;
+      return GetShadow()->WithChannels([](auto &channels) {
+        auto it = channels.find("shadow_test_chan4");
+        return it != channels.end() && it->second.publishers.size() == 1;
+      });
     }));
   }
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    return GetShadow()->GetChannels().count("shadow_test_chan4") == 0;
+    return GetShadow()->WithChannels([](auto &channels) {
+      return channels.count("shadow_test_chan4") == 0;
+    });
   }));
 }
 
@@ -246,16 +255,18 @@ TEST_F(ShadowTest, ShadowReceivesRemoveSubscriber) {
     ASSERT_THAT(sub, IsOk());
 
     ASSERT_TRUE(WaitForShadowState([]() {
-      auto &channels = GetShadow()->GetChannels();
-      auto it = channels.find("shadow_test_chan5");
-      return it != channels.end() && it->second.subscribers.size() == 1;
+      return GetShadow()->WithChannels([](auto &channels) {
+        auto it = channels.find("shadow_test_chan5");
+        return it != channels.end() && it->second.subscribers.size() == 1;
+      });
     }));
   }
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    auto &channels = GetShadow()->GetChannels();
-    auto it = channels.find("shadow_test_chan5");
-    return it != channels.end() && it->second.subscribers.empty();
+    return GetShadow()->WithChannels([](auto &channels) {
+      auto it = channels.find("shadow_test_chan5");
+      return it != channels.end() && it->second.subscribers.empty();
+    });
   }));
 }
 
@@ -268,12 +279,16 @@ TEST_F(ShadowTest, ShadowReceivesRemoveChannel) {
     ASSERT_THAT(pub, IsOk());
 
     ASSERT_TRUE(WaitForShadowState([]() {
-      return GetShadow()->GetChannels().count("shadow_test_chan6") > 0;
+      return GetShadow()->WithChannels([](auto &channels) {
+        return channels.count("shadow_test_chan6") > 0;
+      });
     }));
   }
 
   ASSERT_TRUE(WaitForShadowState([]() {
-    return GetShadow()->GetChannels().count("shadow_test_chan6") == 0;
+    return GetShadow()->WithChannels([](auto &channels) {
+      return channels.count("shadow_test_chan6") == 0;
+    });
   }));
 }
 
@@ -416,23 +431,22 @@ TEST_F(ShadowRecoveryTest, ServerRecoversStateFromShadow) {
 
   // Wait for shadow to receive the full state.
   ASSERT_TRUE(WaitForShadowState([this]() {
-    auto &channels = shadow_->GetChannels();
-    auto it = channels.find("recovery_chan");
-    return it != channels.end() && it->second.publishers.size() == 1 &&
-           it->second.subscribers.size() == 1;
+    return shadow_->WithChannels([](auto &channels) {
+      auto it = channels.find("recovery_chan");
+      return it != channels.end() && it->second.publishers.size() == 1 &&
+             it->second.subscribers.size() == 1;
+    });
   }));
 
   // Record the shadow state before stopping the server.
   uint64_t old_session_id = shadow_->GetSessionId();
   ASSERT_NE(old_session_id, 0u);
 
-  int old_channel_id;
-  {
-    auto &channels = shadow_->GetChannels();
+  int old_channel_id = shadow_->WithChannels([](auto &channels) {
     auto it = channels.find("recovery_chan");
-    ASSERT_NE(it, channels.end());
-    old_channel_id = it->second.channel_id;
-  }
+    EXPECT_NE(it, channels.end());
+    return it->second.channel_id;
+  });
 
   // Simulate a crash: disconnect the shadow replicators first so that
   // cleanup events from Stop() don't reach the shadow.
@@ -496,10 +510,11 @@ TEST_F(ShadowRecoveryTest, ServerFunctionalAfterRecovery) {
   ASSERT_THAT(pre_sub, IsOk());
 
   ASSERT_TRUE(WaitForShadowState([this]() {
-    auto &ch = shadow_->GetChannels();
-    auto it = ch.find("persist_chan");
-    return it != ch.end() && it->second.publishers.size() == 1 &&
-           it->second.subscribers.size() == 1;
+    return shadow_->WithChannels([](auto &ch) {
+      auto it = ch.find("persist_chan");
+      return it != ch.end() && it->second.publishers.size() == 1 &&
+             it->second.subscribers.size() == 1;
+    });
   }));
 
   // Simulate crash.
@@ -600,10 +615,11 @@ TEST_F(ShadowRecoveryTest, ClientReconnectsAfterServerRestart) {
 
   // Wait for shadow to have the full state.
   ASSERT_TRUE(WaitForShadowState([this]() {
-    auto &ch = shadow_->GetChannels();
-    auto it = ch.find("reconnect_chan");
-    return it != ch.end() && it->second.publishers.size() == 1 &&
-           it->second.subscribers.size() == 1;
+    return shadow_->WithChannels([](auto &ch) {
+      auto it = ch.find("reconnect_chan");
+      return it != ch.end() && it->second.publishers.size() == 1 &&
+             it->second.subscribers.size() == 1;
+    });
   }));
 
   // Simulate crash: disconnect the shadow replicators so cleanup events
@@ -793,16 +809,18 @@ TEST_F(DualShadowRecoveryTest, RecoverFromPrimaryWhenBothHealthy) {
 
   // Wait for both shadows to receive the state.
   ASSERT_TRUE(WaitForShadowState(primary_shadow_pipe_[0], [this]() {
-    auto &ch = primary_shadow_->GetChannels();
-    auto it = ch.find("dual_chan");
-    return it != ch.end() && it->second.publishers.size() == 1 &&
-           it->second.subscribers.size() == 1;
+    return primary_shadow_->WithChannels([](auto &ch) {
+      auto it = ch.find("dual_chan");
+      return it != ch.end() && it->second.publishers.size() == 1 &&
+             it->second.subscribers.size() == 1;
+    });
   }));
   ASSERT_TRUE(WaitForShadowState(secondary_shadow_pipe_[0], [this]() {
-    auto &ch = secondary_shadow_->GetChannels();
-    auto it = ch.find("dual_chan");
-    return it != ch.end() && it->second.publishers.size() == 1 &&
-           it->second.subscribers.size() == 1;
+    return secondary_shadow_->WithChannels([](auto &ch) {
+      auto it = ch.find("dual_chan");
+      return it != ch.end() && it->second.publishers.size() == 1 &&
+             it->second.subscribers.size() == 1;
+    });
   }));
 
   uint64_t primary_session = primary_shadow_->GetSessionId();
@@ -857,10 +875,14 @@ TEST_F(DualShadowRecoveryTest, RecoverFromSecondaryWhenPrimaryDown) {
 
   // Wait for both shadows to have the channel.
   ASSERT_TRUE(WaitForShadowState(primary_shadow_pipe_[0], [this]() {
-    return primary_shadow_->GetChannels().count("dual_fallback_chan") > 0;
+    return primary_shadow_->WithChannels([](auto &ch) {
+      return ch.count("dual_fallback_chan") > 0;
+    });
   }));
   ASSERT_TRUE(WaitForShadowState(secondary_shadow_pipe_[0], [this]() {
-    return secondary_shadow_->GetChannels().count("dual_fallback_chan") > 0;
+    return secondary_shadow_->WithChannels([](auto &ch) {
+      return ch.count("dual_fallback_chan") > 0;
+    });
   }));
 
   // Simulate crash.
@@ -928,10 +950,14 @@ TEST_F(DualShadowRecoveryTest, FreshStartWhenBothShadowsEmpty) {
 
   // Both shadows should have received the new state.
   ASSERT_TRUE(WaitForShadowState(primary_shadow_pipe_[0], [this]() {
-    return primary_shadow_->GetChannels().count("fresh_chan") > 0;
+    return primary_shadow_->WithChannels([](auto &ch) {
+      return ch.count("fresh_chan") > 0;
+    });
   }));
   ASSERT_TRUE(WaitForShadowState(secondary_shadow_pipe_[0], [this]() {
-    return secondary_shadow_->GetChannels().count("fresh_chan") > 0;
+    return secondary_shadow_->WithChannels([](auto &ch) {
+      return ch.count("fresh_chan") > 0;
+    });
   }));
 
   StopServer();
@@ -1159,9 +1185,10 @@ TEST_F(BridgeShadowRecoveryTest, BridgeRecoversAfterServerRestart) {
 
   // Wait for shadow to replicate the channel state.
   ASSERT_TRUE(WaitForShadowState([this]() {
-    auto &ch = shadow_->GetChannels();
-    auto it = ch.find("/bridge_recovery_chan");
-    return it != ch.end() && it->second.publishers.size() >= 1;
+    return shadow_->WithChannels([](auto &ch) {
+      auto it = ch.find("/bridge_recovery_chan");
+      return it != ch.end() && it->second.publishers.size() >= 1;
+    });
   }));
 
   // Simulate crash on server 0.  SimulateCrash() prevents the


### PR DESCRIPTION
Add inline free functions in the subspace namespace that combine client creation with publisher/subscriber creation in a single call. The returned Publisher/Subscriber already holds a shared_ptr to the ClientImpl so the client lifetime is managed automatically.

Includes positive and negative tests for both functions.

Made-with: Cursor