### PR TITLE
Fix ListenerCoroutine shutdown check (use shutting_down_, drop unused running_)

### DIFF
--- a/server/server.cc
+++ b/server/server.cc
@@ -187,7 +187,7 @@ void Server::CloseHandler(ClientHandler *handler) {
 // the client.
 void Server::ListenerCoroutine(toolbelt::UnixSocket &listen_socket) {
   for (;;) {
-    if (!running_) {
+    if (shutting_down_) {
       // Keep this running until all other coroutines have completed.
       // This is to make sure that other coroutines that have publisher
       // and subscribers are able to connect to the server and delete them

--- a/server/server.h
+++ b/server/server.h
@@ -223,7 +223,6 @@ private:
   std::string socket_name_;
   uint64_t session_id_;
   std::vector<std::unique_ptr<ClientHandler>> client_handlers_;
-  bool running_ = false;
   std::string server_id_;
   std::string hostname_;
   std::string interface_;


### PR DESCRIPTION
## Summary

- `Server::ListenerCoroutine` was checking `!running_` to decide when to drain and exit, but `subspace::Server::running_` is never assigned anywhere in the codebase. With `running_` always `false`, the listener loop took the "we're shutting down" branch on every iteration and exited as soon as the scheduler had a single coroutine left, instead of waiting for an actual shutdown.
- Switch the check to `shutting_down_`, which is the flag that `Server::Stop()` sets and that the discovery / gratuitous-advertise coroutines already use for the same purpose.
- Remove the now-unused `bool running_ = false;` member of `subspace::Server`. (The unrelated `running_` field in `server/python/server.cc` is on a different class and is not affected.)

## Test plan

- [ ] `bazel test //server:server_test`
- [ ] `bazel test //client:client_test`
- [ ] Manually run `subspace_server` + `manual_tests/{pub,sub}` and confirm the server keeps accepting new client connections instead of exiting prematurely once the first client disconnects.
- [ ] Send `SIGTERM` / call `Stop()` and confirm the listener still drains correctly on actual shutdown.

Made with [Cursor](https://cursor.com)