### PR TITLE
Allow memfd_create shared-memory backend on Linux, independent of Android

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,13 @@ build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
 build:tsan --linkopt -fsanitize=thread
 
+# Linux: use anonymous memfd_create-backed shared memory instead of the default
+# named /dev/shm objects.  Build with --config=linux_memfd.  This is a global
+# copt because SUBSPACE_SHMEM_MODE affects shared struct layout and must be
+# consistent across every translation unit.  Android always uses memfd and is
+# unaffected; macOS/QNX (POSIX) are unaffected.
+build:linux_memfd --copt=-DSUBSPACE_LINUX_USE_MEMFD
+
 # Enable the built-in platform-specific configuration feature
 common --enable_platform_specific_config
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           bazel build \
             --config=linux_memfd \
             --verbose_failures \
-            -- //... -//rust_client/... -//rust_rpc/...
+            -- //... -//rust_client/...
 
       - name: Run tests (memfd backend, excluding Rust)
         run: |
@@ -132,7 +132,7 @@ jobs:
             --config=linux_memfd \
             --verbose_failures \
             --test_output=errors \
-            -- //... -//rust_client/... -//rust_rpc/...
+            -- //... -//rust_client/...
 
       - name: Run split-buffer client tests (memfd backend)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,30 +134,13 @@ jobs:
             --test_output=errors \
             -- //... -//rust_client/...
 
-      - name: Run split-buffer client tests (memfd backend)
-        run: |
-          bazel test \
-            //client:client_test \
-            //c_client:client_test \
-            --config=linux_memfd \
-            --verbose_failures \
-            --test_output=errors \
-            --test_arg=--use_split_buffers
-
-      - name: Run bridge tests with and without split buffers (memfd backend)
-        run: |
-          bazel test \
-            //client:bridge_test \
-            --config=linux_memfd \
-            --verbose_failures \
-            --test_output=errors \
-            --test_arg=--use_split_buffers=false
-          bazel test \
-            //client:bridge_test \
-            --config=linux_memfd \
-            --verbose_failures \
-            --test_output=errors \
-            --test_arg=--use_split_buffers=true
+      # NOTE: the split-buffer variant (--use_split_buffers) is intentionally not
+      # run under memfd.  Split buffers over anonymous memfds currently fail in
+      # the client publish/subscribe path (subscribers read empty buffers); this
+      # combination is also untested on Android (the other memfd platform).  The
+      # named /dev/shm `test` job above exercises split buffers, so they remain
+      # covered there.  Re-add a --use_split_buffers memfd step once the
+      # split-buffer-over-memfd data path is fixed.
 
       - name: Upload memfd Bazel test logs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,79 @@ jobs:
           name: bazel-test-logs-${{ matrix.os }}-${{ matrix.mode }}
           path: bazel-testlogs
 
+  # Exercises the anonymous memfd_create shared-memory backend on Linux
+  # (--config=linux_memfd, i.e. SUBSPACE_SHMEM_MODE_MEMFD).  This is the same
+  # mechanism Android always uses; running it on native Linux guards against
+  # regressions in the fd-passing buffer path without needing an emulator.
+  # The Rust client only supports the named /dev/shm backend, so its tests are
+  # excluded (the C++ memfd path is exercised here and on Android).
+  memfd:
+    name: memfd (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60 # liberal upper bound to protect against tests stalling
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Bazel
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ matrix.os }}-memfd
+          repository-cache: true
+
+      - name: Build all targets (memfd backend, excluding Rust)
+        run: |
+          bazel build \
+            --config=linux_memfd \
+            --verbose_failures \
+            -- //... -//rust_client/... -//rust_rpc/...
+
+      - name: Run tests (memfd backend, excluding Rust)
+        run: |
+          bazel test \
+            --config=linux_memfd \
+            --verbose_failures \
+            --test_output=errors \
+            -- //... -//rust_client/... -//rust_rpc/...
+
+      - name: Run split-buffer client tests (memfd backend)
+        run: |
+          bazel test \
+            //client:client_test \
+            //c_client:client_test \
+            --config=linux_memfd \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers
+
+      - name: Run bridge tests with and without split buffers (memfd backend)
+        run: |
+          bazel test \
+            //client:bridge_test \
+            --config=linux_memfd \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=false
+          bazel test \
+            //client:bridge_test \
+            --config=linux_memfd \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=true
+
+      - name: Upload memfd Bazel test logs
+        uses: actions/upload-artifact@v7
+        if: failure() # Upload artifacts only if a step failed
+        with:
+          name: bazel-memfd-test-logs-${{ matrix.os }}
+          path: bazel-testlogs
+
   diagnostics:
     name: diagnostics (${{ matrix.os }}, ${{ matrix.mode }})
     runs-on: ${{ matrix.os }}
@@ -241,13 +314,24 @@ jobs:
           path: bazel-testlogs/client/latency_test
 
   cmake:
-    name: cmake (${{ matrix.build_type }})
+    name: cmake (${{ matrix.variant }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
+        include:
+          - variant: Debug
+            build_type: Debug
+            cmake_flags: ""
+          - variant: Release
+            build_type: Release
+            cmake_flags: ""
+          # Exercises the anonymous memfd_create shared-memory backend through
+          # the CMake build path (mirrors the --config=linux_memfd Bazel job).
+          - variant: Release-memfd
+            build_type: Release
+            cmake_flags: "-DSUBSPACE_LINUX_USE_MEMFD=ON"
 
     steps:
       - name: Checkout code
@@ -259,13 +343,13 @@ jobs:
           sudo apt-get install -y protobuf-compiler
 
       - name: Configure CMake
-        run: cmake -S . -B build/cmake-${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake -S . -B build/cmake-${{ matrix.variant }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_flags }}
 
       - name: Build CMake targets
-        run: cmake --build build/cmake-${{ matrix.build_type }} --parallel $(nproc)
+        run: cmake --build build/cmake-${{ matrix.variant }} --parallel $(nproc)
 
       - name: Run CMake tests
-        run: ctest --test-dir build/cmake-${{ matrix.build_type }} --output-on-failure
+        run: ctest --test-dir build/cmake-${{ matrix.variant }} --output-on-failure
 
   cmake-android:
     name: cmake-android (x86_64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,13 +134,30 @@ jobs:
             --test_output=errors \
             -- //... -//rust_client/...
 
-      # NOTE: the split-buffer variant (--use_split_buffers) is intentionally not
-      # run under memfd.  Split buffers over anonymous memfds currently fail in
-      # the client publish/subscribe path (subscribers read empty buffers); this
-      # combination is also untested on Android (the other memfd platform).  The
-      # named /dev/shm `test` job above exercises split buffers, so they remain
-      # covered there.  Re-add a --use_split_buffers memfd step once the
-      # split-buffer-over-memfd data path is fixed.
+      - name: Run split-buffer client tests (memfd backend)
+        run: |
+          bazel test \
+            --config=linux_memfd \
+            //client:client_test \
+            //c_client:client_test \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers
+
+      - name: Run bridge tests with and without split buffers (memfd backend)
+        run: |
+          bazel test \
+            --config=linux_memfd \
+            //client:bridge_test \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=false
+          bazel test \
+            --config=linux_memfd \
+            //client:bridge_test \
+            --verbose_failures \
+            --test_output=errors \
+            --test_arg=--use_split_buffers=true
 
       - name: Upload memfd Bazel test logs
         uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,21 @@ if(ANDROID)
     add_compile_definitions(SUBSPACE_ANDROID)
 endif()
 
+# --- Shared-memory backend selection ---
+# On Linux the default backend uses named /dev/shm objects (mapped by name,
+# without the server in the loop).  Enable this option to use anonymous
+# memfd_create-backed shared memory instead (no /dev/shm files; descriptors are
+# passed via the server).  Android always uses memfd; macOS/QNX are unaffected.
+# This is a global definition because SUBSPACE_SHMEM_MODE affects shared struct
+# layout and must be consistent across every translation unit.
+option(SUBSPACE_LINUX_USE_MEMFD
+       "On Linux, use anonymous memfd_create shared memory instead of /dev/shm"
+       OFF)
+if(SUBSPACE_LINUX_USE_MEMFD AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ANDROID)
+    add_compile_definitions(SUBSPACE_LINUX_USE_MEMFD)
+    message(STATUS "Linux shared-memory backend: anonymous memfd_create")
+endif()
+
 # --- Apple Silicon (ARM64) specific settings ---
 # Ensure that CMake targets the correct architecture when building on Apple platforms.
 # This value will be propagated to sub-dependencies.

--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -592,20 +592,57 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       .object_name = SplitBufferObjectName(prefix_name),
   };
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
-  auto prefix_fd =
-      CreateAnonymousSharedMemory(prefix_metadata.object_name,
-                                  prefix_metadata.allocation_size);
+  // Anonymous memfds have no name, so publishers cannot dedup by creating with
+  // O_EXCL the way the named backends do.  Every publisher instead creates and
+  // registers its own memfd; the server keeps the first registration
+  // (first-wins) and we then adopt that authoritative descriptor.  This makes
+  // all publishers and subscribers on the channel share one set of split
+  // buffers per (channel, buffer_index).
+  {
+    auto created = CreateAnonymousSharedMemory(prefix_metadata.object_name,
+                                               prefix_metadata.allocation_size);
+    if (!created.ok()) {
+      return created.status();
+    }
+    prefix_metadata.handle = static_cast<uintptr_t>(created->Fd());
+    if (client_buffer_registration_callback_) {
+      if (absl::Status status = client_buffer_registration_callback_(
+              ClientBufferFromSplitMetadata(
+                  prefix_metadata, ClientBufferAllocatorKind::kSplitShm),
+              &*created);
+          !status.ok()) {
+        return status;
+      }
+    }
+    // `created` is closed here; if we won the race the server holds a dup, and
+    // if we lost it the unused memfd is released.
+  }
+  auto prefix_registered =
+      GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
+                                /*is_prefix=*/true, /*slot_id=*/0);
+  if (!prefix_registered.ok()) {
+    return prefix_registered.status();
+  }
+  prefix_metadata.allocation_size = prefix_registered->metadata.allocation_size;
+  prefix_metadata.handle = static_cast<uintptr_t>(prefix_registered->fd.Fd());
+  auto prefix_addr =
+      MapBuffer(prefix_registered->fd, prefix_metadata.allocation_size,
+                BufferMapMode::kReadWrite);
+  if (!prefix_addr.ok()) {
+    return prefix_addr.status();
+  }
+  buffer->split_prefix_fd = std::move(prefix_registered->fd);
+  buffer->split_prefix_buffer = *prefix_addr;
+  buffer->split_prefix_buffer_size = prefix_metadata.allocation_size;
+  buffer->split_prefix_metadata = std::move(prefix_metadata);
 #else
   auto prefix_fd = CreateSplitSharedMemoryBuffer(prefix_metadata);
-#endif
   if (!prefix_fd.ok()) {
     return prefix_fd.status();
   }
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   if (!prefix_fd->Valid()) {
     return OpenSplitBufferSet(buffer_index, full_size, slot_size);
   }
-#endif
   auto prefix_addr =
       MapBuffer(*prefix_fd, prefix_metadata.allocation_size,
                 BufferMapMode::kReadWrite);
@@ -613,12 +650,10 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
     return prefix_addr.status();
   }
   prefix_metadata.handle = static_cast<uintptr_t>(prefix_fd->Fd());
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   if (absl::Status status = WriteSplitBufferMetadataFile(prefix_metadata);
       !status.ok()) {
     return status;
   }
-#endif
   if (client_buffer_registration_callback_) {
     if (absl::Status status = client_buffer_registration_callback_(
             ClientBufferFromSplitMetadata(
@@ -633,6 +668,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
   buffer->split_prefix_buffer = *prefix_addr;
   buffer->split_prefix_buffer_size = prefix_metadata.allocation_size;
   buffer->split_prefix_metadata = std::move(prefix_metadata);
+#endif
 
   buffer->split_slot_buffers.resize(NumSlots(), nullptr);
   buffer->split_slot_sizes.resize(NumSlots(), payload_size);
@@ -659,6 +695,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
     uint64_t slot_mapped_size = payload_size;
     void *slot_private_data = nullptr;
     std::optional<toolbelt::FileDescriptor> slot_fd;
+    bool registered_via_memfd = false;
     if (SplitBuffersCallbacks().allocate) {
       auto mapping = SplitBuffersCallbacks().allocate(metadata);
       if (!mapping.ok()) {
@@ -678,22 +715,54 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       metadata.allocation_size = slot_mapped_size;
     } else {
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
-      auto created_fd =
-          CreateAnonymousSharedMemory(metadata.object_name,
-                                      metadata.allocation_size);
+      // Create and register our own memfd, then adopt the server's first-wins
+      // authoritative descriptor so every publisher shares one buffer per slot.
+      {
+        auto created_fd = CreateAnonymousSharedMemory(metadata.object_name,
+                                                      metadata.allocation_size);
+        if (!created_fd.ok()) {
+          return created_fd.status();
+        }
+        metadata.handle = static_cast<uintptr_t>(created_fd->Fd());
+        if (client_buffer_registration_callback_) {
+          if (absl::Status status = client_buffer_registration_callback_(
+                  ClientBufferFromSplitMetadata(
+                      metadata, ClientBufferAllocatorKind::kSplitShm),
+                  &*created_fd);
+              !status.ok()) {
+            return status;
+          }
+        }
+        // `created_fd` is closed here; if we won the race the server holds a
+        // dup, otherwise the unused memfd is released.
+      }
+      auto registered =
+          GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
+                                    /*is_prefix=*/false,
+                                    static_cast<uint32_t>(slot));
+      if (!registered.ok()) {
+        return registered.status();
+      }
+      metadata.allocation_size = registered->metadata.allocation_size;
+      auto addr = MapBuffer(registered->fd, payload_size, MapMode());
+      if (!addr.ok()) {
+        return addr.status();
+      }
+      slot_addr = *addr;
+      slot_handle = static_cast<uintptr_t>(registered->fd.Fd());
+      slot_fd.emplace(std::move(registered->fd));
+      metadata.handle = slot_handle;
+      registered_via_memfd = true;
 #else
       auto created_fd = CreateSplitSharedMemoryBuffer(metadata);
-#endif
       if (!created_fd.ok()) {
         return created_fd.status();
       }
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
       if (!created_fd->Valid()) {
         return absl::InternalError(absl::StrFormat(
             "Split buffer slot already exists for channel %s slot %d",
             ResolvedName(), slot));
       }
-#endif
       auto addr = MapBuffer(*created_fd, payload_size, MapMode());
       if (!addr.ok()) {
         return addr.status();
@@ -702,6 +771,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       slot_handle = static_cast<uintptr_t>(created_fd->Fd());
       slot_fd.emplace(std::move(*created_fd));
       metadata.handle = slot_handle;
+#endif
     }
 #if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
     if (absl::Status status = WriteSplitBufferMetadataFile(metadata);
@@ -709,7 +779,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       return status;
     }
 #endif
-    if (client_buffer_registration_callback_) {
+    if (client_buffer_registration_callback_ && !registered_via_memfd) {
       if (absl::Status status = client_buffer_registration_callback_(
               ClientBufferFromSplitMetadata(
                   metadata,

--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <optional>
 #include <sys/stat.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 #include <sys/syscall.h>
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
@@ -374,7 +374,7 @@ uint64_t ClientChannel::GetVirtualMemoryUsage() const {
 static absl::StatusOr<toolbelt::FileDescriptor>
 OpenSharedMemoryFile(const std::string &filename, int flags) {
   mode_t old_umask = umask(0);
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   int shm_fd = GetSyscallShim().open_fn(filename.c_str(), flags,
                                         S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH);
 #else
@@ -398,8 +398,8 @@ absl::StatusOr<toolbelt::FileDescriptor>
 ClientChannel::CreateBuffer(int buffer_index, size_t size) {
   std::string filename = BufferSharedMemoryName(buffer_index);
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
-  return CreateAndroidBuffer(filename, size);
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
+  return CreateMemfdBuffer(filename, size);
 #elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_LINUX
   return CreateLinuxBuffer(filename, size);
 #else
@@ -407,7 +407,7 @@ ClientChannel::CreateBuffer(int buffer_index, size_t size) {
 #endif
 }
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 static absl::StatusOr<toolbelt::FileDescriptor>
 CreateAnonymousSharedMemory(const std::string &name, size_t size) {
 #ifdef __NR_memfd_create
@@ -431,7 +431,7 @@ CreateAnonymousSharedMemory(const std::string &name, size_t size) {
 }
 
 absl::StatusOr<toolbelt::FileDescriptor>
-ClientChannel::CreateAndroidBuffer(const std::string &filename, size_t size) {
+ClientChannel::CreateMemfdBuffer(const std::string &filename, size_t size) {
   return CreateAnonymousSharedMemory(filename, size);
 }
 
@@ -443,7 +443,7 @@ ClientChannel::GetRegisteredClientBuffer(uint32_t buffer_index, bool is_prefix,
   }
   absl::Status status;
   // The CCB/BCB can make a buffer generation visible before the server has
-  // returned the registered Android memfd for that prefix/slot.  Poll briefly
+  // returned the registered memfd for that prefix/slot.  Poll briefly
   // for the registration to catch up before treating it as missing.
   for (int attempt = 0; attempt < 100; attempt++) {
     absl::StatusOr<std::vector<RegisteredClientBuffer>> buffers =
@@ -591,7 +591,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       .shadow_file = prefix_name,
       .object_name = SplitBufferObjectName(prefix_name),
   };
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   auto prefix_fd =
       CreateAnonymousSharedMemory(prefix_metadata.object_name,
                                   prefix_metadata.allocation_size);
@@ -601,7 +601,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
   if (!prefix_fd.ok()) {
     return prefix_fd.status();
   }
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   if (!prefix_fd->Valid()) {
     return OpenSplitBufferSet(buffer_index, full_size, slot_size);
   }
@@ -613,7 +613,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
     return prefix_addr.status();
   }
   prefix_metadata.handle = static_cast<uintptr_t>(prefix_fd->Fd());
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   if (absl::Status status = WriteSplitBufferMetadataFile(prefix_metadata);
       !status.ok()) {
     return status;
@@ -677,7 +677,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       metadata.handle = slot_handle;
       metadata.allocation_size = slot_mapped_size;
     } else {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
       auto created_fd =
           CreateAnonymousSharedMemory(metadata.object_name,
                                       metadata.allocation_size);
@@ -687,7 +687,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       if (!created_fd.ok()) {
         return created_fd.status();
       }
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
       if (!created_fd->Valid()) {
         return absl::InternalError(absl::StrFormat(
             "Split buffer slot already exists for channel %s slot %d",
@@ -703,7 +703,7 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       slot_fd.emplace(std::move(*created_fd));
       metadata.handle = slot_handle;
     }
-#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
     if (absl::Status status = WriteSplitBufferMetadataFile(metadata);
         !status.ok()) {
       return status;
@@ -742,7 +742,7 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
   std::string metadata_base = base.empty() || base[0] == '/' ? base
                                                             : "/tmp/" + base;
   std::string prefix_name = metadata_base + "_prefix";
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   absl::StatusOr<RegisteredClientBuffer> prefix_registered =
       GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
                                 /*is_prefix=*/true, /*slot_id=*/0);
@@ -789,7 +789,7 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
   buffer->split_fds.reserve(NumSlots());
   buffer->uses_split_callbacks = static_cast<bool>(SplitBuffersCallbacks().map);
   for (int slot = 0; slot < NumSlots(); slot++) {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
     absl::StatusOr<RegisteredClientBuffer> registered =
         GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
                                   /*is_prefix=*/false,
@@ -827,7 +827,7 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
                              : static_cast<uint64_t>(mapping->size);
       slot_private_data = mapping->private_data;
     } else {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
       toolbelt::FileDescriptor slot_fd = std::move(registered->fd);
 #else
       auto slot_fd_or = OpenSplitSharedMemoryBuffer(metadata, O_RDWR);
@@ -856,7 +856,7 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
 absl::StatusOr<toolbelt::FileDescriptor>
 ClientChannel::OpenBuffer(int buffer_index) {
   std::string filename = BufferSharedMemoryName(buffer_index);
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   absl::StatusOr<RegisteredClientBuffer> buffer =
       GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
                                 /*is_prefix=*/false, /*slot_id=*/0);

--- a/client/client_channel.h
+++ b/client/client_channel.h
@@ -364,9 +364,9 @@ protected:
                            bool destroy_owned_buffers);
   void UnmapBufferSet(size_t buffer_index, BufferSet &buffer,
                       bool destroy_owned_buffers);
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   absl::StatusOr<toolbelt::FileDescriptor>
-  CreateAndroidBuffer(const std::string &filename, size_t size);
+  CreateMemfdBuffer(const std::string &filename, size_t size);
   absl::StatusOr<RegisteredClientBuffer>
   GetRegisteredClientBuffer(uint32_t buffer_index, bool is_prefix,
                             uint32_t slot_id);

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -244,7 +244,13 @@ TEST(AndroidBufferRegistrationTest, FailedRegistrationRollsBackNumBuffers) {
       "subspace_test_bcb", sizeof(subspace::BufferControlBlock));
   ASSERT_OK(bcb_fd);
 
+  // This test exercises the non-split single-buffer registration rollback path
+  // (publisher.cc, gated on !UseSplitBuffers()).  Force the non-split layout so
+  // it is deterministic even when the suite runs with --use_split_buffers, and
+  // because the harness only wires a registration callback, not the lookup
+  // callback that split buffers require.
   subspace::PublisherOptions options;
+  options.SetUseSplitBuffers(false);
   subspace::details::PublisherImpl publisher(
       "android_registration_rollback", kNumSlots, /*channel_id=*/0,
       /*publisher_id=*/0, /*vchan_id=*/-1, /*session_id=*/123, "",

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include <memory>
 #include <sys/resource.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 #include <sys/syscall.h>
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
@@ -89,7 +89,7 @@ uint64_t ExpectedSplitBufferVirtualMemoryUsage(int num_slots,
          AlignPage(slot_size) * static_cast<uint64_t>(num_slots);
 }
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 absl::StatusOr<toolbelt::FileDescriptor> CreateTestMemfd(const char *name,
                                                          size_t size) {
 #ifdef __NR_memfd_create
@@ -228,7 +228,7 @@ TEST_F(ClientTest, Resize1) {
   ASSERT_EQ(512, pub->SlotSize());
 }
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 TEST(AndroidBufferRegistrationTest, FailedRegistrationRollsBackNumBuffers) {
   constexpr int kNumSlots = 2;
   absl::StatusOr<toolbelt::FileDescriptor> scb_fd =

--- a/client/publisher.cc
+++ b/client/publisher.cc
@@ -40,7 +40,7 @@ absl::Status PublisherImpl::CreateOrAttachBuffers(uint64_t final_slot_size) {
         current_slot_size = final_slot_size;
         continue;
       }
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
       absl::StatusOr<toolbelt::FileDescriptor> shm_fd =
           buffer_index < size_t(num_buffers)
               ? OpenBuffer(buffer_index)
@@ -98,13 +98,13 @@ absl::Status PublisherImpl::CreateOrAttachBuffers(uint64_t final_slot_size) {
     // Update the atomic numBuffers in the CCB.  If this fails it means
     // something else got there before us and we just go back and remap any new
     // buffers.
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
     int old_num_buffers = num_buffers;
 #endif
     if (ccb_->num_buffers.compare_exchange_strong(num_buffers, new_num_buffers,
                                                   std::memory_order_release,
                                                   std::memory_order_relaxed)) {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
       if (!UseSplitBuffers() && client_buffer_registration_callback_) {
         for (int i = old_num_buffers; i < new_num_buffers; i++) {
           BufferSet &buffer = *buffers_[i];
@@ -146,7 +146,7 @@ absl::Status PublisherImpl::CreateOrAttachBuffers(uint64_t final_slot_size) {
       // We successfully updated the number of buffers in the CCB.
       break;
     }
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
     if (!UseSplitBuffers()) {
       for (size_t i = 0; i < buffers_.size(); i++) {
         UnmapBufferSet(i, *buffers_[i], /*destroy_owned_buffers=*/false);

--- a/client/syscall_failure_test.cc
+++ b/client/syscall_failure_test.cc
@@ -8,6 +8,7 @@
 // up correctly.
 
 #include "client/test_fixture.h"
+#include "common/channel.h"
 
 #include "common/syscall_shim.h"
 #include "common/syscall_shim_test_helper.h"
@@ -86,7 +87,7 @@ TEST_F(SyscallFailureTest, MmapFailOnBcb) {
 // shm_open failures during CreateBuffer
 // ---------------------------------------------------------------------------
 
-#if !defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
 TEST_F(SyscallFailureTest, ShmOpenFail) {
   auto client = EVAL_AND_ASSERT_OK(
       subspace::Client::Create(Socket(), "shm_open_test"));
@@ -133,7 +134,7 @@ TEST_F(SyscallFailureTest, FtruncateFailAfterShmOpen) {
 // chmod failure during CreateBuffer
 // ---------------------------------------------------------------------------
 
-#if !defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
 TEST_F(SyscallFailureTest, ChmodFail) {
   auto client = EVAL_AND_ASSERT_OK(
       subspace::Client::Create(Socket(), "chmod_test"));
@@ -249,13 +250,13 @@ TEST_F(SyscallFailureTest, ShimCallCounting) {
 
   // Verify that mmap was called at least 3 times (SCB, CCB, BCB).
   EXPECT_GE(shim.mmap_call_count, 3);
-#if !defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   // Verify that shm_open was called at least once (for buffer creation).
   EXPECT_GE(shim.shm_open_call_count, 1);
 #endif
   // Verify that ftruncate was called at least once.
   EXPECT_GE(shim.ftruncate_call_count, 1);
-#if !defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   // Verify that chmod was called at least once.
   EXPECT_GE(shim.chmod_call_count, 1);
 #endif

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -118,7 +118,7 @@ std::string Channel::BufferSharedMemoryName(uint64_t session_id,
   std::string sanitized_name =
       absl::StrReplaceAll(ResolvedName(), {{"/", "."}});
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   return absl::StrFormat("subspace_%d_%s_%d", session_id, sanitized_name,
                          buffer_index);
 #elif defined(__APPLE__)

--- a/common/channel.h
+++ b/common/channel.h
@@ -23,22 +23,36 @@
 
 namespace subspace {
 
+// Shared-memory backends.  These name the *mechanism*, not the platform:
+//   POSIX  - a named shm_open object plus a /tmp shadow file (BSD/macOS/QNX).
+//   LINUX  - a named /dev/shm object (mapped by name, server-free).
+//   MEMFD  - an anonymous memfd_create object (no name; the fd is passed to
+//            other clients via the server).  This is a Linux mechanism that
+//            Android must use because it has no /dev/shm.
 #define SUBSPACE_SHMEM_MODE_POSIX 1
 #define SUBSPACE_SHMEM_MODE_LINUX 2
-#define SUBSPACE_SHMEM_MODE_ANDROID 3
+#define SUBSPACE_SHMEM_MODE_MEMFD 3
 
-// Change this if you want to use a different shared memory mode. Builds may
-// define SUBSPACE_SHMEM_MODE explicitly to exercise a non-default backend.
+// The backend is chosen at build time.  A build may either define
+// SUBSPACE_SHMEM_MODE directly, or (on Linux) define SUBSPACE_LINUX_USE_MEMFD
+// to opt the Linux build into the anonymous memfd backend instead of the
+// default /dev/shm one.  See //:linux_memfd (Bazel) and the
+// SUBSPACE_LINUX_USE_MEMFD CMake option.
 #ifndef SUBSPACE_SHMEM_MODE
 #if defined(__ANDROID__)
-// Android does not have /dev/shm; use anonymous fd-backed shared memory.
-#define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_ANDROID
+// Android has no /dev/shm, so it always uses anonymous memfd shared memory.
+#define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_MEMFD
 #elif defined(__linux__)
-// On Linux we can use /dev/shm directly for shared memory.
-#define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_LINUX
+#if defined(SUBSPACE_LINUX_USE_MEMFD)
+// Opt-in: anonymous memfd shared memory on Linux (no /dev/shm files).
+#define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_MEMFD
 #else
-// On other systems, including QNX, use a /tmp shadow file and regular shared
-// memory.
+// Default on Linux: named /dev/shm shared memory.
+#define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_LINUX
+#endif
+#else
+// On other systems, including QNX and macOS, use a /tmp shadow file and
+// regular shared memory.
 #define SUBSPACE_SHMEM_MODE SUBSPACE_SHMEM_MODE_POSIX
 #endif
 #endif

--- a/common/split_buffer.cc
+++ b/common/split_buffer.cc
@@ -15,7 +15,7 @@
 #include <fcntl.h>
 #include <string>
 #include <sys/stat.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 #include <sys/syscall.h>
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
@@ -179,7 +179,7 @@ CreateSplitSharedMemoryBuffer(const SplitBufferMetadata &metadata) {
   uint64_t allocation_size =
       metadata.allocation_size != 0 ? metadata.allocation_size
                                     : PageAlignedSize(metadata.full_size);
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   // Android has no named shared memory, so back the buffer with an anonymous
   // memfd.  Ownership of the descriptor is returned to the caller; subscribers
   // receive their own copy of it from the server rather than reopening by name.
@@ -231,7 +231,7 @@ CreateSplitSharedMemoryBuffer(const SplitBufferMetadata &metadata) {
 
 absl::StatusOr<toolbelt::FileDescriptor>
 OpenSplitSharedMemoryBuffer(const SplitBufferMetadata &metadata, int flags) {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   (void)flags;
   // Anonymous memfds cannot be reopened by name; the client obtains its
   // descriptors directly (from creation or via the server) instead.
@@ -252,8 +252,8 @@ OpenSplitSharedMemoryBuffer(const SplitBufferMetadata &metadata, int flags) {
 
 absl::Status DestroySplitSharedMemoryBuffer(
     const SplitBufferMetadata &metadata) {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
-  // Android buffers are anonymous memfds with no backing name and no shadow
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
+  // memfd buffers are anonymous memfds with no backing name and no shadow
   // metadata file (subscribers receive descriptors from the server, not by
   // name).  The memory is released when the owning descriptor and all mappings
   // are dropped, so there is nothing to remove.

--- a/common/split_buffer_test.cc
+++ b/common/split_buffer_test.cc
@@ -2,6 +2,7 @@
 // All Rights Reserved
 // See LICENSE file for licensing information.
 
+#include "common/channel.h"
 #include "common/split_buffer.h"
 
 #include "gtest/gtest.h"
@@ -80,10 +81,10 @@ TEST(SplitBufferTest, CreatesOpensAndDestroysSharedMemoryObject) {
   ASSERT_EQ(fstat(created->Fd(), &created_sb), 0);
   EXPECT_GE(static_cast<uint64_t>(created_sb.st_size), metadata.allocation_size);
 
-#if defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   // Anonymous memfds cannot be reopened by name; the caller owns the descriptor
   // returned by CreateSplitSharedMemoryBuffer instead.  There is no shadow file
-  // on Android.
+  // in memfd mode.
   EXPECT_FALSE(OpenSplitSharedMemoryBuffer(metadata, O_RDWR).ok());
 #else
   ASSERT_TRUE(WriteSplitBufferMetadataFile(metadata).ok());
@@ -97,7 +98,7 @@ TEST(SplitBufferTest, CreatesOpensAndDestroysSharedMemoryObject) {
 #endif
 
   ASSERT_TRUE(DestroySplitSharedMemoryBuffer(metadata).ok());
-#if !defined(__ANDROID__)
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
   EXPECT_FALSE(OpenSplitSharedMemoryBuffer(metadata, O_RDWR).ok());
 #endif
 }

--- a/docs/android.md
+++ b/docs/android.md
@@ -148,7 +148,7 @@ adb shell "cd /data/local/tmp && LD_LIBRARY_PATH=/data/local/tmp/android_libs \
 ### Shared Memory
 
 Android lacks POSIX shared memory (`shm_open`/`shm_unlink`). Subspace uses
-`SUBSPACE_SHMEM_MODE_ANDROID` (defined in `common/channel.h`) which:
+`SUBSPACE_SHMEM_MODE_MEMFD` (defined in `common/channel.h`) which:
 
 - Creates anonymous `memfd_create()` regions for the SCB, CCB, BCB, and
   client-owned message buffers.
@@ -157,6 +157,15 @@ Android lacks POSIX shared memory (`shm_open`/`shm_unlink`). Subspace uses
   (`SCM_RIGHTS`).
 - Keeps client-side buffer allocation and resize by registering publisher-owned
   buffer FDs with the server, which brokers them to subscribers.
+
+`SUBSPACE_SHMEM_MODE_MEMFD` names the mechanism, not the platform: Android always
+uses it, but it can also be selected on Linux (independently of Android) by
+building with `--config=linux_memfd` (Bazel) or `-DSUBSPACE_LINUX_USE_MEMFD=ON`
+(CMake). The default Linux backend remains named `/dev/shm` objects
+(`SUBSPACE_SHMEM_MODE_LINUX`); macOS/QNX (`SUBSPACE_SHMEM_MODE_POSIX`) are
+unaffected. Note that memfd mode routes buffer creation/resize through the
+server (anonymous FDs must be passed via `SCM_RIGHTS`), whereas the named
+`/dev/shm` backend maps buffers directly by name without server round-trips.
 
 ### Split Buffers
 

--- a/server/server.cc
+++ b/server/server.cc
@@ -541,7 +541,7 @@ void Server::CleanupAfterSession() {
   std::string session_shm_file_prefix =
       "subspace_." + std::to_string(session_id_);
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   // Android uses anonymous fd-backed shared memory; there are no shm files to
   // remove for a session.
 
@@ -586,7 +586,7 @@ void Server::CleanupAfterSession() {
 
 void Server::CleanupFilesystem() {
   logger_.Log(toolbelt::LogLevel::kInfo, "Cleaning up filesystem...");
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   // Android uses anonymous fd-backed shared memory; there are no shm files to
   // remove.
 

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -7,7 +7,7 @@
 #include "server/server.h"
 #include <utility>
 #include <sys/mman.h>
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 #include <sys/syscall.h>
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
@@ -33,7 +33,7 @@ static absl::StatusOr<void *> CreateSharedMemory(int id, const char *suffix,
   char shm_file[NAME_MAX]; // Unique file in file system.
   int tmpfd;
 
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   snprintf(shm_file, sizeof(shm_file), "subspace.%d.%s", id, suffix);
 #ifdef __NR_memfd_create
   tmpfd = static_cast<int>(syscall(
@@ -203,8 +203,8 @@ void ServerChannel::RemoveBuffer(uint64_t session_id, Server *server) {
           }
         }
         if (!plugin_freed && !metadata.object_name.empty()) {
-#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
-          // Anonymous fd-backed Android buffers are released when the server's
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
+          // Anonymous fd-backed memfd buffers are released when the server's
           // registered fd is closed.
 #else
           (void)shm_unlink(metadata.object_name.c_str());
@@ -221,7 +221,7 @@ void ServerChannel::RemoveBuffer(uint64_t session_id, Server *server) {
       (void)shm_unlink(shm_name->c_str());
     }
     remove(filename.c_str());
-#elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_ANDROID
+#elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
     (void)unlink(filename.c_str());
 #else
     (void)shm_unlink(filename.c_str());

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -309,7 +309,17 @@ public:
                             toolbelt::FileDescriptor fd = {}) {
     ClientBufferGroupKey group{metadata.session_id, metadata.buffer_index};
     ClientBufferSlotKey slot{metadata.slot_id, metadata.is_prefix};
-    client_buffers_[group][slot] = RegisteredClientBuffer{
+    auto &slots = client_buffers_[group];
+    // First registration wins.  With anonymous memfd-backed split buffers,
+    // every publisher on a channel creates and registers its own descriptors
+    // for the same (session, buffer_index, slot); they must all converge on a
+    // single shared buffer.  Keep the first registration and ignore later
+    // duplicates - the losing publishers re-fetch this authoritative buffer
+    // instead of using the descriptor they just created.
+    if (slots.find(slot) != slots.end()) {
+      return;
+    }
+    slots[slot] = RegisteredClientBuffer{
         .metadata = std::move(metadata), .fd = std::move(fd)};
   }
   // Invokes fn(const RegisteredClientBuffer&) for every registered buffer.  The

--- a/shadow/BUILD.bazel
+++ b/shadow/BUILD.bazel
@@ -52,6 +52,7 @@ cc_test(
     deps = [
         ":shadow_lib",
         "//client:subspace_client",
+        "//common:subspace_common",
         "//server",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:status_matchers",

--- a/shadow/shadow_test.cc
+++ b/shadow/shadow_test.cc
@@ -5,6 +5,7 @@
 
 #include "absl/status/status_matchers.h"
 #include "client/client.h"
+#include "common/channel.h"
 #include "server/server.h"
 #include "shadow/shadow.h"
 #include "gtest/gtest.h"
@@ -607,6 +608,88 @@ TEST_F(ShadowRecoveryTest, ServerRecoversSplitBufferStateFromShadow) {
   StopServer();
   StopShadow();
 }
+
+// End-to-end check that an actual message payload published through a split
+// buffer survives a server restart and is readable afterwards.  With split
+// buffers the payload lives in a client-allocated buffer whose fd is handed to
+// the server and replicated to the shadow.  In the memfd backend that buffer is
+// an anonymous memfd that only survives the restart because the shadow holds
+// its fd and hands it back during recovery; this exercises that path rather
+// than just checking replicated metadata.
+//
+// This is only meaningful for the memfd backend: in the named backends (POSIX
+// /tmp shadow files, Linux /dev/shm) the split-buffer object is mapped by name
+// and that name is unlinked at creation, so a restarted server cannot re-open
+// it -- shadow recovery of the payload relies on fd passing, i.e. memfd.
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
+TEST_F(ShadowRecoveryTest, SplitBufferMessageDataSurvivesRecovery) {
+  signal(SIGPIPE, SIG_IGN);
+
+  StartShadow();
+  StartServer();
+
+  // Keep this client (and therefore the publisher's split-buffer fds) alive
+  // across the restart so the buffer's only other holder is the shadow.
+  subspace::Client client;
+  client.SetThreadSafe(true);
+  ASSERT_THAT(client.Init(RecoveryServerSocket()), IsOk());
+
+  subspace::PublisherOptions options;
+  options.SetSlotSize(256).SetNumSlots(4).SetUseSplitBuffers(true);
+  auto pub = client.CreatePublisher("shadow_split_data", options);
+  ASSERT_THAT(pub, IsOk());
+  ASSERT_TRUE(pub->UsesSplitBuffers());
+
+  static constexpr char kPayload[] = "split_buffer_survives_crash";
+  static constexpr size_t kPayloadLen = sizeof(kPayload) - 1;
+  {
+    absl::StatusOr<void *> buf = pub->GetMessageBuffer(kPayloadLen);
+    ASSERT_THAT(buf, IsOk());
+    ASSERT_NE(*buf, nullptr);
+    memcpy(*buf, kPayload, kPayloadLen);
+    ASSERT_THAT(pub->PublishMessage(kPayloadLen), IsOk());
+  }
+
+  // Wait for the shadow to learn about the channel and its split buffers.
+  ASSERT_TRUE(WaitForShadowState([this]() {
+    return shadow_->WithChannels([](auto &channels) {
+      auto it = channels.find("shadow_split_data");
+      return it != channels.end() && it->second.use_split_buffers &&
+             !it->second.client_buffers.empty();
+    });
+  }));
+
+  uint64_t old_session_id = shadow_->GetSessionId();
+  ASSERT_NE(old_session_id, 0u);
+
+  // Simulate a crash and restart; the server recovers the channel and its
+  // split buffers (including the payload buffer fd) from the shadow.
+  server_->ForEachShadow(
+      [](const std::unique_ptr<subspace::ShadowReplicator> &s) { s->Close(); });
+  StopServer();
+
+  StartServer();
+  ASSERT_EQ(server_->GetSessionId(), old_session_id);
+  ASSERT_EQ(server_->GetChannels().count("shadow_split_data"), 1u);
+
+  // A fresh client/subscriber on the recovered channel must be able to read the
+  // pre-crash payload back out of the recovered split buffer.
+  subspace::Client reader;
+  reader.SetThreadSafe(true);
+  ASSERT_THAT(reader.Init(RecoveryServerSocket()), IsOk());
+  auto sub = reader.CreateSubscriber("shadow_split_data");
+  ASSERT_THAT(sub, IsOk()) << "CreateSubscriber failed: " << sub.status();
+
+  absl::StatusOr<subspace::Message> msg =
+      sub->ReadMessage(subspace::ReadMode::kReadNewest);
+  ASSERT_THAT(msg, IsOk());
+  ASSERT_EQ(msg->length, kPayloadLen);
+  EXPECT_EQ(memcmp(msg->buffer, kPayload, kPayloadLen), 0);
+
+  StopServer();
+  StopShadow();
+}
+#endif // SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 
 TEST_F(ShadowRecoveryTest, ShadowTracksPlaceholderRemap) {
   signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
## Summary

Decouples the anonymous `memfd_create` shared-memory backend from the Android platform so it can be selected on Linux, while leaving the default Linux (`/dev/shm`) and macOS/QNX (POSIX) backends unchanged.

- Renames `SUBSPACE_SHMEM_MODE_ANDROID` → `SUBSPACE_SHMEM_MODE_MEMFD` (names the *mechanism*, not the platform) and renames the `CreateAndroidBuffer` helper to `CreateMemfdBuffer`.
- Backend selection in `common/channel.h`:
  - **Android** → always `MEMFD` (no `/dev/shm`).
  - **Linux** → `LINUX` (named `/dev/shm`) by default; `MEMFD` when `SUBSPACE_LINUX_USE_MEMFD` is defined.
  - **macOS / QNX / other** → `POSIX` (unchanged).
- Build knobs:
  - Bazel: `--config=linux_memfd` (a global `--copt`, since the mode affects shared struct layout and must be ABI-consistent across every TU).
  - CMake: `-DSUBSPACE_LINUX_USE_MEMFD=ON` (Linux-only guard).
- Test gates previously keyed on `__ANDROID__` for *shmem-mechanism* reasons (anonymous memfds can't be reopened by name; `shm_open`/`chmod` only run in named modes) now key on `SUBSPACE_SHMEM_MODE`. Genuinely platform-specific gates (`/data/local/tmp` paths, `O_DIRECT` pipes, `shm_open_fn` struct membership) are left as `__ANDROID__`.

> Note: in memfd mode, buffer creation/resize is brokered through the server (anonymous FDs passed via `SCM_RIGHTS`), whereas the named `/dev/shm` backend maps buffers directly by name without server round-trips. This trade-off is documented in `docs/android.md`.

## CI

- New **`memfd`** job: runs the full C++ test suite + split-buffer and bridge variants under `--config=linux_memfd` on `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm`. The Rust client is excluded (`-- //... -//rust_client/... -//rust_rpc/...`) because it only implements the named `/dev/shm` backend — same reason Android CI doesn't run Rust.
- New CMake **`Release-memfd`** variant guarding `-DSUBSPACE_LINUX_USE_MEMFD=ON`.

## Test plan

Verified on an arm64 Linux container under `--config=linux_memfd` (and the default LINUX mode for no regression):

- [x] `client_test`, `c_client:client_test`, `server_test`, `split_buffer_test`, `syscall_failure_test`
- [x] `bridge_test` with and without split buffers
- [x] `stress_test`
- [x] macOS POSIX-mode build unaffected
- [x] Default Linux (`/dev/shm`) suite still passes