### PR TITLE
Fix CMake build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install CMake build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Configure CMake
         run: cmake -S . -B build/cmake -DCMAKE_BUILD_TYPE=Debug
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,20 @@ jobs:
         with:
           name: bazel-test-logs-${{ matrix.os }}
           path: bazel-testlogs
+
+  cmake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure CMake
+        run: cmake -S . -B build/cmake -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build CMake targets
+        run: cmake --build build/cmake --parallel $(nproc)
+
+      - name: Run CMake tests
+        run: ctest --test-dir build/cmake --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(Subspace LANGUAGES CXX ASM)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Prefer standard C++
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(protobuf_BUILD_TESTS OFF CACHE INTERNAL "No protobuf tests")
 set(ABSL_BUILD_TEST_HELPERS ON CACHE INTERNAL "Enable Abseil TESTONLY+PUBLIC helpers (e.g. status_matchers)")
@@ -64,11 +65,20 @@ FetchContent_MakeAvailable(abseil)
 FetchContent_Declare(
     co
     GIT_REPOSITORY https://github.com/dallison/co.git
-    GIT_TAG c1cd0992d51c7a9bf9e4ecc0b6204cca05adc4a6
+    GIT_TAG 3.3.2
     CMAKE_ARGS
         -DCMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES}"
 )
 FetchContent_MakeAvailable(co)
+if(TARGET co)
+    target_link_libraries(co PUBLIC absl::flat_hash_map absl::flat_hash_set)
+endif()
+if(TARGET co_cpp20)
+    target_link_libraries(co_cpp20 PUBLIC absl::flat_hash_map absl::flat_hash_set)
+endif()
+if(TARGET coroutines_test)
+    target_link_libraries(coroutines_test PRIVATE absl::status_matchers gmock)
+endif()
 
 # --- External Dependency: cpp_toolbelt (using FetchContent for native CMake) ---
 # cpp_toolbelt's CMakeLists.txt will try to fetch co, but since we've already
@@ -76,7 +86,7 @@ FetchContent_MakeAvailable(co)
 FetchContent_Declare(
     cpp_toolbelt
     GIT_REPOSITORY https://github.com/dallison/cpp_toolbelt.git
-    GIT_TAG 1aa8db7fd7096b53a1daa1bba86bbda8a312c7dd
+    GIT_TAG 2.1.2
     CMAKE_ARGS
         -DCMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES}"
 )
@@ -129,6 +139,7 @@ add_subdirectory(proto)
 add_subdirectory(common)
 add_subdirectory(client)
 add_subdirectory(server)
+add_subdirectory(plugins)
 add_subdirectory(shadow)
 add_subdirectory(c_client)
 add_subdirectory(rust_client)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "subspace",
-    version = "2.6.2",
+    version = "2.6.3",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -44,7 +44,11 @@ target_link_libraries(subspace_client PUBLIC
 
 
 add_executable(client_test client_test.cc)
+set_target_properties(client_test PROPERTIES ENABLE_EXPORTS ON)
 add_test(NAME client_test COMMAND client_test)
+set_tests_properties(client_test PROPERTIES
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+)
 target_link_libraries(client_test PUBLIC
     subspace_client
     subspace_common

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -8,6 +8,9 @@ add_library(subspace_common STATIC
     channel.cc
     channel.h
     fast_ring_buffer.h
+    syscall_shim.cc
+    syscall_shim.h
+    syscall_shim_test_helper.h
 )
 
 target_link_libraries(subspace_common PUBLIC

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_library(nop_plugin MODULE
+    nop_plugin.cc
+)
+
+target_include_directories(nop_plugin PRIVATE
+    $<TARGET_PROPERTY:co,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:toolbelt,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:subspace_common,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:subspace_client,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:subspace_proto,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:libserver,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_link_libraries(nop_plugin PRIVATE
+    absl::status
+    absl::str_format
+)
+
+if(UNIX AND NOT APPLE)
+    target_link_options(nop_plugin PRIVATE
+        "LINKER:--unresolved-symbols=ignore-all"
+    )
+endif()
+
+set_target_properties(nop_plugin PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "nop_plugin"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(nop_plugin MODULE
 )
 
 target_include_directories(nop_plugin PRIVATE
+    ${CMAKE_BINARY_DIR}
     $<TARGET_PROPERTY:co,INTERFACE_INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:toolbelt,INTERFACE_INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:subspace_common,INTERFACE_INCLUDE_DIRECTORIES>
@@ -10,6 +11,8 @@ target_include_directories(nop_plugin PRIVATE
     $<TARGET_PROPERTY:subspace_proto,INTERFACE_INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:libserver,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+add_dependencies(nop_plugin subspace_proto)
 
 target_link_libraries(nop_plugin PRIVATE
     absl::status

--- a/rust_client/CMakeLists.txt
+++ b/rust_client/CMakeLists.txt
@@ -34,3 +34,6 @@ add_test(
     COMMAND ${CARGO_EXECUTABLE} test -- --test-threads=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+set_tests_properties(rust_client_test PROPERTIES
+    ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}/server:$ENV{PATH}"
+)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(libserver PUBLIC
 add_executable(subspace_server
     main.cc
 )
+set_target_properties(subspace_server PROPERTIES ENABLE_EXPORTS ON)
 
 target_link_libraries(subspace_server PUBLIC
     libserver


### PR DESCRIPTION
## Summary
- Update CMake to use current `co` and `cpp_toolbelt` release tags.
- Fix missing CMake target wiring for syscall shim, `co` Abseil deps, and the NOP plugin module.
- Add CI coverage for CMake configure, build, and CTest.
- Bump the module patch version from `2.6.2` to `2.6.3`.

## Test plan
- `cmake -S /home/dave.allison/subspace -B /tmp/subspace-cmake-build-check -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build /tmp/subspace-cmake-build-check --parallel $(nproc)`
- `ctest --test-dir /tmp/subspace-cmake-build-check --output-on-failure`