### PR TITLE
Port shared memory headers to QNX

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "subspace",
-    version = "2.6.1",
+    version = "2.6.2",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/client/client.h
+++ b/client/client.h
@@ -32,6 +32,16 @@
 #include <thread>
 namespace subspace {
 
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(attribute) 0
+#endif
+
+#if __has_cpp_attribute(no_unique_address) && !defined(__QNX__)
+#define SUBSPACE_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define SUBSPACE_NO_UNIQUE_ADDRESS
+#endif
+
 enum class ReadMode {
   kReadNext,
   kReadNewest,
@@ -154,7 +164,7 @@ private:
   template <typename M, typename OtherAliaser> friend class weak_ptr;
 
   std::shared_ptr<ActiveMessage> msg_;
-  [[no_unique_address]] Aliaser aliaser_;
+  SUBSPACE_NO_UNIQUE_ADDRESS Aliaser aliaser_;
 };
 
 template <typename T, typename Aliaser> class weak_ptr {

--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -5,7 +5,7 @@
 #include "client/client_channel.h"
 #include "common/syscall_shim.h"
 #include <sys/mman.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX && defined(__APPLE__)
 #include <sys/posix_shm.h>
 #endif
 #include <chrono>

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -6,7 +6,7 @@
 #include "absl/strings/str_format.h"
 #include "server/server.h"
 #include <sys/mman.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX && defined(__APPLE__)
 #include <sys/posix_shm.h>
 #endif
 


### PR DESCRIPTION
## Summary
- Avoid including Apple-specific POSIX shared-memory headers on QNX.
- Suppress `no_unique_address` usage on QNX where the compiler ignores the attribute.
- Bump the module version to `2.6.2`.

## Test plan
- `bazelisk build //...`