### PR TITLE
Support split buffers over bridges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,21 @@ jobs:
             --test_arg=--use_split_buffers \
             ${{ matrix.bazel_flags }}
 
+      - name: Run bridge tests with and without split buffers
+        run: |
+          bazel test \
+            //client:bridge_test \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=false \
+            ${{ matrix.bazel_flags }}
+          bazel test \
+            //client:bridge_test \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=true \
+            ${{ matrix.bazel_flags }}
+
       - name: Upload Bazel test logs
         uses: actions/upload-artifact@v7
         if: failure() # Upload artifacts only if a step failed

--- a/c_client/subspace.cc
+++ b/c_client/subspace.cc
@@ -521,6 +521,7 @@ SubspacePublisherOptions subspace_publisher_options_default(int32_t slot_size,
       .metadata_size = 0,
       .prefer_retired_slots = true,
       .use_split_buffers = false,
+      .split_buffers_over_bridge = false,
       .max_publishers = 0,
       .split_callbacks = {},
   };
@@ -587,6 +588,7 @@ SubspacePublisher subspace_create_publisher(SubspaceClient client,
       .prefer_retired_slots = options.prefer_retired_slots,
       .max_publishers = options.max_publishers,
       .use_split_buffers = options.use_split_buffers,
+      .split_buffers_over_bridge = options.split_buffers_over_bridge,
       .split_buffer_callbacks = ToCppSplitCallbacks(options.split_callbacks),
   };
   subspace_clear_error();

--- a/c_client/subspace.h
+++ b/c_client/subspace.h
@@ -244,6 +244,9 @@ typedef struct {
   // message prefixes in regular shared memory and delegates payload slot
   // allocation/mapping/freeing to split_callbacks.
   bool use_split_buffers;
+  // If true, bridge receivers create their mirror publisher with split payload
+  // buffers. This is independent of use_split_buffers for the local channel.
+  bool split_buffers_over_bridge;
   int32_t max_publishers;
   SubspaceSplitBufferCallbacks split_callbacks;
 } SubspacePublisherOptions;

--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -162,7 +162,6 @@ cc_test(
     data = [
         "//server:subspace_server",
     ],
-    tags = ["manual"], # Seems to have a ~50% flake rate.
     deps = [
         ":subspace_client",
         "//server",

--- a/client/bridge_test.cc
+++ b/client/bridge_test.cc
@@ -13,16 +13,23 @@
 #include "toolbelt/clock.h"
 #include "toolbelt/hexdump.h"
 #include "toolbelt/pipe.h"
+#include <array>
+#include <chrono>
 #include <gtest/gtest.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <memory>
 #include <signal.h>
+#include <sys/file.h>
 #include <sys/resource.h>
 #include <thread>
+#include <unistd.h>
 
 ABSL_FLAG(bool, start_server, true, "Start the subspace servers");
 ABSL_FLAG(std::string, server, "", "Path to server executable");
 ABSL_FLAG(std::string, log_level, "debug", "Log level");
+ABSL_FLAG(bool, use_split_buffers, false,
+          "Run publishers with split-buffer payload storage");
 
 void SignalHandler(int sig) { printf("Signal %d", sig); }
 
@@ -53,7 +60,20 @@ public:
     if (!absl::GetFlag(FLAGS_start_server)) {
       return;
     }
-    constexpr int kDiscPorts[2] = {6522, 6523};
+    int lock_fd = ::open("/tmp/subspace_bridge_test_port.lock",
+                         O_CREAT | O_RDWR, 0666);
+    ASSERT_NE(-1, lock_fd);
+    ASSERT_EQ(0, ::flock(lock_fd, LOCK_EX));
+
+    std::array<int, 2> disc_ports;
+    std::array<toolbelt::UDPSocket, 2> reserved_ports;
+    {
+      for (int i = 0; i < 2; i++) {
+        ASSERT_OK(reserved_ports[i].Bind(
+            toolbelt::InetAddress::AnyAddress(/*port=*/0)));
+        disc_ports[i] = reserved_ports[i].BoundAddress().Port();
+      }
+    }
     for (int i = 0; i < 2; i++) {
       printf("Starting Subspace server %d\n", i);
       char socket_name_template[] = "/tmp/subspaceXXXXXX"; // NOLINT
@@ -64,9 +84,10 @@ public:
       // has started and stopped.  This end of the pipe is blocking.
       (void)pipe(server_pipe_[i]);
 
-      int peer_port = kDiscPorts[(i + 1) % 2];
+      int peer_port = disc_ports[(i + 1) % 2];
+      reserved_ports[i].Close();
       server_[i] = std::make_unique<subspace::Server>(
-          scheduler_[i], socket_[i], "", kDiscPorts[i % 2], peer_port,
+          scheduler_[i], socket_[i], "", disc_ports[i], peer_port,
           /*local=*/false, server_pipe_[i][1]);
 
       server_[i]->SetLogLevel(absl::GetFlag(FLAGS_log_level));
@@ -89,6 +110,8 @@ public:
       char buf[8];
       (void)::read(server_pipe_[i][0], buf, 8);
     }
+    ASSERT_EQ(0, ::flock(lock_fd, LOCK_UN));
+    ::close(lock_fd);
   }
 
   static void TearDownTestSuite() {
@@ -172,6 +195,23 @@ void WaitForSubscribedMessage(toolbelt::FileDescriptor &bridge_pipe,
             << subscribed.channel_name() << std::endl;
 }
 
+absl::StatusOr<Message> ReadMessageEventually(Subscriber &sub) {
+  for (int i = 0; i < 100; i++) {
+    absl::StatusOr<Message> msg = sub.ReadMessage();
+    if (!msg.ok()) {
+      return msg.status();
+    }
+    if (msg->length != 0) {
+      return msg;
+    }
+    absl::Status status = sub.Wait(std::chrono::milliseconds(100));
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  return absl::DeadlineExceededError("Timed out waiting for bridge message");
+}
+
 TEST_F(BridgeTest, Basic) {
   subspace::Client client1;
   InitClient(client1, 0);
@@ -202,7 +242,7 @@ TEST_F(BridgeTest, Basic) {
   WaitForSubscribedMessage(recv_bridge_pipe, "/bridged_channel");
 
   // Receive the message on the subscriber.
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(6, msg->length);
   ASSERT_EQ(256, sub->SlotSize());
@@ -242,12 +282,12 @@ TEST_F(BridgeTest, TwoSubs) {
   WaitForSubscribedMessage(recv_bridge_pipe, "/bridged_channel");
 
   // Receive the message on the subscriber.
-  absl::StatusOr<Message> msg = sub1->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub1);
   ASSERT_OK(msg);
   ASSERT_EQ(6, msg->length);
   ASSERT_EQ(256, sub1->SlotSize());
 
-  msg = sub2->ReadMessage();
+  msg = ReadMessageEventually(*sub2);
   ASSERT_OK(msg);
   ASSERT_EQ(6, msg->length);
   ASSERT_EQ(256, sub2->SlotSize());
@@ -289,7 +329,7 @@ TEST_F(BridgeTest, BasicRetirement) {
   ASSERT_TRUE(retirement_fd.Valid());
 
   // Receive the message on the subscriber.
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(6, msg->length);
   ASSERT_EQ(256, sub->SlotSize());
@@ -507,6 +547,33 @@ void WaitForSubscribedMessageWithSizes(
             << " metadata_size: " << subscribed.metadata_size() << std::endl;
 }
 
+subspace::Subscribed
+ReadSubscribedMessage(toolbelt::FileDescriptor &bridge_pipe,
+                      const std::string &channel_name) {
+  std::cerr << "Waiting for bridge notification\n";
+  char buffer[4096];
+  int32_t length;
+  absl::StatusOr<ssize_t> n = bridge_pipe.Read(&length, sizeof(length));
+  if (!n.ok()) {
+    ADD_FAILURE() << n.status();
+    return {};
+  }
+  EXPECT_EQ(sizeof(int32_t), *n);
+  length = ntohl(length);
+  n = bridge_pipe.Read(buffer, length);
+  if (!n.ok()) {
+    ADD_FAILURE() << n.status();
+    return {};
+  }
+
+  subspace::Subscribed subscribed;
+  EXPECT_TRUE(subscribed.ParseFromArray(buffer, *n));
+  EXPECT_EQ(subscribed.channel_name(), channel_name);
+  std::cerr << "Received bridge notification for channel: "
+            << subscribed.channel_name() << std::endl;
+  return subscribed;
+}
+
 TEST_F(BridgeTest, LargeChecksumBridge) {
   subspace::Client client1;
   InitClient(client1, 0);
@@ -538,7 +605,7 @@ TEST_F(BridgeTest, LargeChecksumBridge) {
   toolbelt::FileDescriptor &recv_bridge_pipe = BridgeNotificationPipe(1);
   WaitForSubscribedMessageWithSizes(recv_bridge_pipe, "/bridged_sizes", 20, 50);
 
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(12, msg->length);
   ASSERT_EQ(0, memcmp("bridge_sizes", msg->buffer, 12));
@@ -578,7 +645,7 @@ TEST_F(BridgeTest, DefaultSizesBridge) {
   WaitForSubscribedMessageWithSizes(recv_bridge_pipe, "/bridged_def_sizes",
                                     4, 0);
 
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(7, msg->length);
   ASSERT_EQ(0, memcmp("default", msg->buffer, 7));
@@ -622,7 +689,7 @@ TEST_F(BridgeTest, MetadataBridge) {
   toolbelt::FileDescriptor &recv_bridge_pipe = BridgeNotificationPipe(1);
   WaitForSubscribedMessageWithSizes(recv_bridge_pipe, "/bridged_meta", 4, 24);
 
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(10, msg->length);
   ASSERT_EQ(0, memcmp("bridgemeta", msg->buffer, 10));
@@ -674,7 +741,7 @@ TEST_F(BridgeTest, MetadataLargeBridge) {
   WaitForSubscribedMessageWithSizes(recv_bridge_pipe, "/bridged_meta_lg",
                                     20, 100);
 
-  absl::StatusOr<Message> msg = sub->ReadMessage();
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
   ASSERT_OK(msg);
   ASSERT_EQ(5, msg->length);
   ASSERT_EQ(192, sub->PrefixSize());
@@ -688,9 +755,90 @@ TEST_F(BridgeTest, MetadataLargeBridge) {
   }
 }
 
+TEST_F(BridgeTest, SplitBufferSourceBridge) {
+  subspace::Client client1;
+  InitClient(client1, 0);
+
+  subspace::Client client2;
+  InitClient(client2, 1);
+
+  absl::StatusOr<Publisher> pub = client1.CreatePublisher(
+      "/bridged_split_source",
+      {.slot_size = 256, .num_slots = 10, .local = false,
+       .use_split_buffers = true, .split_buffers_over_bridge = false});
+  ASSERT_OK(pub);
+  ASSERT_TRUE(pub->UsesSplitBuffers());
+
+  absl::StatusOr<Subscriber> sub = client2.CreateSubscriber(
+      "/bridged_split_source", {.max_active_messages = 2});
+  ASSERT_OK(sub);
+
+  subspace::Subscribed sent = ReadSubscribedMessage(
+      BridgeNotificationPipe(0), "/bridged_split_source");
+  ASSERT_TRUE(sent.split_buffers());
+  ASSERT_FALSE(sent.split_buffers_over_bridge());
+
+  absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
+  ASSERT_OK(buffer);
+  memcpy(*buffer, "split-source", 12);
+  ASSERT_OK(pub->PublishMessage(12));
+
+  subspace::Subscribed received = ReadSubscribedMessage(
+      BridgeNotificationPipe(1), "/bridged_split_source");
+  ASSERT_TRUE(received.split_buffers());
+  ASSERT_FALSE(received.split_buffers_over_bridge());
+
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
+  ASSERT_OK(msg);
+  ASSERT_EQ(12, msg->length);
+  ASSERT_EQ(0, memcmp("split-source", msg->buffer, 12));
+  ASSERT_FALSE(sub->UsesSplitBuffers());
+}
+
+TEST_F(BridgeTest, SplitBuffersOverBridge) {
+  subspace::Client client1;
+  InitClient(client1, 0);
+
+  subspace::Client client2;
+  InitClient(client2, 1);
+
+  absl::StatusOr<Publisher> pub = client1.CreatePublisher(
+      "/bridged_split_remote",
+      {.slot_size = 256, .num_slots = 10, .local = false,
+       .use_split_buffers = false, .split_buffers_over_bridge = true});
+  ASSERT_OK(pub);
+  ASSERT_FALSE(pub->UsesSplitBuffers());
+
+  absl::StatusOr<Subscriber> sub = client2.CreateSubscriber(
+      "/bridged_split_remote", {.max_active_messages = 2});
+  ASSERT_OK(sub);
+
+  subspace::Subscribed sent = ReadSubscribedMessage(
+      BridgeNotificationPipe(0), "/bridged_split_remote");
+  ASSERT_FALSE(sent.split_buffers());
+  ASSERT_TRUE(sent.split_buffers_over_bridge());
+
+  absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
+  ASSERT_OK(buffer);
+  memcpy(*buffer, "split-remote", 12);
+  ASSERT_OK(pub->PublishMessage(12));
+
+  subspace::Subscribed received = ReadSubscribedMessage(
+      BridgeNotificationPipe(1), "/bridged_split_remote");
+  ASSERT_FALSE(received.split_buffers());
+  ASSERT_TRUE(received.split_buffers_over_bridge());
+
+  absl::StatusOr<Message> msg = ReadMessageEventually(*sub);
+  ASSERT_OK(msg);
+  ASSERT_EQ(12, msg->length);
+  ASSERT_EQ(0, memcmp("split-remote", msg->buffer, 12));
+  ASSERT_TRUE(sub->UsesSplitBuffers());
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   absl::ParseCommandLine(argc, argv);
+  subspace::SetDefaultUseSplitBuffers(absl::GetFlag(FLAGS_use_split_buffers));
 
   return RUN_ALL_TESTS();
 }

--- a/client/client.cc
+++ b/client/client.cc
@@ -1610,6 +1610,7 @@ void ClientImpl::FillCreatePublisherRequest(CreatePublisherRequest *cmd,
   cmd->set_publisher_id(publisher_id);
   cmd->set_max_publishers(opts.MaxPublishers());
   cmd->set_use_split_buffers(opts.UseSplitBuffers());
+  cmd->set_split_buffers_over_bridge(opts.SplitBuffersOverBridge());
 }
 
 void ClientImpl::ApplyPublisherResponseFds(

--- a/client/options.h
+++ b/client/options.h
@@ -197,6 +197,15 @@ struct PublisherOptions {
   }
   bool UseSplitBuffers() const { return use_split_buffers; }
 
+  // When true, bridge receivers that mirror this channel create their local
+  // bridge publisher with split payload buffers. This is independent of
+  // UseSplitBuffers(), which controls this server's local channel storage.
+  PublisherOptions &SetSplitBuffersOverBridge(bool v) {
+    split_buffers_over_bridge = v;
+    return *this;
+  }
+  bool SplitBuffersOverBridge() const { return split_buffers_over_bridge; }
+
   PublisherOptions &SetSplitBufferCallbacks(
       subspace::SplitBufferCallbacks callbacks) {
     split_buffer_callbacks = std::move(callbacks);
@@ -231,6 +240,7 @@ struct PublisherOptions {
   bool prefer_retired_slots = false;
   int32_t max_publishers = 0;
   bool use_split_buffers = DefaultUseSplitBuffers();
+  bool split_buffers_over_bridge = false;
   subspace::SplitBufferCallbacks split_buffer_callbacks;
 };
 

--- a/docs/c-client.md
+++ b/docs/c-client.md
@@ -100,6 +100,7 @@ Important publisher options:
 | `metadata_size` | Reserve per-message user metadata bytes in the prefix. |
 | `prefer_retired_slots` | Prefer recently retired slots for unreliable publishers. |
 | `use_split_buffers` | Store payloads in split payload buffers. |
+| `split_buffers_over_bridge` | Ask receiving bridge servers to create their mirror publisher with split payload buffers. |
 | `max_publishers` | Maximum publishers allowed on a split-buffer channel. |
 | `split_callbacks` | Optional allocator callbacks for split payload buffers. |
 

--- a/docs/rust-client.md
+++ b/docs/rust-client.md
@@ -103,6 +103,7 @@ loop {
 | `checksum` | false | Compute CRC32 checksums on published messages. |
 | `checksum_size` | 4 | Bytes reserved for checksums (default: 4 for CRC32). |
 | `metadata_size` | 0 | Bytes reserved in each message prefix for user metadata. |
+| `split_buffers_over_bridge` | false | Ask receiving bridge servers to create their mirror publisher with split payload buffers. |
 
 All options use a builder pattern:
 

--- a/docs/split-buffers.md
+++ b/docs/split-buffers.md
@@ -45,6 +45,26 @@ Split buffers are a channel-level setting:
 - The server records split-buffer metadata in the shadow process so recovery can
   rebuild channel state after a server restart.
 
+## Bridged Channels
+
+Split-buffer behavior over a server bridge has two independent settings:
+
+- `use_split_buffers` controls the local channel layout on the server where the
+  publisher is created.
+- `split_buffers_over_bridge` controls the mirror publisher created by a
+  receiving bridge server.
+
+When the source channel uses split buffers, bridge messages are sent as two
+length-prefixed chunks: the `MessagePrefix` area first, then the payload buffer.
+When the source channel does not use split buffers, bridge messages keep the
+legacy single length-prefixed prefix-plus-payload chunk.
+
+Set `split_buffers_over_bridge` when the receiving server should create its
+bridge publisher with split payload buffers, even if the source channel itself
+does not use split buffers locally. The two flags can be set independently so a
+channel can use split buffers only on the source side, only on the receiving side,
+on both sides, or on neither side.
+
 ## C++ API
 
 Publishers enable split buffers through `PublisherOptions`:
@@ -57,6 +77,16 @@ auto opts = subspace::PublisherOptions()
     .SetMaxPublishers(4);
 
 auto pub = client.CreatePublisher("camera", opts);
+```
+
+To request split payload buffers for the remote mirror publisher created over a
+bridge, set `SetSplitBuffersOverBridge(true)`:
+
+```cpp
+auto opts = subspace::PublisherOptions()
+    .SetSlotSize(4096)
+    .SetNumSlots(16)
+    .SetSplitBuffersOverBridge(true);
 ```
 
 For a custom allocator, provide split-buffer callbacks. The allocator returns an
@@ -104,6 +134,7 @@ SubspacePublisherOptions pub_opts =
     subspace_publisher_options_default(4096, 16);
 pub_opts.use_split_buffers = true;
 pub_opts.max_publishers = 4;
+pub_opts.split_buffers_over_bridge = true;
 
 SubspacePublisher pub =
     subspace_create_publisher(client, "camera", pub_opts);

--- a/proto/subspace.proto
+++ b/proto/subspace.proto
@@ -40,6 +40,7 @@ message CreatePublisherRequest {
   int32 publisher_id = 14;     // -1 for new, >= 0 to reclaim existing.
   bool use_split_buffers = 16; // Prefixes and payload slots are separate.
   int32 max_publishers = 17;   // 0 means no explicit publisher limit.
+  bool split_buffers_over_bridge = 18; // Remote bridge publisher uses split buffers.
 }
 
 message CreatePublisherResponse {
@@ -259,6 +260,8 @@ message Subscribed {
   ChannelAddress retirement_socket = 6;
   int32 checksum_size = 7;  // Bytes reserved for checksum.
   int32 metadata_size = 8;  // Bytes reserved for user metadata.
+  bool split_buffers = 9; // Bridge messages are sent as prefix and payload chunks.
+  bool split_buffers_over_bridge = 10; // Receiving bridge publisher uses split buffers.
 }
 
 // This is sent over a TCP connection from the peer server when the
@@ -275,6 +278,7 @@ message Discovery {
     string channel_name = 1;
     bool reliable = 2;
     bool notify_retirement = 3; // Notify publisher when slots retire.
+    bool split_buffers = 4;     // Peer bridge publisher should use split buffers.
   }
 
   // Subscribe to the given channel.  The sender is listening
@@ -430,6 +434,7 @@ message ShadowCreateChannel {
   bool use_split_buffers = 14;
   bool has_max_publishers = 15;
   int32 max_publishers = 16;
+  bool split_buffers_over_bridge = 17;
   // FDs sent via SCM_RIGHTS: [ccb_fd, bcb_fd]
 }
 
@@ -497,4 +502,5 @@ message ShadowUpdateChannelOptions {
   bool use_split_buffers = 3;
   bool has_max_publishers = 4;
   int32 max_publishers = 5;
+  bool split_buffers_over_bridge = 6;
 }

--- a/rust_client/src/client.rs
+++ b/rust_client/src/client.rs
@@ -835,6 +835,7 @@ impl Client {
                     checksum_size: opts.checksum_size,
                     metadata_size: opts.metadata_size,
                     use_split_buffers: false,
+                    split_buffers_over_bridge: opts.split_buffers_over_bridge,
                     max_publishers: 0,
                     publisher_id: -1,
                 },

--- a/rust_client/src/options.rs
+++ b/rust_client/src/options.rs
@@ -20,6 +20,7 @@ pub struct PublisherOptions {
     pub checksum: bool,
     pub checksum_size: i32,
     pub metadata_size: i32,
+    pub split_buffers_over_bridge: bool,
 }
 
 impl Default for PublisherOptions {
@@ -40,6 +41,7 @@ impl Default for PublisherOptions {
             checksum: false,
             checksum_size: 4,
             metadata_size: 0,
+            split_buffers_over_bridge: false,
         }
     }
 }
@@ -121,6 +123,11 @@ impl PublisherOptions {
 
     pub fn set_metadata_size(mut self, size: i32) -> Self {
         self.metadata_size = size;
+        self
+    }
+
+    pub fn set_split_buffers_over_bridge(mut self, v: bool) -> Self {
+        self.split_buffers_over_bridge = v;
         self
     }
 }

--- a/server/client_handler.cc
+++ b/server/client_handler.cc
@@ -32,7 +32,8 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
 
 SplitBufferOptions
 FromPublisherSplitBufferRequest(const CreatePublisherRequest &req) {
-  return {.use_split_buffers = req.use_split_buffers()};
+  return {.use_split_buffers = req.use_split_buffers(),
+          .split_buffers_over_bridge = req.split_buffers_over_bridge()};
 }
 
 } // namespace

--- a/server/server.cc
+++ b/server/server.cc
@@ -34,6 +34,26 @@ void ClosePluginsOnShutdown() { close_plugins_on_shutdown = true; }
 
 bool ShouldClosePluginsOnShutdown() { return close_plugins_on_shutdown; }
 
+static const ServerChannel *SplitBufferOptionsChannel(
+    const ServerChannel *channel) {
+  if (channel->IsVirtual()) {
+    return static_cast<const VirtualChannel *>(channel)->GetMux();
+  }
+  return channel;
+}
+
+static bool ChannelUsesSplitBuffers(const ServerChannel *channel) {
+  const ServerChannel *split_channel = SplitBufferOptionsChannel(channel);
+  return split_channel->HasSplitBufferOptions() &&
+         split_channel->GetSplitBufferOptions().use_split_buffers;
+}
+
+static bool ChannelUsesSplitBuffersOverBridge(const ServerChannel *channel) {
+  const ServerChannel *split_channel = SplitBufferOptionsChannel(channel);
+  return split_channel->HasSplitBufferOptions() &&
+         split_channel->GetSplitBufferOptions().split_buffers_over_bridge;
+}
+
 // Look for the IP address and calculate the broadcast address
 // for the given interface.  If the interface name is empty
 // choose the first interface that supports broadcast and
@@ -773,7 +793,8 @@ absl::Status Server::RecoverFromShadow(RecoveredState &state) {
     channel->SetMetadataSize(rch.metadata_size);
     if (rch.has_split_buffer_options) {
       if (absl::Status s = channel->ValidateOrSetSplitBufferOptions(
-              {.use_split_buffers = rch.use_split_buffers},
+              {.use_split_buffers = rch.use_split_buffers,
+               .split_buffers_over_bridge = rch.split_buffers_over_bridge},
               /*set_if_missing=*/true, "shadow recovery");
           !s.ok()) {
         return s;
@@ -1049,6 +1070,10 @@ void Server::SendAdvertise(const std::string &channel_name, bool reliable) {
         auto *advertise = disc.mutable_advertise();
         advertise->set_channel_name(channel_name);
         advertise->set_reliable(reliable);
+        if (auto it = channels_.find(channel_name); it != channels_.end()) {
+          advertise->set_split_buffers(
+              ChannelUsesSplitBuffersOverBridge(it->second.get()));
+        }
         bool ok = disc.SerializeToArray(buffer, sizeof(buffer));
         if (!ok) {
           logger_.Log(toolbelt::LogLevel::kError,
@@ -1150,6 +1175,10 @@ void Server::BridgeTransmitterCoroutine(ServerChannel *channel,
   subscribed.set_reliable(pub_reliable);
   subscribed.set_checksum_size(channel->ChecksumSize());
   subscribed.set_metadata_size(channel->MetadataSize());
+  const bool wire_split_buffers = ChannelUsesSplitBuffers(channel);
+  subscribed.set_split_buffers(wire_split_buffers);
+  subscribed.set_split_buffers_over_bridge(
+      ChannelUsesSplitBuffersOverBridge(channel));
 
   toolbelt::StreamSocket retirement_listener;
   toolbelt::SocketAddress retirement_addr;
@@ -1313,13 +1342,6 @@ void Server::BridgeTransmitterCoroutine(ServerChannel *channel,
         // This message came from bridge.  We don't forward them again.
         continue;
       }
-      // SendMessage uses the 4 bytes immediately below the buffer
-      // for the length of the messages.  The MessagePrefix struct
-      // contains a padding member for this purpose.  We don't
-      // count the padding in the length sent.
-      char *data_addr = const_cast<char *>(prefix_addr) + sizeof(int32_t);
-      size_t msglen = msg->length + prefix_area - sizeof(int32_t);
-
       // Note that for a reliable publisher where the subscriber is slower
       // we will get backpressure from the receiver because it won't
       // read from the socket.  We will keep transmitting until the TCP
@@ -1332,15 +1354,59 @@ void Server::BridgeTransmitterCoroutine(ServerChannel *channel,
       // The backpressure received here will be applied upwards because
       // we will stop reading the messages from the channel and thus
       // backpressure any publishers writing to that channel.
-      if (absl::StatusOr<ssize_t> n_sent_2 =
-              bridge.SendMessage(data_addr, msglen, co::self);
-          !n_sent_2.ok()) {
-        done = true;
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Failed to send bridge message for %s: %s",
-                    channel_name.c_str(), n_sent_2.status().ToString().c_str());
-
-        break;
+      if (wire_split_buffers) {
+        char *prefix_without_padding =
+            const_cast<char *>(prefix_addr) + sizeof(int32_t);
+        size_t prefix_length = prefix_area - sizeof(int32_t);
+        if (absl::StatusOr<ssize_t> n_sent_2 =
+                bridge.SendMessage(prefix_without_padding, prefix_length,
+                                   co::self);
+            !n_sent_2.ok()) {
+          done = true;
+          logger_.Log(toolbelt::LogLevel::kError,
+                      "Failed to send bridge prefix for %s: %s",
+                      channel_name.c_str(),
+                      n_sent_2.status().ToString().c_str());
+          break;
+        }
+        int32_t payload_length = htonl(static_cast<int32_t>(msg->length));
+        if (absl::StatusOr<ssize_t> n_sent_3 = bridge.Send(
+                reinterpret_cast<const char *>(&payload_length),
+                sizeof(payload_length), co::self);
+            !n_sent_3.ok()) {
+          done = true;
+          logger_.Log(toolbelt::LogLevel::kError,
+                      "Failed to send bridge payload length for %s: %s",
+                      channel_name.c_str(),
+                      n_sent_3.status().ToString().c_str());
+          break;
+        }
+        if (absl::StatusOr<ssize_t> n_sent_4 = bridge.Send(
+                static_cast<const char *>(msg->buffer), msg->length, co::self);
+            !n_sent_4.ok()) {
+          done = true;
+          logger_.Log(toolbelt::LogLevel::kError,
+                      "Failed to send bridge payload for %s: %s",
+                      channel_name.c_str(),
+                      n_sent_4.status().ToString().c_str());
+          break;
+        }
+      } else {
+        // SendMessage uses the 4 bytes immediately below the buffer for the
+        // frame length. The MessagePrefix padding exists for this purpose, so
+        // the legacy bridge path can write prefix and payload in one chunk.
+        char *data_addr = const_cast<char *>(prefix_addr) + sizeof(int32_t);
+        size_t msglen = msg->length + prefix_area - sizeof(int32_t);
+        if (absl::StatusOr<ssize_t> n_sent_2 =
+                bridge.SendMessage(data_addr, msglen, co::self);
+            !n_sent_2.ok()) {
+          done = true;
+          logger_.Log(
+              toolbelt::LogLevel::kError,
+              "Failed to send bridge message for %s: %s", channel_name.c_str(),
+              n_sent_2.status().ToString().c_str());
+          break;
+        }
       }
       if (notifying_of_retirement) {
         // We need to keep track of the message so that we can retire it
@@ -1475,6 +1541,7 @@ Server::SendSubscribeMessage(const std::string &channel_name, bool reliable,
 // bridge and publishing them to the local channel.
 void Server::BridgeReceiverCoroutine(std::string channel_name,
                                      bool sub_reliable,
+                                     bool split_buffers_over_bridge,
                                      toolbelt::InetAddress publisher) {
   struct BridgeGuard {
     Server *server;
@@ -1543,6 +1610,8 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
                 "Failed to parse Subscribed message");
     return;
   }
+  const bool bridge_publisher_split_buffers =
+      split_buffers_over_bridge || subscribed.split_buffers_over_bridge();
 
   // Build a publisher to publish incoming bridge messages to the channel.
   Client client(co::self);
@@ -1614,7 +1683,8 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
           .SetBridge(true)
           .SetNotifyRetirement(subscribed.notify_retirement())
           .SetChecksumSize(bridge_cs)
-          .SetMetadataSize(bridge_ms));
+          .SetMetadataSize(bridge_ms)
+          .SetUseSplitBuffers(bridge_publisher_split_buffers));
   if (!pub.ok()) {
     logger_.Log(toolbelt::LogLevel::kError,
                 "Failed to create bridge publisher for %s: %s",
@@ -1723,16 +1793,87 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
     char *prefix_addr = reinterpret_cast<char *>(prefix);
     char *after_padding = prefix_addr + sizeof(int32_t);
 
-    absl::StatusOr<ssize_t> n = bridge->ReceiveMessage(
-        after_padding, subscribed.slot_size() + adjusted_prefix_length,
-        co::self);
-    if (!n.ok()) {
-      // This will happen when the bridge transmitter on the other
-      // side of the bridge terminates.
-      logger_.Log(toolbelt::LogLevel::kError,
-                  "Failed to read bridge message for %s: %s",
-                  channel_name.c_str(), n.status().ToString().c_str());
-      break;
+    size_t payload_length = 0;
+    if (subscribed.split_buffers()) {
+      absl::StatusOr<ssize_t> n = bridge->ReceiveMessage(
+          after_padding, adjusted_prefix_length, co::self);
+      if (!n.ok()) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to read bridge prefix for %s: %s",
+                    channel_name.c_str(), n.status().ToString().c_str());
+        break;
+      }
+      if (static_cast<size_t>(*n) != adjusted_prefix_length) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Bridge prefix for %s has invalid length %zd, expected %zu",
+                    channel_name.c_str(), *n, adjusted_prefix_length);
+        break;
+      }
+      if (prefix->message_size > static_cast<uint64_t>(subscribed.slot_size())) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Bridge payload for %s is too large: %llu > %d",
+                    channel_name.c_str(),
+                    static_cast<unsigned long long>(prefix->message_size),
+                    subscribed.slot_size());
+        break;
+      }
+      absl::StatusOr<ssize_t> payload = bridge->ReceiveMessage(
+          static_cast<char *>(*buf), static_cast<size_t>(prefix->message_size),
+          co::self);
+      if (!payload.ok()) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to read bridge payload for %s: %s",
+                    channel_name.c_str(), payload.status().ToString().c_str());
+        break;
+      }
+      payload_length = static_cast<size_t>(*payload);
+      if (payload_length != static_cast<size_t>(prefix->message_size)) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Bridge payload for %s has invalid length %zu, expected "
+                    "%llu",
+                    channel_name.c_str(), payload_length,
+                    static_cast<unsigned long long>(prefix->message_size));
+        break;
+      }
+    } else if (pub->UsesSplitBuffers()) {
+      std::vector<char> combined(subscribed.slot_size() +
+                                 adjusted_prefix_length);
+      absl::StatusOr<ssize_t> n =
+          bridge->ReceiveMessage(combined.data(), combined.size(), co::self);
+      if (!n.ok()) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to read bridge message for %s: %s",
+                    channel_name.c_str(), n.status().ToString().c_str());
+        break;
+      }
+      if (static_cast<size_t>(*n) < adjusted_prefix_length) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Bridge message for %s is too short: %zd < %zu",
+                    channel_name.c_str(), *n, adjusted_prefix_length);
+        break;
+      }
+      memcpy(after_padding, combined.data(), adjusted_prefix_length);
+      payload_length = static_cast<size_t>(*n) - adjusted_prefix_length;
+      memcpy(*buf, combined.data() + adjusted_prefix_length, payload_length);
+    } else {
+      absl::StatusOr<ssize_t> n = bridge->ReceiveMessage(
+          after_padding, subscribed.slot_size() + adjusted_prefix_length,
+          co::self);
+      if (!n.ok()) {
+        // This will happen when the bridge transmitter on the other
+        // side of the bridge terminates.
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to read bridge message for %s: %s",
+                    channel_name.c_str(), n.status().ToString().c_str());
+        break;
+      }
+      if (static_cast<size_t>(*n) < adjusted_prefix_length) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Bridge message for %s is too short: %zd < %zu",
+                    channel_name.c_str(), *n, adjusted_prefix_length);
+        break;
+      }
+      payload_length = static_cast<size_t>(*n) - adjusted_prefix_length;
     }
 
     // Set the kMessageBridged flag in the prefix so that this message isn't
@@ -1745,7 +1886,7 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
     prefix->flags |= kMessageBridged;
 
     absl::StatusOr<const Message> pub_msg = pub->PublishMessageInternal(
-        *n - adjusted_prefix_length, /*omit_prefix=*/true,
+        payload_length, /*omit_prefix=*/true,
         /*omit_prefix_slot_id=*/true);
     if (!pub_msg.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
@@ -1813,10 +1954,12 @@ void Server::RetirementCoroutine(
 }
 
 void Server::SubscribeOverBridge(ServerChannel *channel, bool reliable,
+                                 bool split_buffers_over_bridge,
                                  toolbelt::InetAddress publisher) {
   scheduler_.Spawn(
-      [this, channel, reliable, publisher]() {
-        BridgeReceiverCoroutine(channel->Name(), reliable, publisher);
+      [this, channel, reliable, split_buffers_over_bridge, publisher]() {
+        BridgeReceiverCoroutine(channel->Name(), reliable,
+                                split_buffers_over_bridge, publisher);
       },
       {.name = absl::StrFormat("Bridge receiver for %s", channel->Name()),
        .interrupt_fd = shutdown_trigger_fd_.GetPollFd().Fd()});
@@ -1862,7 +2005,8 @@ void Server::IncomingAdvertise(const Discovery::Advertise &advertise,
                                 num_bridge_subs, num_tunnel_pubs,
                                 num_tunnel_subs);
     if (num_subs > 0) {
-      SubscribeOverBridge(channel->second.get(), advertise.reliable(), sender);
+      SubscribeOverBridge(channel->second.get(), advertise.reliable(),
+                          advertise.split_buffers(), sender);
     }
   }
 }

--- a/server/server.cc
+++ b/server/server.cc
@@ -54,6 +54,212 @@ static bool ChannelUsesSplitBuffersOverBridge(const ServerChannel *channel) {
          split_channel->GetSplitBufferOptions().split_buffers_over_bridge;
 }
 
+struct BridgeReceiveTarget {
+  MessagePrefix *prefix = nullptr;
+  char *prefix_without_padding = nullptr;
+  size_t prefix_length = 0;
+  void *payload = nullptr;
+};
+
+struct BridgeReceivedMessage {
+  MessagePrefix *prefix = nullptr;
+  size_t payload_length = 0;
+};
+
+static absl::Status SendSplitBridgeMessage(toolbelt::StreamSocket &bridge,
+                                           const Message &msg,
+                                           const MessagePrefix *prefix,
+                                           size_t prefix_area) {
+  const char *prefix_addr = reinterpret_cast<const char *>(prefix);
+  char *prefix_without_padding =
+      const_cast<char *>(prefix_addr) + sizeof(int32_t);
+  size_t prefix_length = prefix_area - sizeof(int32_t);
+  if (absl::StatusOr<ssize_t> n =
+          bridge.SendMessage(prefix_without_padding, prefix_length, co::self);
+      !n.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("failed to send bridge prefix: %s",
+                        n.status().ToString()));
+  }
+
+  int32_t payload_length = htonl(static_cast<int32_t>(msg.length));
+  if (absl::StatusOr<ssize_t> n =
+          bridge.Send(reinterpret_cast<const char *>(&payload_length),
+                      sizeof(payload_length), co::self);
+      !n.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("failed to send bridge payload length: %s",
+                        n.status().ToString()));
+  }
+  if (absl::StatusOr<ssize_t> n =
+          bridge.Send(static_cast<const char *>(msg.buffer), msg.length,
+                      co::self);
+      !n.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("failed to send bridge payload: %s",
+                        n.status().ToString()));
+  }
+  return absl::OkStatus();
+}
+
+static absl::Status SendCombinedBridgeMessage(toolbelt::StreamSocket &bridge,
+                                              const Message &msg,
+                                              const MessagePrefix *prefix,
+                                              size_t prefix_area) {
+  const char *prefix_addr = reinterpret_cast<const char *>(prefix);
+  // SendMessage uses the 4 bytes immediately below the buffer for the frame
+  // length. The MessagePrefix padding exists for this purpose, so the legacy
+  // bridge path can write prefix and payload in one chunk.
+  char *data_addr = const_cast<char *>(prefix_addr) + sizeof(int32_t);
+  size_t message_length = msg.length + prefix_area - sizeof(int32_t);
+  if (absl::StatusOr<ssize_t> n =
+          bridge.SendMessage(data_addr, message_length, co::self);
+      !n.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("failed to send bridge message: %s",
+                        n.status().ToString()));
+  }
+  return absl::OkStatus();
+}
+
+static absl::Status SendBridgeMessage(toolbelt::StreamSocket &bridge,
+                                      const Message &msg,
+                                      const MessagePrefix *prefix,
+                                      size_t prefix_area,
+                                      bool split_buffers_on_wire) {
+  if (split_buffers_on_wire) {
+    return SendSplitBridgeMessage(bridge, msg, prefix, prefix_area);
+  }
+  return SendCombinedBridgeMessage(bridge, msg, prefix, prefix_area);
+}
+
+static absl::StatusOr<size_t>
+ReceiveSplitBridgeMessage(toolbelt::StreamSocket &bridge,
+                          const Subscribed &subscribed,
+                          const BridgeReceiveTarget &target) {
+  absl::StatusOr<ssize_t> prefix = bridge.ReceiveMessage(
+      target.prefix_without_padding, target.prefix_length, co::self);
+  if (!prefix.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "failed to read bridge prefix: %s", prefix.status().ToString()));
+  }
+  if (static_cast<size_t>(*prefix) != target.prefix_length) {
+    return absl::InternalError(
+        absl::StrFormat("bridge prefix has invalid length %zd, expected %zu",
+                        *prefix, target.prefix_length));
+  }
+  if (target.prefix->message_size >
+      static_cast<uint64_t>(subscribed.slot_size())) {
+    return absl::InternalError(absl::StrFormat(
+        "bridge payload is too large: %llu > %d",
+        static_cast<unsigned long long>(target.prefix->message_size),
+        subscribed.slot_size()));
+  }
+
+  absl::StatusOr<ssize_t> payload =
+      bridge.ReceiveMessage(static_cast<char *>(target.payload),
+                            static_cast<size_t>(target.prefix->message_size),
+                            co::self);
+  if (!payload.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "failed to read bridge payload: %s", payload.status().ToString()));
+  }
+  size_t payload_length = static_cast<size_t>(*payload);
+  if (payload_length != static_cast<size_t>(target.prefix->message_size)) {
+    return absl::InternalError(absl::StrFormat(
+        "bridge payload has invalid length %zu, expected %llu", payload_length,
+        static_cast<unsigned long long>(target.prefix->message_size)));
+  }
+  return payload_length;
+}
+
+static absl::StatusOr<size_t>
+ReceiveCombinedBridgeMessageForSplitPublisher(toolbelt::StreamSocket &bridge,
+                                              const Subscribed &subscribed,
+                                              const BridgeReceiveTarget &target) {
+  std::vector<char> combined(subscribed.slot_size() + target.prefix_length);
+  absl::StatusOr<ssize_t> n =
+      bridge.ReceiveMessage(combined.data(), combined.size(), co::self);
+  if (!n.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "failed to read bridge message: %s", n.status().ToString()));
+  }
+  if (static_cast<size_t>(*n) < target.prefix_length) {
+    return absl::InternalError(
+        absl::StrFormat("bridge message is too short: %zd < %zu", *n,
+                        target.prefix_length));
+  }
+  memcpy(target.prefix_without_padding, combined.data(), target.prefix_length);
+  size_t payload_length = static_cast<size_t>(*n) - target.prefix_length;
+  memcpy(target.payload, combined.data() + target.prefix_length,
+         payload_length);
+  return payload_length;
+}
+
+static absl::StatusOr<size_t>
+ReceiveCombinedBridgeMessage(toolbelt::StreamSocket &bridge,
+                             const Subscribed &subscribed,
+                             const BridgeReceiveTarget &target) {
+  absl::StatusOr<ssize_t> n = bridge.ReceiveMessage(
+      target.prefix_without_padding,
+      subscribed.slot_size() + target.prefix_length, co::self);
+  if (!n.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "failed to read bridge message: %s", n.status().ToString()));
+  }
+  if (static_cast<size_t>(*n) < target.prefix_length) {
+    return absl::InternalError(absl::StrFormat(
+        "bridge message is too short: %zd < %zu", *n, target.prefix_length));
+  }
+  return static_cast<size_t>(*n) - target.prefix_length;
+}
+
+static absl::StatusOr<BridgeReceivedMessage>
+ReceiveBridgeMessage(toolbelt::StreamSocket &bridge, Publisher &pub,
+                     const Subscribed &subscribed, void *payload_buffer) {
+  // The MessagePrefix struct contains 4 bytes of padding at offset 0. This is
+  // to allow SendMessage to use it for the length in the combined wire format.
+  size_t prefix_area = pub.PrefixSize();
+  BridgeReceiveTarget target = {
+      .prefix = pub.Prefix(),
+      .prefix_without_padding = nullptr,
+      .prefix_length = prefix_area - sizeof(int32_t),
+      .payload = payload_buffer,
+  };
+  if (target.prefix == nullptr) {
+    return absl::InternalError("failed to find message prefix");
+  }
+  char *prefix_addr = reinterpret_cast<char *>(target.prefix);
+  target.prefix_without_padding = prefix_addr + sizeof(int32_t);
+
+  if (subscribed.split_buffers()) {
+    absl::StatusOr<size_t> payload_length =
+        ReceiveSplitBridgeMessage(bridge, subscribed, target);
+    if (!payload_length.ok()) {
+      return payload_length.status();
+    }
+    return BridgeReceivedMessage{.prefix = target.prefix,
+                                 .payload_length = *payload_length};
+  }
+  if (pub.UsesSplitBuffers()) {
+    absl::StatusOr<size_t> payload_length =
+        ReceiveCombinedBridgeMessageForSplitPublisher(bridge, subscribed,
+                                                      target);
+    if (!payload_length.ok()) {
+      return payload_length.status();
+    }
+    return BridgeReceivedMessage{.prefix = target.prefix,
+                                 .payload_length = *payload_length};
+  }
+  absl::StatusOr<size_t> payload_length =
+      ReceiveCombinedBridgeMessage(bridge, subscribed, target);
+  if (!payload_length.ok()) {
+    return payload_length.status();
+  }
+  return BridgeReceivedMessage{.prefix = target.prefix,
+                               .payload_length = *payload_length};
+}
+
 // Look for the IP address and calculate the broadcast address
 // for the given interface.  If the interface name is empty
 // choose the first interface that supports broadcast and
@@ -1333,7 +1539,6 @@ void Server::BridgeTransmitterCoroutine(ServerChannel *channel,
                     channel_name.c_str());
         continue;
       }
-      const char *prefix_addr = reinterpret_cast<const char *>(prefix);
       // NOTE: there's a question here about whether we want to send an
       // activation message across the bridge.  Currently we do send
       // it but the receiver will disregard it.  I don't think we need
@@ -1354,59 +1559,15 @@ void Server::BridgeTransmitterCoroutine(ServerChannel *channel,
       // The backpressure received here will be applied upwards because
       // we will stop reading the messages from the channel and thus
       // backpressure any publishers writing to that channel.
-      if (wire_split_buffers) {
-        char *prefix_without_padding =
-            const_cast<char *>(prefix_addr) + sizeof(int32_t);
-        size_t prefix_length = prefix_area - sizeof(int32_t);
-        if (absl::StatusOr<ssize_t> n_sent_2 =
-                bridge.SendMessage(prefix_without_padding, prefix_length,
-                                   co::self);
-            !n_sent_2.ok()) {
-          done = true;
-          logger_.Log(toolbelt::LogLevel::kError,
-                      "Failed to send bridge prefix for %s: %s",
-                      channel_name.c_str(),
-                      n_sent_2.status().ToString().c_str());
-          break;
-        }
-        int32_t payload_length = htonl(static_cast<int32_t>(msg->length));
-        if (absl::StatusOr<ssize_t> n_sent_3 = bridge.Send(
-                reinterpret_cast<const char *>(&payload_length),
-                sizeof(payload_length), co::self);
-            !n_sent_3.ok()) {
-          done = true;
-          logger_.Log(toolbelt::LogLevel::kError,
-                      "Failed to send bridge payload length for %s: %s",
-                      channel_name.c_str(),
-                      n_sent_3.status().ToString().c_str());
-          break;
-        }
-        if (absl::StatusOr<ssize_t> n_sent_4 = bridge.Send(
-                static_cast<const char *>(msg->buffer), msg->length, co::self);
-            !n_sent_4.ok()) {
-          done = true;
-          logger_.Log(toolbelt::LogLevel::kError,
-                      "Failed to send bridge payload for %s: %s",
-                      channel_name.c_str(),
-                      n_sent_4.status().ToString().c_str());
-          break;
-        }
-      } else {
-        // SendMessage uses the 4 bytes immediately below the buffer for the
-        // frame length. The MessagePrefix padding exists for this purpose, so
-        // the legacy bridge path can write prefix and payload in one chunk.
-        char *data_addr = const_cast<char *>(prefix_addr) + sizeof(int32_t);
-        size_t msglen = msg->length + prefix_area - sizeof(int32_t);
-        if (absl::StatusOr<ssize_t> n_sent_2 =
-                bridge.SendMessage(data_addr, msglen, co::self);
-            !n_sent_2.ok()) {
-          done = true;
-          logger_.Log(
-              toolbelt::LogLevel::kError,
-              "Failed to send bridge message for %s: %s", channel_name.c_str(),
-              n_sent_2.status().ToString().c_str());
-          break;
-        }
+      if (absl::Status status =
+              SendBridgeMessage(bridge, *msg, prefix, prefix_area,
+                                wire_split_buffers);
+          !status.ok()) {
+        done = true;
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to send bridge message for %s: %s",
+                    channel_name.c_str(), status.ToString().c_str());
+        break;
       }
       if (notifying_of_retirement) {
         // We need to keep track of the message so that we can retire it
@@ -1771,113 +1932,18 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
       continue;
     }
 
-    // Read the received message into the prefix that is located just
-    // before the message buffer.  When the message is published into
-    // the channel, we tell the client to omit the prefix so that it
-    // remains intact.  This means that the ordinal is carried intact
-    // over the bridge.
-    //
-    // The MessagePrefix struct contains 4 bytes of padding at offset 0.
-    // This is to allow SendMessage to use it for the length to avoid
-    // 2 sends to the network.  We need to receive into the address
-    // after the padding.
-    size_t prefix_area = pub->PrefixSize();
-    size_t adjusted_prefix_length = prefix_area - sizeof(int32_t);
-    MessagePrefix *prefix = pub->Prefix();
-    if (prefix == nullptr) {
+    absl::StatusOr<BridgeReceivedMessage> bridge_msg =
+        ReceiveBridgeMessage(*bridge, *pub, subscribed, *buf);
+    if (!bridge_msg.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
-                  "Failed to find message prefix for bridge receiver on %s",
-                  channel_name.c_str());
+                  "Failed to read bridge message for %s: %s",
+                  channel_name.c_str(), bridge_msg.status().ToString().c_str());
       break;
-    }
-    char *prefix_addr = reinterpret_cast<char *>(prefix);
-    char *after_padding = prefix_addr + sizeof(int32_t);
-
-    size_t payload_length = 0;
-    if (subscribed.split_buffers()) {
-      absl::StatusOr<ssize_t> n = bridge->ReceiveMessage(
-          after_padding, adjusted_prefix_length, co::self);
-      if (!n.ok()) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Failed to read bridge prefix for %s: %s",
-                    channel_name.c_str(), n.status().ToString().c_str());
-        break;
-      }
-      if (static_cast<size_t>(*n) != adjusted_prefix_length) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Bridge prefix for %s has invalid length %zd, expected %zu",
-                    channel_name.c_str(), *n, adjusted_prefix_length);
-        break;
-      }
-      if (prefix->message_size > static_cast<uint64_t>(subscribed.slot_size())) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Bridge payload for %s is too large: %llu > %d",
-                    channel_name.c_str(),
-                    static_cast<unsigned long long>(prefix->message_size),
-                    subscribed.slot_size());
-        break;
-      }
-      absl::StatusOr<ssize_t> payload = bridge->ReceiveMessage(
-          static_cast<char *>(*buf), static_cast<size_t>(prefix->message_size),
-          co::self);
-      if (!payload.ok()) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Failed to read bridge payload for %s: %s",
-                    channel_name.c_str(), payload.status().ToString().c_str());
-        break;
-      }
-      payload_length = static_cast<size_t>(*payload);
-      if (payload_length != static_cast<size_t>(prefix->message_size)) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Bridge payload for %s has invalid length %zu, expected "
-                    "%llu",
-                    channel_name.c_str(), payload_length,
-                    static_cast<unsigned long long>(prefix->message_size));
-        break;
-      }
-    } else if (pub->UsesSplitBuffers()) {
-      std::vector<char> combined(subscribed.slot_size() +
-                                 adjusted_prefix_length);
-      absl::StatusOr<ssize_t> n =
-          bridge->ReceiveMessage(combined.data(), combined.size(), co::self);
-      if (!n.ok()) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Failed to read bridge message for %s: %s",
-                    channel_name.c_str(), n.status().ToString().c_str());
-        break;
-      }
-      if (static_cast<size_t>(*n) < adjusted_prefix_length) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Bridge message for %s is too short: %zd < %zu",
-                    channel_name.c_str(), *n, adjusted_prefix_length);
-        break;
-      }
-      memcpy(after_padding, combined.data(), adjusted_prefix_length);
-      payload_length = static_cast<size_t>(*n) - adjusted_prefix_length;
-      memcpy(*buf, combined.data() + adjusted_prefix_length, payload_length);
-    } else {
-      absl::StatusOr<ssize_t> n = bridge->ReceiveMessage(
-          after_padding, subscribed.slot_size() + adjusted_prefix_length,
-          co::self);
-      if (!n.ok()) {
-        // This will happen when the bridge transmitter on the other
-        // side of the bridge terminates.
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Failed to read bridge message for %s: %s",
-                    channel_name.c_str(), n.status().ToString().c_str());
-        break;
-      }
-      if (static_cast<size_t>(*n) < adjusted_prefix_length) {
-        logger_.Log(toolbelt::LogLevel::kError,
-                    "Bridge message for %s is too short: %zd < %zu",
-                    channel_name.c_str(), *n, adjusted_prefix_length);
-        break;
-      }
-      payload_length = static_cast<size_t>(*n) - adjusted_prefix_length;
     }
 
     // Set the kMessageBridged flag in the prefix so that this message isn't
     // forwarded again over a bridge.
+    MessagePrefix *prefix = bridge_msg->prefix;
     if ((prefix->flags & kMessageActivate) != 0) {
       // Since we have created a reliable publisher and it has sent an
       // activation message through, we don't send another one.
@@ -1886,7 +1952,7 @@ void Server::BridgeReceiverCoroutine(std::string channel_name,
     prefix->flags |= kMessageBridged;
 
     absl::StatusOr<const Message> pub_msg = pub->PublishMessageInternal(
-        payload_length, /*omit_prefix=*/true,
+        bridge_msg->payload_length, /*omit_prefix=*/true,
         /*omit_prefix_slot_id=*/true);
     if (!pub_msg.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,

--- a/server/server.h
+++ b/server/server.h
@@ -185,6 +185,7 @@ private:
                                   toolbelt::SocketAddress subscriber,
                                   bool notify_retirement);
   void BridgeReceiverCoroutine(std::string channel_name, bool sub_reliable,
+                               bool split_buffers_over_bridge,
                                toolbelt::InetAddress publisher);
   void RetirementCoroutine(
       const std::string &channel_name, toolbelt::FileDescriptor &&retirement_fd,
@@ -195,6 +196,7 @@ private:
       std::shared_ptr<std::vector<std::shared_ptr<ActiveMessage>>> active_retirement_msgs);
 
   void SubscribeOverBridge(ServerChannel *channel, bool reliable,
+                           bool split_buffers_over_bridge,
                            toolbelt::InetAddress publisher);
   void IncomingQuery(const Discovery::Query &query,
                      const toolbelt::InetAddress &sender);

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -94,7 +94,8 @@ absl::Status ServerChannel::ValidateOrSetSplitBufferOptions(
     const SplitBufferOptions &options, bool set_if_missing,
     const char *user_type) {
   if (!split_buffer_options_set_) {
-    if (set_if_missing || options.use_split_buffers) {
+    if (set_if_missing || options.use_split_buffers ||
+        options.split_buffers_over_bridge) {
       split_buffer_options_ = options;
       split_buffer_options_set_ = true;
     }
@@ -105,6 +106,13 @@ absl::Status ServerChannel::ValidateOrSetSplitBufferOptions(
       split_buffer_options_.use_split_buffers != options.use_split_buffers) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Inconsistent split-buffer mode for %s on channel %s", user_type,
+        Name()));
+  }
+  if (options.split_buffers_over_bridge &&
+      split_buffer_options_.split_buffers_over_bridge !=
+          options.split_buffers_over_bridge) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Inconsistent bridge split-buffer mode for %s on channel %s", user_type,
         Name()));
   }
   return absl::OkStatus();

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -38,6 +38,7 @@ struct ResizeInfo {
 
 struct SplitBufferOptions {
   bool use_split_buffers = false;
+  bool split_buffers_over_bridge = false;
 };
 
 // A user is a publisher or subscriber on a channel.  Each user has a

--- a/server/shadow_replicator.cc
+++ b/server/shadow_replicator.cc
@@ -141,6 +141,8 @@ void ShadowReplicator::SendCreateChannel(ServerChannel *channel) {
     msg->set_has_split_buffer_options(true);
     msg->set_use_split_buffers(
         channel->GetSplitBufferOptions().use_split_buffers);
+    msg->set_split_buffers_over_bridge(
+        channel->GetSplitBufferOptions().split_buffers_over_bridge);
   }
   if (channel->MaxPublishers() > 0) {
     msg->set_has_max_publishers(true);
@@ -252,6 +254,8 @@ void ShadowReplicator::SendUpdateChannelOptions(const ServerChannel *channel) {
     msg->set_has_split_buffer_options(true);
     msg->set_use_split_buffers(
         channel->GetSplitBufferOptions().use_split_buffers);
+    msg->set_split_buffers_over_bridge(
+        channel->GetSplitBufferOptions().split_buffers_over_bridge);
   }
   if (channel->MaxPublishers() > 0) {
     msg->set_has_max_publishers(true);
@@ -370,6 +374,7 @@ absl::StatusOr<RecoveredState> ShadowReplicator::ReceiveStateDump() {
           .vchan_id = msg.vchan_id(),
           .has_split_buffer_options = msg.has_split_buffer_options(),
           .use_split_buffers = msg.use_split_buffers(),
+          .split_buffers_over_bridge = msg.split_buffers_over_bridge(),
           .has_max_publishers = msg.has_max_publishers(),
           .max_publishers = msg.max_publishers(),
           .ccb_fd = std::move(fds[0]),

--- a/server/shadow_replicator.h
+++ b/server/shadow_replicator.h
@@ -61,6 +61,7 @@ struct RecoveredChannel {
   int vchan_id = -1;
   bool has_split_buffer_options = false;
   bool use_split_buffers = false;
+  bool split_buffers_over_bridge = false;
   bool has_max_publishers = false;
   int max_publishers = 0;
   toolbelt::FileDescriptor ccb_fd;

--- a/shadow/shadow.cc
+++ b/shadow/shadow.cc
@@ -233,6 +233,7 @@ Shadow::HandleCreateChannel(const ShadowCreateChannel &msg,
     ch.vchan_id = msg.vchan_id();
     ch.has_split_buffer_options = msg.has_split_buffer_options();
     ch.use_split_buffers = msg.use_split_buffers();
+    ch.split_buffers_over_bridge = msg.split_buffers_over_bridge();
     ch.has_max_publishers = msg.has_max_publishers();
     ch.max_publishers = msg.max_publishers();
     ch.ccb_fd = std::move(fds[0]);
@@ -430,6 +431,7 @@ Shadow::HandleUpdateChannelOptions(const ShadowUpdateChannelOptions &msg) {
   ShadowChannel &channel = it->second;
   channel.has_split_buffer_options = msg.has_split_buffer_options();
   channel.use_split_buffers = msg.use_split_buffers();
+  channel.split_buffers_over_bridge = msg.split_buffers_over_bridge();
   channel.has_max_publishers = msg.has_max_publishers();
   channel.max_publishers = msg.max_publishers();
   return absl::OkStatus();
@@ -498,6 +500,7 @@ absl::Status Shadow::SendStateDump(toolbelt::UnixSocket &socket) {
       msg->set_vchan_id(ch.vchan_id);
       msg->set_has_split_buffer_options(ch.has_split_buffer_options);
       msg->set_use_split_buffers(ch.use_split_buffers);
+      msg->set_split_buffers_over_bridge(ch.split_buffers_over_bridge);
       msg->set_has_max_publishers(ch.has_max_publishers);
       msg->set_max_publishers(ch.max_publishers);
 

--- a/shadow/shadow.h
+++ b/shadow/shadow.h
@@ -58,6 +58,7 @@ struct ShadowChannel {
   int vchan_id = -1;
   bool has_split_buffer_options = false;
   bool use_split_buffers = false;
+  bool split_buffers_over_bridge = false;
   bool has_max_publishers = false;
   int max_publishers = 0;
   toolbelt::FileDescriptor ccb_fd;


### PR DESCRIPTION
## Summary
- Add bridge negotiation for split-buffer framing and independent remote bridge publisher split-buffer mode.
- Preserve legacy single-frame bridge reads/writes when split buffers are not enabled.
- Make bridge tests stable and run them in CI with split buffers both enabled and disabled.

## Test plan
- bazelisk test //client:bridge_test --runs_per_test=100 --test_output=errors
- bazelisk test //client:bridge_test --test_arg=--use_split_buffers=false --test_output=errors
- bazelisk test //client:bridge_test --test_arg=--use_split_buffers=true --test_output=errors
- bazelisk test //client:bridge_test --runs_per_test=30 --test_arg=--use_split_buffers=false --test_output=errors
- bazelisk test //client:bridge_test --runs_per_test=30 --test_arg=--use_split_buffers=true --test_output=errors
- bazelisk test //client:bridge_test //shadow:shadow_test //c_client:client_test //server:server_test