### PR TITLE
Add asynchronous RPC support to co::Coroutine rpc server

### DIFF
--- a/rpc/server/rpc_server.cc
+++ b/rpc/server/rpc_server.cc
@@ -5,7 +5,10 @@
 #include "rpc/server/rpc_server.h"
 #include "proto/subspace.pb.h"
 #include <inttypes.h>
+#include <poll.h>
 #include <stdio.h>
+#include <unistd.h>
+#include <vector>
 
 namespace subspace {
 
@@ -42,15 +45,22 @@ absl::Status RpcServer::RegisterMethod(
                                google::protobuf::Any *, co::Coroutine *)>
         callback,
     MethodOptions &&options) {
-  if (methods_.find(method) != methods_.end()) {
-    return absl::AlreadyExistsError("Method already registered: " + method);
-  }
-
-  methods_[method] = std::make_shared<Method>(
-      this, method, std::string{request_type}, std::string{response_type}, options.slot_size,
-      options.num_slots, std::move(callback),
-      options.id == -1 ? ++next_method_id_ : options.id);
-  return absl::OkStatus();
+  return RegisterMethodAsync(
+      method,
+      [method, callback = std::move(callback)](
+          const google::protobuf::Any &req, co::Coroutine *c,
+          std::function<void(std::unique_ptr<google::protobuf::Any>)> reply,
+          std::function<void(std::string)> error_reply) {
+        auto res = std::make_unique<google::protobuf::Any>();
+        auto status = callback(req, res.get(), c);
+        if (!status.ok()) {
+          error_reply(absl::StrFormat("Error executing method %s: %s", method,
+                                      status.ToString()));
+          return;
+        }
+        reply(std::move(res));
+      },
+      std::move(options), request_type, response_type);
 }
 
 // Register void method.
@@ -59,23 +69,43 @@ absl::Status RpcServer::RegisterMethod(
     std::function<absl::Status(const google::protobuf::Any &, co::Coroutine *)>
         callback,
     MethodOptions &&options) {
-  if (methods_.find(method) != methods_.end()) {
-    return absl::AlreadyExistsError("Method already registered: " + method);
-  }
-  methods_[method] = std::make_shared<Method>(
-      this, method, std::string{request_type}, "subspace.VoidMessage", options.slot_size,
-      options.num_slots,
-      [callback](const google::protobuf::Any &req, google::protobuf::Any *res,
-                 co::Coroutine *c) {
+  return RegisterMethodAsync(
+      method,
+      [method, callback = std::move(callback)](
+          const google::protobuf::Any &req, co::Coroutine *c,
+          std::function<void(std::unique_ptr<google::protobuf::Any>)> reply,
+          std::function<void(std::string)> error_reply) {
         auto status = callback(req, c);
         if (!status.ok()) {
-          return status;
+          error_reply(absl::StrFormat("Error executing method %s: %s", method,
+                                      status.ToString()));
+          return;
         }
         // The response for this void method is a VoidMessage packed
         // into a google.protobuf.Any.
+        auto res = std::make_unique<google::protobuf::Any>();
         res->PackFrom(VoidMessage());
-        return absl::OkStatus();
+        reply(std::move(res));
       },
+      std::move(options), request_type, "subspace.VoidMessage");
+}
+
+absl::Status RpcServer::RegisterMethodAsync(
+    const std::string &method,
+    std::function<void(
+        const google::protobuf::Any &, co::Coroutine *,
+        std::function<void(std::unique_ptr<google::protobuf::Any>)>,
+        std::function<void(std::string)>)>
+        callback,
+    MethodOptions &&options, std::string_view request_type,
+    std::string_view response_type) {
+  if (methods_.find(method) != methods_.end()) {
+    return absl::AlreadyExistsError("Method already registered: " + method);
+  }
+
+  methods_[method] = std::make_shared<Method>(
+      this, method, std::string{request_type}, std::string{response_type},
+      options.slot_size, options.num_slots, std::move(callback),
       options.id == -1 ? ++next_method_id_ : options.id);
   return absl::OkStatus();
 }
@@ -441,20 +471,50 @@ RpcServer::CreateSession(uint64_t client_id) {
 
     session->methods.insert({method->id, method_instance});
 
-    AddCoroutine(std::make_unique<co::Coroutine>(
-        *scheduler_,
-        [server = shared_from_this(), session,
-         method_instance](co::Coroutine *c) {
-          if (method_instance->method->IsStreaming()) {
+    if (method->IsStreaming()) {
+      AddCoroutine(std::make_unique<co::Coroutine>(
+          *scheduler_,
+          [server = shared_from_this(), session,
+           method_instance](co::Coroutine *c) {
             SessionStreamingMethodCoroutine(std::move(server), session,
                                             method_instance, c);
-          } else {
-            SessionMethodCoroutine(std::move(server), session, method_instance,
-                                   c);
-          }
-        },
-        absl::StrFormat("Session %d Method %s", session->session_id,
-                        method->name.c_str())));
+          },
+          absl::StrFormat("Session %d Method %s", session->session_id,
+                          method->name.c_str())));
+    } else {
+      // Non-streaming methods use a two-coroutine pipeline: a request
+      // coroutine that invokes the (possibly async) handler and a response
+      // coroutine that publishes completed replies.  They communicate via a
+      // SharedPtrPipe of ReplyItems.
+      auto pipe = toolbelt::SharedPtrPipe<internal::ReplyItem>::Create();
+      if (!pipe.ok()) {
+        logger_.Log(toolbelt::LogLevel::kError,
+                    "Failed to create reply queue for method %s: %s",
+                    method->name.c_str(), pipe.status().ToString().c_str());
+        return pipe.status();
+      }
+      method_instance->reply_queue =
+          std::make_shared<internal::ReplyQueue>(std::move(*pipe));
+
+      AddCoroutine(std::make_unique<co::Coroutine>(
+          *scheduler_,
+          [server = shared_from_this(), session,
+           method_instance](co::Coroutine *c) {
+            SessionRequestCoroutine(std::move(server), session, method_instance,
+                                    c);
+          },
+          absl::StrFormat("Session %d Method %s request", session->session_id,
+                          method->name.c_str())));
+      AddCoroutine(std::make_unique<co::Coroutine>(
+          *scheduler_,
+          [server = shared_from_this(), session,
+           method_instance](co::Coroutine *c) {
+            SessionResponseCoroutine(std::move(server), session,
+                                     method_instance, c);
+          },
+          absl::StrFormat("Session %d Method %s response", session->session_id,
+                          method->name.c_str())));
+    }
   }
   sessions_[session->session_id] = session;
   logger_.Log(toolbelt::LogLevel::kDebug, "Created session: %d",
@@ -468,7 +528,7 @@ absl::Status RpcServer::DestroySession(int session_id) {
   return absl::OkStatus();
 }
 
-void RpcServer::SessionMethodCoroutine(
+void RpcServer::SessionRequestCoroutine(
     std::shared_ptr<RpcServer> server, std::shared_ptr<Session> session,
     std::shared_ptr<MethodInstance> method_instance, co::Coroutine *c) {
   while (server->running_) {
@@ -483,8 +543,9 @@ void RpcServer::SessionMethodCoroutine(
     if (*s == server->interrupt_pipe_.ReadFd().Fd()) {
       break;
     }
-    subspace::RpcRequest request;
-    bool request_ok = false;
+    // Drain all requests currently available for this method.  Requests for
+    // other sessions can share the same channel, so only this session's
+    // messages are dispatched to the handler below.
     for (;;) {
       auto m = method_instance->request_subscriber->ReadMessage();
       if (!m.ok()) {
@@ -495,46 +556,108 @@ void RpcServer::SessionMethodCoroutine(
         break;
       }
       if (m->length == 0) {
-        // No message, continue waiting.
+        // No more messages, go back to waiting.
         break;
       }
+      subspace::RpcRequest request;
       if (!request.ParseFromArray(m->buffer, m->length)) {
         server->logger_.Log(toolbelt::LogLevel::kError,
-                            "Error parsing request for method %s: %s",
-                            method_instance->method->name.c_str(),
-                            m.status().ToString().c_str());
+                            "Error parsing request for method %s",
+                            method_instance->method->name.c_str());
         continue;
       }
-      if (request.session_id() == session->session_id) {
-        request_ok = true;
-        break;
+      if (request.session_id() != session->session_id) {
+        continue;
       }
+
+      // Give the handler reply handles tied to this request.  The handler runs
+      // on this request coroutine (c), so the completed result is pushed into
+      // the reply queue from c and the response coroutine routes it back to the
+      // client that issued this request.  Writes pass c so that, if the reply
+      // pipe is momentarily full, the write yields this coroutine (letting the
+      // response coroutine drain it) instead of blocking the scheduler thread.
+      // No locking is needed: the server runs on a single coroutine scheduler
+      // thread.  Reply functions must only be invoked from c.
+      auto queue = method_instance->reply_queue;
+      auto reply_fn =
+          [queue, c, session_id = session->session_id,
+           request_id = request.request_id(), client_id = request.client_id()](
+              std::unique_ptr<google::protobuf::Any> response) mutable {
+            auto item = std::make_shared<internal::ReplyItem>();
+            item->session_id = session_id;
+            item->request_id = request_id;
+            item->client_id = client_id;
+            item->response = std::move(response);
+            (void)queue->pipe.Write(std::move(item), c);
+          };
+      auto error_fn =
+          [queue, c, session_id = session->session_id,
+           request_id = request.request_id(),
+           client_id = request.client_id()](std::string error_msg) mutable {
+            auto item = std::make_shared<internal::ReplyItem>();
+            item->session_id = session_id;
+            item->request_id = request_id;
+            item->client_id = client_id;
+            item->error_message = std::move(error_msg);
+            (void)queue->pipe.Write(std::move(item), c);
+          };
+
+      server->logger_.Log(toolbelt::LogLevel::kDebug, "Calling method %s",
+                          method_instance->method->name.c_str());
+      method_instance->method->async_callback(
+          request.argument(), c, std::move(reply_fn), std::move(error_fn));
     }
-    if (!request_ok) {
+  }
+}
+
+void RpcServer::SessionResponseCoroutine(
+    std::shared_ptr<RpcServer> server, std::shared_ptr<Session> session,
+    std::shared_ptr<MethodInstance> method_instance, co::Coroutine *c) {
+  auto &queue = *method_instance->reply_queue;
+  // dup the interrupt fd so this coroutine can wait on it concurrently with
+  // the request coroutine without violating the epoll "one waiter per fd"
+  // restriction.
+  toolbelt::FileDescriptor interrupt(
+      ::dup(server->interrupt_pipe_.ReadFd().Fd()));
+
+  while (server->running_) {
+    // Wait for the next completed reply for this method, or for shutdown.
+    int fd = c->Wait(std::vector<int>{queue.pipe.ReadFd().Fd(), interrupt.Fd()},
+                     POLLIN);
+    if (fd == interrupt.Fd()) {
+      break;
+    }
+    if (fd != queue.pipe.ReadFd().Fd()) {
       continue;
     }
 
-    subspace::RpcResponse response;
-    response.set_session_id(session->session_id);
-    response.set_request_id(request.request_id());
-    response.set_client_id(request.client_id());
-    auto *result = response.mutable_result();
-    server->logger_.Log(toolbelt::LogLevel::kDebug, "Calling method %s",
-                        method_instance->method->name.c_str());
-    absl::Status method_status =
-        method_instance->method->callback(request.argument(), result, c);
-    if (!method_status.ok()) {
+    auto item_or = queue.pipe.Read(c);
+    if (!item_or.ok()) {
       server->logger_.Log(toolbelt::LogLevel::kError,
-                          "Error executing method %s: %s",
+                          "Error reading queued response for method %s: %s",
                           method_instance->method->name.c_str(),
-                          method_status.ToString().c_str());
-      response.set_error(absl::StrFormat("Error executing method %s: %s",
-                                         method_instance->method->name,
-                                         method_status.ToString()));
+                          item_or.status().ToString().c_str());
+      continue;
+    }
+    auto item = std::move(*item_or);
+
+    // Convert the completed handler result into the protocol response expected
+    // by the waiting client.
+    subspace::RpcResponse response;
+    response.set_session_id(item->session_id);
+    response.set_request_id(item->request_id);
+    response.set_client_id(item->client_id);
+    if (!item->error_message.empty()) {
+      response.set_error(item->error_message);
+    } else if (item->response != nullptr) {
+      response.mutable_result()->CopyFrom(*item->response);
+    } else {
+      response.set_error("handler produced a null response");
     }
 
     uint64_t length = response.ByteSizeLong();
     absl::StatusOr<void *> buffer;
+    bool got_buffer = false;
     for (;;) {
       buffer = method_instance->response_publisher->GetMessageBuffer(
           int32_t(length));
@@ -543,36 +666,36 @@ void RpcServer::SessionMethodCoroutine(
                             "Error getting buffer for method %s: %s",
                             method_instance->method->name.c_str(),
                             buffer.status().ToString().c_str());
-        response.set_error(absl::StrFormat(
-            "Error getting buffer for method %s: %s",
-            method_instance->method->name, buffer.status().ToString()));
-        return;
+        break;
       }
       if (*buffer != nullptr) {
+        got_buffer = true;
         break;
       }
       if (!server->interrupt_pipe_.ReadFd().Valid()) {
         return;
       }
-      // Buffer is not ready, wait and try again.
-      auto status = method_instance->response_publisher->Wait(
-          server->interrupt_pipe_.ReadFd(), c);
+      // The response channel is temporarily full; wait for the client to free
+      // a slot or for shutdown.
+      auto status = method_instance->response_publisher->Wait(interrupt, c);
       if (!status.ok()) {
         server->logger_.Log(toolbelt::LogLevel::kError,
                             "Error waiting for buffer: %s",
                             status.status().ToString().c_str());
         return;
       }
-      if (*status == server->interrupt_pipe_.ReadFd().Fd()) {
+      if (*status == interrupt.Fd()) {
         return;
       }
     }
-    // We got a buffer, fill it in and send it.
+    if (!got_buffer) {
+      continue;
+    }
     if (!response.SerializeToArray(*buffer, length)) {
       server->logger_.Log(toolbelt::LogLevel::kError,
                           "Error serializing response for method %s",
                           method_instance->method->name.c_str());
-      break;
+      continue;
     }
     server->logger_.Log(
         toolbelt::LogLevel::kDebug, "Publishing response for method %s: %s",

--- a/rpc/server/rpc_server.h
+++ b/rpc/server/rpc_server.h
@@ -44,16 +44,49 @@ struct AnyStreamWriter {
   bool is_cancelled = false;
 };
 
+// An item pushed by either the reply function or the error function of an
+// async method handler.  Exactly one of response or error_message is
+// meaningful: a non-empty error_message produces an error response, otherwise
+// `response` owns the result Any.  The session/request/client ids are copied
+// from the originating RpcRequest so the response coroutine can build the
+// RpcResponse without keeping the original request alive.
+struct ReplyItem {
+  std::unique_ptr<google::protobuf::Any> response;
+  int32_t session_id;
+  int32_t request_id;
+  uint64_t client_id;
+  std::string error_message;
+};
+
+// Completed replies for a single non-streaming method instance are pushed into
+// this queue by the request coroutine (or by a later async completion from
+// another coroutine) and drained by the response coroutine.  The whole RPC
+// server runs on a single coroutine scheduler thread, so no locking is needed:
+// only one coroutine runs at a time and a small SharedPtrPipe write does not
+// yield, so writes never interleave.
+struct ReplyQueue {
+  explicit ReplyQueue(toolbelt::SharedPtrPipe<ReplyItem> pipe)
+      : pipe(std::move(pipe)) {}
+
+  toolbelt::SharedPtrPipe<ReplyItem> pipe;
+};
+
 struct Method {
+  // Async handler: receives the request Any, a coroutine pointer (usable for
+  // inline async work), a reply function for success and an error function for
+  // failure.  Exactly one of reply/error_reply should be called.  They may be
+  // called immediately, or kept and invoked later from any thread.
   Method(RpcServer *server, std::string name, std::string request_type,
          std::string response_type, int32_t slot_size, int32_t num_slots,
-         std::function<absl::Status(const google::protobuf::Any &,
-                                    google::protobuf::Any *, co::Coroutine *)>
+         std::function<void(
+             const google::protobuf::Any &, co::Coroutine *,
+             std::function<void(std::unique_ptr<google::protobuf::Any>)>,
+             std::function<void(std::string)>)>
              callback,
          int id)
       : name(std::move(name)), request_type(std::move(request_type)),
         response_type(std::move(response_type)), slot_size(slot_size),
-        num_slots(num_slots), callback(std::move(callback)), id(id) {
+        num_slots(num_slots), async_callback(std::move(callback)), id(id) {
     MakeChannelNames(server);
   }
   // Streaming method constructor.
@@ -79,11 +112,12 @@ struct Method {
   std::string response_type;
   int32_t slot_size;
   int32_t num_slots;
-  // Callback for normal, non-streaming method that is called and returns a
-  // single result.
-  std::function<absl::Status(const google::protobuf::Any &,
-                             google::protobuf::Any *, co::Coroutine *)>
-      callback;
+  // Async handler for a normal, non-streaming method.  See the constructor
+  // above for the calling convention.
+  std::function<void(const google::protobuf::Any &, co::Coroutine *,
+                     std::function<void(std::unique_ptr<google::protobuf::Any>)>,
+                     std::function<void(std::string)>)>
+      async_callback;
   // Callback for a streaming method that produces multiple responses.
   std::function<absl::Status(const google::protobuf::Any &,
                              internal::AnyStreamWriter &, co::Coroutine *)>
@@ -99,6 +133,9 @@ struct MethodInstance {
   std::shared_ptr<subspace::Subscriber> request_subscriber;
   std::shared_ptr<subspace::Publisher> response_publisher;
   std::shared_ptr<subspace::Subscriber> cancel_subscriber;
+  // Non-null for non-streaming methods: completed responses are pushed here by
+  // the request coroutine and drained by the response coroutine.
+  std::shared_ptr<ReplyQueue> reply_queue;
 };
 
 struct Session {
@@ -200,6 +237,26 @@ public:
           callback,
       MethodOptions &&options = {});
 
+  // Register an async handler.  The callback receives the request Any, a
+  // coroutine pointer (usable for inline async work), a reply function for
+  // success and an error function for failure.  Exactly one of reply/error
+  // should be called.  Unlike the synchronous RegisterMethod overloads, the
+  // callback does not have to produce its result before returning: it may keep
+  // the reply/error functions and invoke one of them later, possibly from
+  // another thread.  request_type and response_type are the protobuf type
+  // names advertised to clients; by default async methods exchange RawMessage
+  // payloads.
+  absl::Status RegisterMethodAsync(
+      const std::string &method,
+      std::function<void(
+          const google::protobuf::Any &, co::Coroutine *,
+          std::function<void(std::unique_ptr<google::protobuf::Any>)>,
+          std::function<void(std::string)>)>
+          callback,
+      MethodOptions &&options = {},
+      std::string_view request_type = "subspace.RawMessage",
+      std::string_view response_type = "subspace.RawMessage");
+
   absl::Status UnregisterMethod(const std::string &method) {
     auto it = methods_.find(method);
     if (it == methods_.end()) {
@@ -271,7 +328,18 @@ private:
   CreateSession(uint64_t client_id);
   absl::Status DestroySession(int session_id);
 
-  static void SessionMethodCoroutine(
+  // Request coroutine for non-streaming methods: reads incoming requests and
+  // invokes the method's async_callback.  The callback may reply immediately or
+  // keep the reply function and complete later, possibly from another thread.
+  static void SessionRequestCoroutine(
+      std::shared_ptr<RpcServer> server,
+      std::shared_ptr<internal::Session> session,
+      std::shared_ptr<internal::MethodInstance> method_instance,
+      co::Coroutine *c);
+
+  // Response coroutine for non-streaming methods: drains the reply queue and
+  // publishes responses via the Subspace response publisher.
+  static void SessionResponseCoroutine(
       std::shared_ptr<RpcServer> server,
       std::shared_ptr<internal::Session> session,
       std::shared_ptr<internal::MethodInstance> method_instance,

--- a/rpc/server/server_test.cc
+++ b/rpc/server/server_test.cc
@@ -212,6 +212,28 @@ static std::shared_ptr<subspace::RpcServer> BuildServer() {
       });
   EXPECT_TRUE(s.ok());
 
+  // Async method registered via the async API.  It does some coroutine work
+  // (yielding the scheduler) before completing the reply, exercising the
+  // asynchronous reply path through the request/response coroutine pipeline.
+  s = server->RegisterMethodAsync(
+      "AsyncMethod",
+      [](const google::protobuf::Any &req, co::Coroutine *c,
+         std::function<void(std::unique_ptr<google::protobuf::Any>)> reply,
+         std::function<void(std::string)> /*error_reply*/) {
+        rpc::TestRequest test;
+        (void)req.UnpackTo(&test);
+        // Simulate async work; the scheduler runs other coroutines while we
+        // sleep, then we complete the reply.
+        c->Millisleep(50);
+        rpc::TestResponse r;
+        r.set_message("Hello from AsyncMethod");
+        auto any = std::make_unique<google::protobuf::Any>();
+        any->PackFrom(r);
+        reply(std::move(any));
+      },
+      {}, "subspace.TestRequest", "subspace.TestResponse");
+  EXPECT_TRUE(s.ok());
+
   return server;
 }
 
@@ -491,6 +513,85 @@ TEST_F(ServerTest, OpenAndCall) {
 
     Close(server, ctx, c);
 
+    server->Stop();
+  });
+
+  scheduler.Run();
+}
+
+TEST_F(ServerTest, CallAsyncMethod) {
+  co::CoroutineScheduler scheduler;
+
+  auto server = BuildServer();
+  ASSERT_OK(server->Run(&scheduler));
+
+  co::Coroutine test(scheduler, [&](co::Coroutine *c) {
+    ServerContext ctx;
+    subspace::RpcServerResponse response;
+    Open(server, response, ctx, c);
+
+    // Find the async method in the response.
+    auto *method = FindMethod(response.open(), "AsyncMethod");
+    ASSERT_NE(method, nullptr);
+
+    subspace::RpcRequest req;
+    req.set_client_id(ctx.client_id);
+    req.set_session_id(response.open().session_id());
+    int request_id = next_request_id++;
+    req.set_request_id(request_id);
+    req.set_method(method->id());
+    auto *arg = req.mutable_argument();
+
+    rpc::TestRequest test_request;
+    test_request.set_message("Hello, async world!");
+    arg->PackFrom(test_request);
+
+    subspace::Client client;
+    InitClient(client);
+
+    auto pub = client.CreatePublisher(
+        method->request_channel().name(), method->request_channel().slot_size(),
+        method->request_channel().num_slots(),
+        {.reliable = true, .type = method->request_channel().type()});
+    ASSERT_OK(pub);
+
+    auto sub = client.CreateSubscriber(
+        method->response_channel().name(),
+        {.reliable = true, .type = method->response_channel().type()});
+    ASSERT_OK(sub);
+
+    auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
+    ASSERT_OK(buffer);
+    ASSERT_TRUE(req.SerializeToArray(*buffer, req.ByteSizeLong()));
+    ASSERT_OK(pub->PublishMessage(int(req.ByteSizeLong())));
+
+    subspace::Message msg;
+    bool done = false;
+    while (!done) {
+      ASSERT_OK(sub->Wait(c));
+      for (;;) {
+        auto m = sub->ReadMessage();
+        ASSERT_OK(m);
+        if (m->length > 0) {
+          msg = std::move(*m);
+          subspace::RpcResponse rpc_response;
+          ASSERT_TRUE(rpc_response.ParseFromArray(msg.buffer, msg.length));
+          if (rpc_response.client_id() == ctx.client_id &&
+              rpc_response.request_id() == request_id) {
+            EXPECT_EQ("", rpc_response.error());
+            rpc::TestResponse response_message;
+            ASSERT_TRUE(rpc_response.result().UnpackTo(&response_message));
+            EXPECT_EQ("Hello from AsyncMethod", response_message.message());
+            done = true;
+            break;
+          }
+          continue;
+        }
+        break;
+      }
+    }
+
+    Close(server, ctx, c);
     server->Stop();
   });
 


### PR DESCRIPTION
## Summary
- Reworks the `co::Coroutine`-based `rpc` server so non-streaming methods run as a **two-coroutine pipeline**: a request coroutine dispatches incoming requests to the handler, and a response coroutine drains completed replies from a `toolbelt::SharedPtrPipe` and publishes them to the client.
- Handlers now receive `reply`/`error` callbacks and may complete their reply later (e.g. after yielding/sleeping on their coroutine), decoupling request dispatch from response delivery.
- Adds the public `RegisterMethodAsync(...)` API. Existing synchronous `RegisterMethod` overloads are now thin wrappers over it, preserving prior behavior (including the `"Error executing method <name>: ..."` error formatting).
- Reply writes pass the request coroutine to `SharedPtrPipe::Write`, so a momentarily full reply pipe yields the coroutine (letting the response coroutine drain it) instead of blocking the scheduler thread or silently dropping the reply.

## Design notes
- The whole server runs on a single coroutine scheduler thread, so no locking is used; replies are produced on the request coroutine that owns them.
- The response coroutine `dup`s the interrupt fd so it can wait on both the reply pipe and shutdown without violating the epoll "one waiter per fd" restriction.

## Test plan
- [x] `bazelisk test //rpc/...` — all pass (`client_test`, `server_test`, `rpc_test`)
- [x] New `ServerTest.CallAsyncMethod` exercises the async reply path (handler defers its reply via coroutine work before completing)