### PR TITLE
Fix QNX test builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -125,11 +125,13 @@ build:android --config=android_arm64
 # QNX 8 Toolchain Configurations
 # Set QNX_SDP_PATH environment variable or use default ~/qnx800
 build:qnx_aarch64 --platforms=//bazel/toolchains/qnx/platforms:qnx_aarch64
+build:qnx_aarch64 --config=qnx
 build:qnx_aarch64 --action_env=QNX_SDP_PATH
 build:qnx_aarch64 --define=QNX_SDP_PATH=/home/dave.allison/qnx800
 build:qnx_aarch64 --cxxopt=-D__QNX__
 
 build:qnx_x86_64 --platforms=//bazel/toolchains/qnx/platforms:qnx_x86_64
+build:qnx_x86_64 --config=qnx
 build:qnx_x86_64 --action_env=QNX_SDP_PATH
 build:qnx_x86_64 --define=QNX_SDP_PATH=/home/dave.allison/qnx800
 build:qnx_x86_64 --cxxopt=-D__QNX__
@@ -137,3 +139,4 @@ build:qnx_x86_64 --cxxopt=-D__QNX__
 # QNX common flags
 build:qnx --cxxopt=-std=c++17
 build:qnx --cxxopt=-Wno-sign-compare
+build:qnx --linkopt=-lsocket

--- a/.bazelrc
+++ b/.bazelrc
@@ -139,4 +139,3 @@ build:qnx_x86_64 --cxxopt=-D__QNX__
 # QNX common flags
 build:qnx --cxxopt=-std=c++17
 build:qnx --cxxopt=-Wno-sign-compare
-build:qnx --linkopt=-lsocket

--- a/.bazelrc
+++ b/.bazelrc
@@ -123,18 +123,21 @@ build:android_x86_64 --copt=-DABSL_FLAGS_STRIP_NAMES=0
 build:android --config=android_arm64
 
 # QNX 8 Toolchain Configurations
-# Set QNX_SDP_PATH environment variable or use default ~/qnx800
+# Set QNX_SDP_PATH in the environment and pass a matching
+# --define=QNX_SDP_PATH=... after --config=qnx_* if your SDP is elsewhere.
 build:qnx_aarch64 --platforms=//bazel/toolchains/qnx/platforms:qnx_aarch64
 build:qnx_aarch64 --config=qnx
 build:qnx_aarch64 --action_env=QNX_SDP_PATH
-build:qnx_aarch64 --define=QNX_SDP_PATH=/home/dave.allison/qnx800
-build:qnx_aarch64 --cxxopt=-D__QNX__
+build:qnx_aarch64 --define=QNX_SDP_PATH=/home/dallison/qnx800
+build:qnx_aarch64 --cpu=aarch64
+build:qnx_aarch64 --extra_toolchains=//bazel/toolchains/qnx:qnx_aarch64_cc_toolchain
 
 build:qnx_x86_64 --platforms=//bazel/toolchains/qnx/platforms:qnx_x86_64
 build:qnx_x86_64 --config=qnx
 build:qnx_x86_64 --action_env=QNX_SDP_PATH
-build:qnx_x86_64 --define=QNX_SDP_PATH=/home/dave.allison/qnx800
-build:qnx_x86_64 --cxxopt=-D__QNX__
+build:qnx_x86_64 --define=QNX_SDP_PATH=/home/dallison/qnx800
+build:qnx_x86_64 --cpu=x86_64
+build:qnx_x86_64 --extra_toolchains=//bazel/toolchains/qnx:qnx_x86_64_cc_toolchain
 
 # QNX common flags
 build:qnx --cxxopt=-std=c++17

--- a/.github/scripts/qnx-deploy-client-test.sh
+++ b/.github/scripts/qnx-deploy-client-test.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Stage and copy Subspace's QNX x86_64 client_test bundle to a QNX VM.
+
+Usage:
+  .github/scripts/qnx-deploy-client-test.sh [options]
+
+Options:
+  --qnx-ip IP          QNX VM IP address. If omitted, the script tries
+                      "mkqnximage --getip" in --vm-dir.
+  --vm-dir DIR         mkqnximage VM directory. Default: $HOME/qnx-vm
+  --remote-dir DIR     Destination on QNX. Default: /tmp/subspace-client-test
+  --deploy-dir DIR     Local staging directory. Default:
+                      $HOME/qnx-deploy/client-test
+  --ssh-key PATH       SSH private key. Default: $HOME/.ssh/id_ed25519
+  --user USER          SSH user. Default: root
+  --bazel CMD          Bazel command. Default: bazelisk
+  --config CONFIG      Bazel config. Default: qnx_x86_64
+  --no-build           Do not build first; use existing bazel-bin outputs.
+  --no-strip           Do not strip copied QNX binaries/libraries.
+  --stage-only         Only create the local bundle; do not copy to QNX.
+  -h, --help           Show this help.
+
+The bundle layout is:
+  client/client_test
+  _solib_x86_64/*.so
+  plugins/*.so
+
+Run it on QNX from the bundle root:
+  cd /tmp/subspace-client-test
+  ./client/client_test
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+quote_sh() {
+  printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+extract_ipv4() {
+  printf "%s\n" "$1" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | tail -n 1
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_DIR="${DEPLOY_DIR:-$HOME/qnx-deploy/client-test}"
+REMOTE_DIR="${REMOTE_DIR:-/tmp/subspace-client-test}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+SSH_USER="${SSH_USER:-root}"
+VM_DIR="${VM_DIR:-$HOME/qnx-vm}"
+BAZEL="${BAZEL:-bazelisk}"
+CONFIG="${CONFIG:-qnx_x86_64}"
+QNX_IP="${QNX_IP:-}"
+BUILD=1
+COPY_TO_QNX=1
+STRIP=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --qnx-ip)
+      QNX_IP="${2:?missing value for --qnx-ip}"
+      shift 2
+      ;;
+    --vm-dir)
+      VM_DIR="${2:?missing value for --vm-dir}"
+      shift 2
+      ;;
+    --remote-dir)
+      REMOTE_DIR="${2:?missing value for --remote-dir}"
+      shift 2
+      ;;
+    --deploy-dir)
+      DEPLOY_DIR="${2:?missing value for --deploy-dir}"
+      shift 2
+      ;;
+    --ssh-key)
+      SSH_KEY="${2:?missing value for --ssh-key}"
+      shift 2
+      ;;
+    --user)
+      SSH_USER="${2:?missing value for --user}"
+      shift 2
+      ;;
+    --bazel)
+      BAZEL="${2:?missing value for --bazel}"
+      shift 2
+      ;;
+    --config)
+      CONFIG="${2:?missing value for --config}"
+      shift 2
+      ;;
+    --no-build)
+      BUILD=0
+      shift
+      ;;
+    --no-strip)
+      STRIP=0
+      shift
+      ;;
+    --stage-only)
+      COPY_TO_QNX=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+case "$DEPLOY_DIR" in
+  ""|"/"|"/tmp"|"/tmp/"|"$HOME")
+    die "refusing unsafe --deploy-dir: $DEPLOY_DIR"
+    ;;
+esac
+
+if [[ "$BUILD" -eq 1 ]]; then
+  [[ -n "${QNX_SDP_PATH:-}" ]] ||
+    die "set QNX_SDP_PATH first, e.g. export QNX_SDP_PATH=\$HOME/qnx800"
+
+  echo "Building QNX client_test and plugin shared libraries..."
+  "$BAZEL" build \
+    //client:client_test \
+    //plugins:nop_plugin.so \
+    //plugins:split_buffer_free_test_plugin.so \
+    "--config=${CONFIG}"
+fi
+
+CLIENT_TEST="bazel-bin/client/client_test"
+SOLIB_DIR="bazel-bin/_solib_x86_64"
+NOP_PLUGIN="bazel-bin/plugins/nop_plugin.so"
+SPLIT_PLUGIN="bazel-bin/plugins/split_buffer_free_test_plugin.so"
+
+[[ -x "$CLIENT_TEST" ]] || die "missing executable: $CLIENT_TEST"
+[[ -d "$SOLIB_DIR" ]] || die "missing shared library directory: $SOLIB_DIR"
+[[ -f "$NOP_PLUGIN" ]] || die "missing plugin: $NOP_PLUGIN"
+[[ -f "$SPLIT_PLUGIN" ]] || die "missing plugin: $SPLIT_PLUGIN"
+
+if [[ -e "$DEPLOY_DIR" && ! -w "$DEPLOY_DIR" ]]; then
+  die "$DEPLOY_DIR is not writable. Remove it or choose --deploy-dir under your home directory."
+fi
+
+echo "Creating local bundle: $DEPLOY_DIR"
+rm -rf "$DEPLOY_DIR"
+mkdir -p "$DEPLOY_DIR/client" "$DEPLOY_DIR/_solib_x86_64" "$DEPLOY_DIR/plugins"
+
+install -m 0755 "$CLIENT_TEST" "$DEPLOY_DIR/client/client_test"
+
+shopt -s nullglob
+solibs=("$SOLIB_DIR"/*.so)
+[[ "${#solibs[@]}" -gt 0 ]] || die "no .so files found in $SOLIB_DIR"
+for lib in "${solibs[@]}"; do
+  cp -L "$lib" "$DEPLOY_DIR/_solib_x86_64/"
+done
+shopt -u nullglob
+
+cp -L "$NOP_PLUGIN" "$DEPLOY_DIR/plugins/"
+cp -L "$SPLIT_PLUGIN" "$DEPLOY_DIR/plugins/"
+
+if [[ "$STRIP" -eq 1 ]]; then
+  [[ -n "${QNX_SDP_PATH:-}" ]] ||
+    die "set QNX_SDP_PATH or pass --no-strip"
+  # Copied Bazel outputs may be read-only; make staged copies writable first.
+  chmod -R u+w "$DEPLOY_DIR"
+  # shellcheck disable=SC1091
+  . "$QNX_SDP_PATH/qnxsdp-env.sh" >/dev/null
+  "${QNX_HOST}/usr/bin/ntox86_64-strip" \
+    "$DEPLOY_DIR/client/client_test" \
+    "$DEPLOY_DIR/plugins/"*.so \
+    "$DEPLOY_DIR/_solib_x86_64/"*.so
+fi
+
+echo "Bundle contents:"
+echo "  $DEPLOY_DIR/client/client_test"
+echo "  $DEPLOY_DIR/_solib_x86_64/ (${#solibs[@]} libraries)"
+echo "  $DEPLOY_DIR/plugins/"
+
+if [[ "$COPY_TO_QNX" -eq 0 ]]; then
+  echo "Stage-only mode. To run after copying manually:"
+  echo "  cd $REMOTE_DIR"
+  echo "  ./client/client_test"
+  exit 0
+fi
+
+if [[ -z "$QNX_IP" ]]; then
+  [[ -d "$VM_DIR" ]] || die "VM dir not found: $VM_DIR; pass --qnx-ip or --vm-dir"
+  [[ -n "${QNX_SDP_PATH:-}" ]] ||
+    die "set QNX_SDP_PATH or pass --qnx-ip so the script does not need mkqnximage"
+
+  echo "Discovering QNX VM IP from $VM_DIR..."
+  # shellcheck disable=SC1091
+  QNX_IP="$(extract_ipv4 "$(cd "$VM_DIR" && . "$QNX_SDP_PATH/qnxsdp-env.sh" >/dev/null && mkqnximage --getip)")"
+  [[ -n "$QNX_IP" ]] || die "mkqnximage --getip returned an empty IP address"
+else
+  raw_qnx_ip="$QNX_IP"
+  QNX_IP="$(extract_ipv4 "$raw_qnx_ip")"
+  [[ -n "$QNX_IP" ]] || die "--qnx-ip did not contain an IPv4 address: $raw_qnx_ip"
+fi
+
+ssh_opts=()
+if [[ -f "$SSH_KEY" ]]; then
+  ssh_opts=(-i "$SSH_KEY")
+else
+  echo "warning: SSH key not found at $SSH_KEY; using ssh defaults" >&2
+fi
+
+remote="${SSH_USER}@${QNX_IP}"
+quoted_remote_dir="$(quote_sh "$REMOTE_DIR")"
+remote_parent="$(dirname "$REMOTE_DIR")"
+quoted_remote_parent="$(quote_sh "$remote_parent")"
+
+echo "Remote filesystem before copy:"
+ssh "${ssh_opts[@]}" "$remote" "mkdir -p $quoted_remote_parent && df -k $quoted_remote_parent || true"
+
+echo "Streaming bundle to ${remote}:${REMOTE_DIR}"
+if ! tar -C "$DEPLOY_DIR" -cf - . | ssh "${ssh_opts[@]}" "$remote" "\
+  rm -rf $quoted_remote_dir && \
+  mkdir -p $quoted_remote_dir && \
+  tar -xf - -C $quoted_remote_dir && \
+  chmod +x $quoted_remote_dir/client/client_test && \
+  df -k $quoted_remote_parent || true"; then
+  die "copy failed. Check free space on QNX with: ssh ${ssh_opts[*]} $remote 'df -k $quoted_remote_parent'. Try a larger filesystem or a different --remote-dir."
+fi
+
+echo
+echo "Copied successfully."
+echo "Run on QNX:"
+echo "  ssh ${ssh_opts[*]} $remote"
+echo "  cd $REMOTE_DIR"
+echo "  ./client/client_test"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,3 +54,8 @@ config_setting(
   constraint_values = ["@platforms//os:android"],
 )
 
+config_setting(
+  name = "qnx",
+  constraint_values = ["@platforms//os:qnx"],
+)
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,12 @@ single_version_override(
     patch_strip = 1,
 )
 
+git_override(
+    module_name = "cpp_toolbelt",
+    remote = "https://github.com/dallison/cpp_toolbelt.git",
+    commit = "cd72868b04bc8483b7131cb3b7f11bb43c820a0a",
+)
+
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     configure_coverage_tool = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,7 +33,7 @@ single_version_override(
 git_override(
     module_name = "cpp_toolbelt",
     remote = "https://github.com/dallison/cpp_toolbelt.git",
-    commit = "cd72868b04bc8483b7131cb3b7f11bb43c820a0a",
+    commit = "04faab2f34ff5d3b460cad0ae6855f2da521d1eb",
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -167,8 +167,6 @@
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/coroutines/3.3.2/MODULE.bazel": "ad1395ae9758ee5d113acab755b4d972c368c4dab66513bfe31423136f3ee608",
     "https://bcr.bazel.build/modules/coroutines/3.3.2/source.json": "fb47a4c3e13d730a1a58ed6a34add8f6aaeef655a47d0f179427f71bf58ba150",
-    "https://bcr.bazel.build/modules/cpp_toolbelt/2.1.2/MODULE.bazel": "9db22ab8e1bf493e7e449d14255dbc8f2bad5bb9b8bb2635ae53a5211cd6fcb3",
-    "https://bcr.bazel.build/modules/cpp_toolbelt/2.1.2/source.json": "2922fb5eb35a57a8bc599120f68843acfc23df85eb85325e50b99a8a64453f33",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",

--- a/asio_rpc/client/rpc_client.cc
+++ b/asio_rpc/client/rpc_client.cc
@@ -207,10 +207,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher to channel: %s",
               request_name.c_str());
   auto pub = client_->CreatePublisher(request_name,
-                                      {.slot_size = kRpcRequestSlotSize,
-                                       .num_slots = kRpcRequestNumSlots,
-                                       .reliable = true,
-                                       .type = "subspace.RpcServerRequest"});
+                                      subspace::PublisherOptions().SetSlotSize(kRpcRequestSlotSize).SetNumSlots(kRpcRequestNumSlots).SetReliable(true).SetType("subspace.RpcServerRequest"));
   if (!pub.ok()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to create request publisher: %s", pub.status().ToString()));
@@ -219,7 +216,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
   auto sub = client_->CreateSubscriber(
       absl::StrFormat("/rpc/%s/response", service_),
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!sub.ok()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -256,7 +253,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
     auto pub = client_->CreatePublisher(
         method.request_channel().name(), m->slot_size, m->num_slots,
-        {.reliable = true, .type = method.request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method.request_channel().type()));
     if (!pub.ok()) {
       return absl::InternalError(absl::StrFormat(
           "Failed to create request publisher: %s", pub.status().ToString()));
@@ -266,7 +263,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
     auto sub = client_->CreateSubscriber(
         method.response_channel().name(),
-        {.reliable = true, .type = method.response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method.response_channel().type()));
     if (!sub.ok()) {
       return absl::InternalError(absl::StrFormat(
           "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -278,9 +275,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
       auto cpub = client_->CreatePublisher(method.cancel_channel(),
                                            kCancelChannelSlotSize,
                                            kCancelChannelNumSlots,
-                                           {
-                                               .reliable = true,
-                                           });
+                                           subspace::PublisherOptions().SetReliable(true));
       if (!cpub.ok()) {
         return absl::InternalError(absl::StrFormat(
             "Failed to create cancel publisher: %s", cpub.status().ToString()));

--- a/asio_rpc/server/rpc_server.cc
+++ b/asio_rpc/server/rpc_server.cc
@@ -185,9 +185,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating subscriber for %s",
               request_name.c_str());
   auto receiver = client_->CreateSubscriber(
-      request_name, {.reliable = true,
-                     .type = "subspace.RpcServerRequest",
-                     .max_active_messages = 1});
+      request_name, subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerRequest").SetMaxActiveMessages(1));
   if (!receiver.ok()) {
     return receiver.status();
   }
@@ -198,10 +196,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher for %s",
               response_name.c_str());
   auto publisher = client_->CreatePublisher(
-      response_name, {.slot_size = kRpcResponseSlotSize,
-                      .num_slots = kRpcResponseNumSlots,
-                      .reliable = true,
-                      .type = "subspace.RpcServerResponse"});
+      response_name, subspace::PublisherOptions().SetSlotSize(kRpcResponseSlotSize).SetNumSlots(kRpcResponseNumSlots).SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!publisher.ok()) {
     return publisher.status();
   }
@@ -425,7 +420,7 @@ RpcServer::CreateSession(uint64_t client_id,
     absl::StatusOr<subspace::Subscriber> sub = client_->CreateSubscriber(
         absl::StrFormat("%s/%d/%d", method->request_channel,
                         session->client_id, session->session_id),
-        {.reliable = true, .type = method->request_type});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->request_type));
     if (!sub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create subscriber for method %s: %s",
@@ -438,10 +433,7 @@ RpcServer::CreateSession(uint64_t client_id,
     absl::StatusOr<subspace::Publisher> pub = client_->CreatePublisher(
         absl::StrFormat("%s/%d/%d", method->response_channel,
                         session->client_id, session->session_id),
-        {.slot_size = method->slot_size,
-         .num_slots = method->num_slots,
-         .reliable = true,
-         .type = method->response_type});
+        subspace::PublisherOptions().SetSlotSize(method->slot_size).SetNumSlots(method->num_slots).SetReliable(true).SetType(method->response_type));
     if (!pub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create publisher for method %s: %s",
@@ -456,7 +448,7 @@ RpcServer::CreateSession(uint64_t client_id,
           client_->CreateSubscriber(
               absl::StrFormat("%s/%d/%d", method->cancel_channel,
                               session->client_id, session->session_id),
-              {.reliable = true, .type = "subspace.RpcCancelRequest"});
+              subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcCancelRequest"));
       if (!cancel_sub.ok()) {
         logger_.Log(toolbelt::LogLevel::kError,
                     "Failed to create cancel subscriber for method %s: %s",

--- a/asio_rpc/server/server_test.cc
+++ b/asio_rpc/server/server_test.cc
@@ -162,13 +162,13 @@ static void Open(std::shared_ptr<subspace::asio_rpc::RpcServer> /*server*/,
 
   auto pub = ctx.client->CreatePublisher(
       "/rpc/AsioTestService/request", 1024, 10,
-      {.reliable = true, .type = "subspace.RpcServerRequest"});
+      subspace::PublisherOptions().SetReliable(true).SetType("subspace.RpcServerRequest"));
   ASSERT_OK(pub);
 
   ctx.pub = std::make_shared<subspace::Publisher>(std::move(*pub));
   auto sub = ctx.client->CreateSubscriber(
       "/rpc/AsioTestService/response",
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   ASSERT_OK(sub);
 
   ctx.sub = std::make_shared<subspace::Subscriber>(std::move(*sub));
@@ -305,12 +305,12 @@ TEST_F(AsioServerTest, OpenAndCall) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -388,12 +388,12 @@ TEST_F(AsioServerTest, CallAsyncMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -474,12 +474,12 @@ TEST_F(AsioServerTest, CallVoidMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -553,12 +553,12 @@ TEST_F(AsioServerTest, CallError) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -636,12 +636,12 @@ TEST_F(AsioServerTest, Stream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -722,16 +722,16 @@ TEST_F(AsioServerTest, CancelStream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         ASSERT_OK(pub);
 
         auto cancel_pub = client.CreatePublisher(
-            method->cancel_channel(), 64, 10, {.reliable = true});
+            method->cancel_channel(), 64, 10, subspace::PublisherOptions().SetReliable(true));
         ASSERT_OK(cancel_pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         ASSERT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));

--- a/bazel/toolchains/qnx/BUILD.bazel
+++ b/bazel/toolchains/qnx/BUILD.bazel
@@ -1,0 +1,92 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
+load(":cc_toolchain_config.bzl", "qnx_cc_toolchain_config")
+
+filegroup(
+    name = "empty",
+    srcs = [],
+)
+
+filegroup(
+    name = "tool_files",
+    srcs = glob(["tools/**"]),
+)
+
+qnx_cc_toolchain_config(
+    name = "aarch64_config",
+    cpu = "aarch64",
+    gcc_triple = "aarch64-unknown-nto-qnx8.0.0",
+    toolchain_identifier = "qnx-aarch64-gcc",
+)
+
+qnx_cc_toolchain_config(
+    name = "x86_64_config",
+    cpu = "x86_64",
+    gcc_triple = "x86_64-pc-nto-qnx8.0.0",
+    toolchain_identifier = "qnx-x86_64-gcc",
+)
+
+cc_toolchain(
+    name = "cc-compiler-aarch64",
+    all_files = ":tool_files",
+    ar_files = ":tool_files",
+    compiler_files = ":tool_files",
+    dwp_files = ":empty",
+    linker_files = ":tool_files",
+    objcopy_files = ":tool_files",
+    strip_files = ":tool_files",
+    supports_param_files = 1,
+    toolchain_config = ":aarch64_config",
+    toolchain_identifier = "qnx-aarch64-gcc",
+)
+
+cc_toolchain(
+    name = "cc-compiler-x86_64",
+    all_files = ":tool_files",
+    ar_files = ":tool_files",
+    compiler_files = ":tool_files",
+    dwp_files = ":empty",
+    linker_files = ":tool_files",
+    objcopy_files = ":tool_files",
+    strip_files = ":tool_files",
+    supports_param_files = 1,
+    toolchain_config = ":x86_64_config",
+    toolchain_identifier = "qnx-x86_64-gcc",
+)
+
+cc_toolchain_suite(
+    name = "toolchain",
+    toolchains = {
+        "aarch64": ":cc-compiler-aarch64",
+        "x86_64": ":cc-compiler-x86_64",
+    },
+)
+
+toolchain(
+    name = "qnx_aarch64_cc_toolchain",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:qnx",
+    ],
+    toolchain = ":cc-compiler-aarch64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "qnx_x86_64_cc_toolchain",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:qnx",
+    ],
+    toolchain = ":cc-compiler-x86_64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/bazel/toolchains/qnx/cc_toolchain_config.bzl
+++ b/bazel/toolchains/qnx/cc_toolchain_config.bzl
@@ -1,0 +1,155 @@
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
+load(
+    "@rules_cc//cc:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+
+_COMPILE_ACTIONS = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.linkstamp_compile,
+]
+
+_LINK_ACTIONS = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _qnx_cc_toolchain_config_impl(ctx):
+    qnx_sdp_path = ctx.var.get("QNX_SDP_PATH", "/home/dallison/qnx800")
+    gcc_root = "{}/host/linux/x86_64/usr/lib/gcc/{}/{}".format(
+        qnx_sdp_path,
+        ctx.attr.gcc_triple,
+        ctx.attr.gcc_version,
+    )
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        toolchain_identifier = ctx.attr.toolchain_identifier,
+        host_system_name = "local",
+        target_system_name = "qnx",
+        target_cpu = ctx.attr.cpu,
+        target_libc = "qnx",
+        compiler = "gcc",
+        abi_version = "gcc",
+        abi_libc_version = "qnx",
+        cxx_builtin_include_directories = [
+            "{}/target/qnx/usr/include/c++/v1".format(qnx_sdp_path),
+            "{}/include".format(gcc_root),
+            "{}/target/qnx/usr/include".format(qnx_sdp_path),
+        ],
+        tool_paths = [
+            tool_path(name = "ar", path = "tools/qnx_{}_ar".format(ctx.attr.cpu)),
+            tool_path(name = "cpp", path = "tools/qnx_{}_cpp".format(ctx.attr.cpu)),
+            tool_path(name = "gcc", path = "tools/qnx_{}_compiler".format(ctx.attr.cpu)),
+            tool_path(name = "gcov", path = "tools/qnx_{}_gcov".format(ctx.attr.cpu)),
+            tool_path(name = "ld", path = "tools/qnx_{}_ld".format(ctx.attr.cpu)),
+            tool_path(name = "nm", path = "tools/qnx_{}_nm".format(ctx.attr.cpu)),
+            tool_path(name = "objcopy", path = "tools/qnx_{}_objcopy".format(ctx.attr.cpu)),
+            tool_path(name = "objdump", path = "tools/qnx_{}_objdump".format(ctx.attr.cpu)),
+            tool_path(name = "strip", path = "tools/qnx_{}_strip".format(ctx.attr.cpu)),
+        ],
+        features = [
+            feature(
+                name = "default_compile_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = _COMPILE_ACTIONS,
+                        flag_groups = [
+                            flag_group(flags = [
+                                "-D_QNX_SOURCE",
+                            ]),
+                        ],
+                    ),
+                ],
+            ),
+            feature(
+                name = "dependency_file",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = _COMPILE_ACTIONS,
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-MD", "-MF", "%{dependency_file}"],
+                                expand_if_available = "dependency_file",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(name = "supports_pic", enabled = True),
+            feature(
+                name = "pic",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = _COMPILE_ACTIONS,
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-fPIC"],
+                                expand_if_available = "pic",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(
+                name = "user_compile_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = _COMPILE_ACTIONS,
+                        flag_groups = [
+                            flag_group(
+                                flags = ["%{user_compile_flags}"],
+                                iterate_over = "user_compile_flags",
+                                expand_if_available = "user_compile_flags",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(
+                name = "user_link_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = _LINK_ACTIONS,
+                        flag_groups = [
+                            flag_group(
+                                flags = ["%{user_link_flags}"],
+                                iterate_over = "user_link_flags",
+                                expand_if_available = "user_link_flags",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(name = "supports_dynamic_linker", enabled = True),
+            feature(name = "supports_param_files", enabled = True),
+        ],
+    )
+
+qnx_cc_toolchain_config = rule(
+    implementation = _qnx_cc_toolchain_config_impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True),
+        "gcc_triple": attr.string(mandatory = True),
+        "gcc_version": attr.string(default = "12.2.0"),
+        "toolchain_identifier": attr.string(mandatory = True),
+    },
+    provides = [CcToolchainConfigInfo],
+)

--- a/bazel/toolchains/qnx/platforms/BUILD.bazel
+++ b/bazel/toolchains/qnx/platforms/BUILD.bazel
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "qnx_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:qnx",
+    ],
+)
+
+platform(
+    name = "qnx_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:qnx",
+    ],
+)

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_ar
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_ar
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_compiler
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_compiler
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_cpp
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_cpp
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_gcov
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_gcov
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_ld
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_ld
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_nm
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_nm
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_objcopy
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_objcopy
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_objdump
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_objdump
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_aarch64_strip
+++ b/bazel/toolchains/qnx/tools/qnx_aarch64_strip
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_tool.sh
+++ b/bazel/toolchains/qnx/tools/qnx_tool.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tool_name="$(basename "$0")"
+
+case "$tool_name" in
+  qnx_aarch64_*)
+    prefix="ntoaarch64"
+    requested="${tool_name#qnx_aarch64_}"
+    ;;
+  qnx_x86_64_*)
+    prefix="ntox86_64"
+    requested="${tool_name#qnx_x86_64_}"
+    ;;
+  *)
+    echo "Unknown QNX Bazel tool wrapper: $tool_name" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -n "${QNX_SDP_PATH:-}" ]]; then
+  qnx_sdp_path="${QNX_SDP_PATH}"
+else
+  qnx_sdp_path="${HOME:-/home/dallison}/qnx800"
+fi
+if [[ ! -f "${qnx_sdp_path}/qnxsdp-env.sh" ]]; then
+  echo "QNX SDP not found at ${qnx_sdp_path}; set QNX_SDP_PATH to your SDP root" >&2
+  exit 1
+fi
+
+# Bazel actions run with a minimal environment. The QNX SDP environment script
+# expects HOME to exist, so synthesize one when the action environment omits it.
+export HOME="${HOME:-${qnx_sdp_path%/*}}"
+
+# qnxsdp-env.sh defines QNX_HOST/QNX_TARGET and prepends the host tools to PATH.
+# shellcheck disable=SC1090
+. "${qnx_sdp_path}/qnxsdp-env.sh" >/dev/null
+
+compiler_kind="g++"
+if [[ "$requested" == "compiler" ]]; then
+  compiler_kind="g++"
+  compile_action=0
+  previous=""
+  for arg in "$@"; do
+    if [[ "$previous" == "-x" ]]; then
+      case "$arg" in
+        c|assembler|assembler-with-cpp) compiler_kind="gcc" ;;
+      esac
+      previous=""
+      continue
+    fi
+
+    case "$arg" in
+      -c|-S|-E)
+        compile_action=1
+        ;;
+      -x)
+        previous="-x"
+        ;;
+      *.c|*.s|*.S)
+        compiler_kind="gcc"
+        ;;
+    esac
+  done
+
+  if [[ "$compile_action" == 0 ]]; then
+    tmp_files=()
+    cleanup() {
+      rm -f "${tmp_files[@]}"
+    }
+    trap cleanup EXIT
+
+    filtered_args=()
+    for arg in "$@"; do
+      if [[ "$arg" == "-lpthread" ]]; then
+        continue
+      fi
+
+      if [[ "$arg" == @* ]]; then
+        src="${arg#@}"
+        dst="$(mktemp "${TMPDIR:-/tmp}/qnx-bazel-params.XXXXXX")"
+        tmp_files+=("$dst")
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          [[ "$line" == "-lpthread" ]] && continue
+          printf '%s\n' "$line"
+        done < "$src" > "$dst"
+        filtered_args+=("@${dst}")
+      else
+        filtered_args+=("$arg")
+      fi
+    done
+
+    exec "${QNX_HOST}/usr/bin/${prefix}-${compiler_kind}" "${filtered_args[@]}"
+  fi
+
+  exec "${QNX_HOST}/usr/bin/${prefix}-${compiler_kind}" "$@"
+fi
+
+exec "${QNX_HOST}/usr/bin/${prefix}-${requested}" "$@"

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_ar
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_ar
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_compiler
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_compiler
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_cpp
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_cpp
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_gcov
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_gcov
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_ld
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_ld
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_nm
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_nm
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_objcopy
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_objcopy
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_objdump
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_objdump
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/bazel/toolchains/qnx/tools/qnx_x86_64_strip
+++ b/bazel/toolchains/qnx/tools/qnx_x86_64_strip
@@ -1,0 +1,1 @@
+qnx_tool.sh

--- a/c_client/subspace.cc
+++ b/c_client/subspace.cc
@@ -485,50 +485,36 @@ bool subspace_get_all_channel_stats(SubspaceClient client,
 }
 
 SubspaceSubscriberOptions subspace_subscriber_options_default(void) {
-  SubspaceSubscriberOptions options = {
-      .reliable = false,
-      .bridge = false,
-      .for_tunnel = false,
-      .type = {.type = nullptr, .type_length = 0},
-      .max_active_messages = 1,
-      .pass_activation = false,
-      .log_dropped_messages = false,
-      .read_write = false,
-      .mux = nullptr,
-      .mux_length = 0,
-      .vchan_id = -1,
-      .checksum = false,
-      .pass_checksum_errors = false,
-      .keep_active_message = false,
-      .split_callbacks = {},
-  };
+  SubspaceSubscriberOptions options = {};
+  options.max_active_messages = 1;
+  options.vchan_id = -1;
   return options;
 }
 
 SubspacePublisherOptions subspace_publisher_options_default(int32_t slot_size,
                                                             int num_slots) {
   SubspacePublisherOptions options = {
-      .slot_size = slot_size,
-      .num_slots = num_slots,
-      .local = false,
-      .reliable = false,
-      .bridge = false,
-      .for_tunnel = false,
-      .fixed_size = false,
-      .type = {.type = nullptr, .type_length = 0},
-      .activate = false,
-      .mux = nullptr,
-      .mux_length = 0,
-      .vchan_id = -1,
-      .notify_retirement = false,
-      .checksum = false,
-      .checksum_size = 4,
-      .metadata_size = 0,
-      .prefer_retired_slots = true,
-      .use_split_buffers = false,
-      .split_buffers_over_bridge = false,
-      .max_publishers = 0,
-      .split_callbacks = {},
+      slot_size,
+      num_slots,
+      false,
+      false,
+      false,
+      false,
+      false,
+      SubspaceTypeInfo{},
+      false,
+      nullptr,
+      0,
+      -1,
+      false,
+      false,
+      4,
+      0,
+      true,
+      false,
+      false,
+      0,
+      SubspaceSplitBufferCallbacks{},
   };
   return options;
 }
@@ -536,22 +522,21 @@ SubspacePublisherOptions subspace_publisher_options_default(int32_t slot_size,
 SubspaceSubscriber
 subspace_create_subscriber(SubspaceClient client, const char *channel_name,
                            SubspaceSubscriberOptions options) {
-  subspace::SubscriberOptions subspace_options = {
-      .reliable = options.reliable,
-      .bridge = options.bridge,
-      .for_tunnel = options.for_tunnel,
-      .type = StringFromPointer(options.type.type, options.type.type_length),
-      .max_active_messages = options.max_active_messages,
-      .log_dropped_messages = options.log_dropped_messages,
-      .pass_activation = options.pass_activation,
-      .read_write = options.read_write,
-      .mux = StringFromPointer(options.mux, options.mux_length),
-      .vchan_id = options.vchan_id,
-      .checksum = options.checksum,
-      .pass_checksum_errors = options.pass_checksum_errors,
-      .keep_active_message = options.keep_active_message,
-      .split_buffer_callbacks = ToCppSplitCallbacks(options.split_callbacks),
-  };
+  subspace::SubscriberOptions subspace_options;
+  subspace_options.SetReliable(options.reliable)
+      .SetBridge(options.bridge)
+      .SetForTunnel(options.for_tunnel)
+      .SetType(StringFromPointer(options.type.type, options.type.type_length))
+      .SetMaxActiveMessages(options.max_active_messages)
+      .SetPassActivation(options.pass_activation)
+      .SetReadWrite(options.read_write)
+      .SetMux(StringFromPointer(options.mux, options.mux_length))
+      .SetVchanId(options.vchan_id)
+      .SetChecksum(options.checksum)
+      .SetPassChecksumErrors(options.pass_checksum_errors)
+      .SetKeepActiveMessage(options.keep_active_message)
+      .SetSplitBufferCallbacks(ToCppSplitCallbacks(options.split_callbacks));
+  subspace_options.SetLogDroppedMessages(options.log_dropped_messages);
   subspace_clear_error();
   SubspaceSubscriber subscriber;
   memset(&subscriber, 0, sizeof(subscriber));
@@ -574,28 +559,27 @@ subspace_create_subscriber(SubspaceClient client, const char *channel_name,
 SubspacePublisher subspace_create_publisher(SubspaceClient client,
                                             const char *channel_name,
                                             SubspacePublisherOptions options) {
-  subspace::PublisherOptions subspace_options = {
-      .slot_size = options.slot_size,
-      .num_slots = options.num_slots,
-      .local = options.local,
-      .reliable = options.reliable,
-      .bridge = options.bridge,
-      .for_tunnel = options.for_tunnel,
-      .fixed_size = options.fixed_size,
-      .type = StringFromPointer(options.type.type, options.type.type_length),
-      .activate = options.activate,
-      .mux = StringFromPointer(options.mux, options.mux_length),
-      .vchan_id = options.vchan_id,
-      .notify_retirement = options.notify_retirement,
-      .checksum = options.checksum,
-      .checksum_size = options.checksum_size,
-      .metadata_size = options.metadata_size,
-      .prefer_retired_slots = options.prefer_retired_slots,
-      .max_publishers = options.max_publishers,
-      .use_split_buffers = options.use_split_buffers,
-      .split_buffers_over_bridge = options.split_buffers_over_bridge,
-      .split_buffer_callbacks = ToCppSplitCallbacks(options.split_callbacks),
-  };
+  subspace::PublisherOptions subspace_options;
+  subspace_options.SetSlotSize(options.slot_size)
+      .SetNumSlots(options.num_slots)
+      .SetLocal(options.local)
+      .SetReliable(options.reliable)
+      .SetBridge(options.bridge)
+      .SetForTunnel(options.for_tunnel)
+      .SetFixedSize(options.fixed_size)
+      .SetType(StringFromPointer(options.type.type, options.type.type_length))
+      .SetActivate(options.activate)
+      .SetMux(StringFromPointer(options.mux, options.mux_length))
+      .SetVchanId(options.vchan_id)
+      .SetNotifyRetirement(options.notify_retirement)
+      .SetChecksum(options.checksum)
+      .SetChecksumSize(options.checksum_size)
+      .SetMetadataSize(options.metadata_size)
+      .SetPreferRetiredSlots(options.prefer_retired_slots)
+      .SetMaxPublishers(options.max_publishers)
+      .SetUseSplitBuffers(options.use_split_buffers)
+      .SetSplitBuffersOverBridge(options.split_buffers_over_bridge)
+      .SetSplitBufferCallbacks(ToCppSplitCallbacks(options.split_callbacks));
   subspace_clear_error();
   SubspacePublisher publisher;
   memset(&publisher, 0, sizeof(publisher));

--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -77,10 +77,6 @@ cc_test(
         "-Wno-missing-field-initializers",
         "-Wno-unused-parameter",
     ],
-    linkopts = select({
-        "//:qnx": ["-lsocket"],
-        "//conditions:default": [],
-    }),
     deps = [
         ":subspace_client",
         ":test_fixture",

--- a/client/BUILD.bazel
+++ b/client/BUILD.bazel
@@ -77,6 +77,10 @@ cc_test(
         "-Wno-missing-field-initializers",
         "-Wno-unused-parameter",
     ],
+    linkopts = select({
+        "//:qnx": ["-lsocket"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":subspace_client",
         ":test_fixture",

--- a/client/asio_client_test.cc
+++ b/client/asio_client_test.cc
@@ -77,7 +77,7 @@ TEST(AsioClientServer, PubSubRoundTrip) {
           return;
         }
         absl::StatusOr<subspace::Publisher> pub = client.CreatePublisher(
-            "asio_chan", {.slot_size = 256, .num_slots = 10, .activate = true});
+            "asio_chan", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetActivate(true));
         if (!pub.ok()) {
           init_error = pub.status().ToString();
           return;
@@ -94,7 +94,7 @@ TEST(AsioClientServer, PubSubRoundTrip) {
         }
 
         absl::StatusOr<subspace::Subscriber> sub = client.CreateSubscriber(
-            "asio_chan", {.max_active_messages = 2, .pass_activation = true});
+            "asio_chan", subspace::SubscriberOptions().SetMaxActiveMessages(2).SetPassActivation(true));
         if (!sub.ok()) {
           init_error = sub.status().ToString();
           return;

--- a/client/bridge_test.cc
+++ b/client/bridge_test.cc
@@ -395,11 +395,11 @@ TEST_F(BridgeTest, Basic) {
 
   // Create a non-local publisher on client 1.
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
-      "/bridged_basic", {.slot_size = 256, .num_slots = 10, .local = false});
+      "/bridged_basic", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_basic", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_basic", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -447,14 +447,12 @@ TEST(BridgePortRangeTest, StaticBridgePortRangeSucceeds) {
 
   absl::StatusOr<Publisher> pub =
       client1.CreatePublisher("/bridged_static_range",
-                              {.slot_size = 256,
-                               .num_slots = 10,
-                               .local = false});
+                              subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
       client2.CreateSubscriber("/bridged_static_range",
-                               {.max_active_messages = 2});
+                               subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   WaitForSubscribedMessage(servers.BridgeNotificationPipe(0),
@@ -492,14 +490,12 @@ TEST(BridgePortRangeTest, FallsBackWhenConfiguredRangeIsBusy) {
 
   absl::StatusOr<Publisher> pub =
       client1.CreatePublisher("/bridged_fallback_range",
-                              {.slot_size = 256,
-                               .num_slots = 10,
-                               .local = false});
+                              subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
       client2.CreateSubscriber("/bridged_fallback_range",
-                               {.max_active_messages = 2});
+                               subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   WaitForSubscribedMessage(servers.BridgeNotificationPipe(0),
@@ -537,14 +533,12 @@ TEST(BridgePortRangeTest, FailsWhenConfiguredRangeIsBusyAndFallbackDisabled) {
 
   absl::StatusOr<Publisher> pub =
       client1.CreatePublisher("/bridged_exhausted_range",
-                              {.slot_size = 256,
-                               .num_slots = 10,
-                               .local = false});
+                              subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
       client2.CreateSubscriber("/bridged_exhausted_range",
-                               {.max_active_messages = 2});
+                               subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -565,15 +559,15 @@ TEST_F(BridgeTest, TwoSubs) {
 
   // Create a non-local publisher on client 1.
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
-      "/bridged_twosubs", {.slot_size = 256, .num_slots = 10, .local = false});
+      "/bridged_twosubs", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub1 =
-      client2.CreateSubscriber("/bridged_twosubs", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_twosubs", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub1);
 
   absl::StatusOr<Subscriber> sub2 =
-      client2.CreateSubscriber("/bridged_twosubs", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_twosubs", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub2);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -610,14 +604,11 @@ TEST_F(BridgeTest, BasicRetirement) {
 
   // Create a non-local publisher on client 1.
   absl::StatusOr<Publisher> pub =
-      client1.CreatePublisher("/bridged_basic_retire", {.slot_size = 256,
-                                                   .num_slots = 10,
-                                                   .local = false,
-                                                   .notify_retirement = true});
+      client1.CreatePublisher("/bridged_basic_retire", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetNotifyRetirement(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_basic_retire", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_basic_retire", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -666,19 +657,16 @@ TEST_F(BridgeTest, MultipleRetirement) {
   // so we will never receive a retirement notification for it.
   absl::StatusOr<Publisher> local_pub = client1.CreatePublisher(
       "/bridged_retire1",
-      {.slot_size = 256, .num_slots = kNumSlots, .local = false});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(kNumSlots).SetLocal(false));
   ASSERT_OK(local_pub);
 
   // Create a non-local publisher on client 1.
   absl::StatusOr<Publisher> pub =
-      client1.CreatePublisher("/bridged_retire1", {.slot_size = 256,
-                                                   .num_slots = kNumSlots,
-                                                   .local = false,
-                                                   .notify_retirement = true});
+      client1.CreatePublisher("/bridged_retire1", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(kNumSlots).SetLocal(false).SetNotifyRetirement(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_retire1", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_retire1", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -754,21 +742,18 @@ TEST_F(BridgeTest, MultipleRetirement2) {
 
   // Create a non-local publisher on client 1.
   absl::StatusOr<Publisher> pub =
-      client1.CreatePublisher("/bridged_retire2", {.slot_size = 256,
-                                                   .num_slots = kNumSlots,
-                                                   .local = false,
-                                                   .notify_retirement = true});
+      client1.CreatePublisher("/bridged_retire2", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(kNumSlots).SetLocal(false).SetNotifyRetirement(true));
   ASSERT_OK(pub);
 
   // Create publisher on the subscriber server.  This wil consume slot 0 on that
   // side.
   absl::StatusOr<Publisher> local_pub = client2.CreatePublisher(
       "/bridged_retire2",
-      {.slot_size = 256, .num_slots = kNumSlots, .local = false});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(kNumSlots).SetLocal(false));
   ASSERT_OK(local_pub);
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_retire2", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_retire2", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -892,13 +877,12 @@ TEST_F(BridgeTest, LargeChecksumBridge) {
   // checksum_size=20, metadata_size=50 → prefix = Aligned<64>(48+20+50) = 128.
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_sizes",
-      {.slot_size = 256, .num_slots = 10, .local = false,
-       .checksum_size = 20, .metadata_size = 50});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_sizes", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_sizes", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -931,12 +915,12 @@ TEST_F(BridgeTest, DefaultSizesBridge) {
 
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_def_sizes",
-      {.slot_size = 256, .num_slots = 10, .local = false});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
 
   absl::StatusOr<Subscriber> sub = client2.CreateSubscriber(
-      "/bridged_def_sizes", {.max_active_messages = 2});
+      "/bridged_def_sizes", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -971,13 +955,13 @@ TEST_F(BridgeTest, MetadataBridge) {
 
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_meta",
-      {.slot_size = 256, .num_slots = 10, .local = false, .metadata_size = 24});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetMetadataSize(24));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
   ASSERT_EQ(24, pub->MetadataSize());
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_meta", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_meta", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -1019,13 +1003,12 @@ TEST_F(BridgeTest, MetadataLargeBridge) {
 
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_meta_lg",
-      {.slot_size = 256, .num_slots = 10, .local = false,
-       .checksum_size = 20, .metadata_size = 100});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetChecksumSize(20).SetMetadataSize(100));
   ASSERT_OK(pub);
   ASSERT_EQ(192, pub->PrefixSize());
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/bridged_meta_lg", {.max_active_messages = 2});
+      client2.CreateSubscriber("/bridged_meta_lg", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   toolbelt::FileDescriptor &send_bridge_pipe = BridgeNotificationPipe(0);
@@ -1072,13 +1055,12 @@ TEST_F(BridgeTest, SplitBufferSourceBridge) {
 
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_split_source",
-      {.slot_size = 256, .num_slots = 10, .local = false,
-       .use_split_buffers = true, .split_buffers_over_bridge = false});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetUseSplitBuffers(true).SetSplitBuffersOverBridge(false));
   ASSERT_OK(pub);
   ASSERT_TRUE(pub->UsesSplitBuffers());
 
   absl::StatusOr<Subscriber> sub = client2.CreateSubscriber(
-      "/bridged_split_source", {.max_active_messages = 2});
+      "/bridged_split_source", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   subspace::Subscribed sent = ReadSubscribedMessage(
@@ -1112,13 +1094,12 @@ TEST_F(BridgeTest, SplitBuffersOverBridge) {
 
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
       "/bridged_split_remote",
-      {.slot_size = 256, .num_slots = 10, .local = false,
-       .use_split_buffers = false, .split_buffers_over_bridge = true});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false).SetUseSplitBuffers(false).SetSplitBuffersOverBridge(true));
   ASSERT_OK(pub);
   ASSERT_FALSE(pub->UsesSplitBuffers());
 
   absl::StatusOr<Subscriber> sub = client2.CreateSubscriber(
-      "/bridged_split_remote", {.max_active_messages = 2});
+      "/bridged_split_remote", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   subspace::Subscribed sent = ReadSubscribedMessage(
@@ -1334,7 +1315,7 @@ TEST(BridgeStressTest, MultiThreadedBridging) {
         return;
       }
       absl::StatusOr<Subscriber> sub =
-          client.CreateSubscriber(channel_name(ch), {.max_active_messages = 8});
+          client.CreateSubscriber(channel_name(ch), subspace::SubscriberOptions().SetMaxActiveMessages(8));
       if (!sub.ok()) {
         ADD_FAILURE() << "CreateSubscriber: " << sub.status();
         failed = true;
@@ -1421,10 +1402,7 @@ TEST(BridgeStressTest, MultiThreadedBridging) {
       // exhaust the process fd limit (macOS defaults are low) - and this test
       // targets the multi-threaded bridge data plane, not split buffers.
       absl::StatusOr<Publisher> pub = client.CreatePublisher(
-          channel_name(ch), {.slot_size = kSlotSize,
-                             .num_slots = kNumSlots,
-                             .local = false,
-                             .use_split_buffers = false});
+          channel_name(ch), subspace::PublisherOptions().SetSlotSize(kSlotSize).SetNumSlots(kNumSlots).SetLocal(false).SetUseSplitBuffers(false));
       if (!pub.ok()) {
         ADD_FAILURE() << "CreatePublisher: " << pub.status();
         failed = true;
@@ -1530,11 +1508,11 @@ TEST(VsockBridgeTest, BridgeOverVsockLoopback) {
   // Non-local publisher on server 0; subscriber on server 1.  Bridging the two
   // requires a vsock data connection between the servers.
   absl::StatusOr<Publisher> pub = client1.CreatePublisher(
-      "/vsock_bridged", {.slot_size = 256, .num_slots = 10, .local = false});
+      "/vsock_bridged", subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client2.CreateSubscriber("/vsock_bridged", {.max_active_messages = 2});
+      client2.CreateSubscriber("/vsock_bridged", subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   ASSERT_TRUE(WaitForBridgesEstablished(servers.BridgeNotificationPipe(0),

--- a/client/client.cc
+++ b/client/client.cc
@@ -16,10 +16,29 @@
 #include <cerrno>
 #include <cstring>
 #include <inttypes.h>
+#if defined(__QNX__) || defined(__QNXNTO__)
+#include <sys/neutrino.h>
+#endif
 namespace subspace {
 
 namespace {
 std::atomic<bool> default_use_split_buffers{false};
+
+#if defined(__QNX__) || defined(__QNXNTO__)
+void ConfigureQnxClockPeriod() {
+  static std::atomic<bool> attempted{false};
+  bool expected = false;
+  if (!attempted.compare_exchange_strong(expected, true,
+                                         std::memory_order_relaxed)) {
+    return;
+  }
+
+  struct _clockperiod period;
+  period.nsec = 10000U;
+  period.fract = 0;
+  (void)ClockPeriod(CLOCK_REALTIME, &period, nullptr, 0);
+}
+#endif
 
 ClientBufferAllocatorKind FromProtoAllocator(ClientBufferAllocator allocator) {
   switch (allocator) {
@@ -199,6 +218,9 @@ absl::Status ClientImpl::CheckConnected() const {
 
 absl::Status ClientImpl::Init(const std::string &server_socket,
                               const std::string &client_name) {
+#if defined(__QNX__) || defined(__QNXNTO__)
+  ConfigureQnxClockPeriod();
+#endif
   ClientLockGuard guard(this);
   if (socket_.Connected()) {
     return absl::InternalError("Client is already connected to the server; "

--- a/client/client.cc
+++ b/client/client.cc
@@ -110,6 +110,22 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   return metadata;
 }
 
+static absl::Status CheckFdIndex(
+    const std::vector<toolbelt::FileDescriptor> &fds, int index,
+    const char *field, const char *response_name) {
+  if (index < 0 || static_cast<size_t>(index) >= fds.size()) {
+    return absl::InternalError(absl::StrFormat(
+        "%s references fd index %d for %s, but response included %zu fds",
+        response_name, index, field, fds.size()));
+  }
+  if (!fds[static_cast<size_t>(index)].Valid()) {
+    return absl::InternalError(absl::StrFormat(
+        "%s references invalid fd at index %d for %s", response_name, index,
+        field));
+  }
+  return absl::OkStatus();
+}
+
 ClientImpl::ClientLockGuard::ClientLockGuard(ClientImpl *client,
                                              LockMode lock_mode)
     : client_(client), lock_mode_(lock_mode) {
@@ -208,6 +224,12 @@ absl::Status ClientImpl::Init(const std::string &server_socket,
   status = SendRequestReceiveResponse(req, resp, fds);
   if (!status.ok()) {
     return status;
+  }
+  if (absl::Status fd_status =
+          CheckFdIndex(fds, resp.init().scb_fd_index(), "scb_fd",
+                       "InitResponse");
+      !fd_status.ok()) {
+    return fd_status;
   }
   scb_fd_ = std::move(fds[resp.init().scb_fd_index()]);
   session_id_ = resp.init().session_id();
@@ -414,6 +436,20 @@ ClientImpl::CreatePublisher(const std::string &channel_name,
   channel->SetMetadataSize(ms);
   channel->SetPrefixSize(Channel::ComputePrefixSize(cs, ms));
 
+  if (absl::Status fd_status =
+          CheckFdIndex(fds, pub_resp.ccb_fd_index(), "ccb_fd",
+                       "CreatePublisherResponse");
+      !fd_status.ok()) {
+    remove_server_publisher();
+    return fd_status;
+  }
+  if (absl::Status fd_status =
+          CheckFdIndex(fds, pub_resp.bcb_fd_index(), "bcb_fd",
+                       "CreatePublisherResponse");
+      !fd_status.ok()) {
+    remove_server_publisher();
+    return fd_status;
+  }
   SharedMemoryFds channel_fds(std::move(fds[pub_resp.ccb_fd_index()]),
                               std::move(fds[pub_resp.bcb_fd_index()]));
   if (absl::Status status = channel->Map(std::move(channel_fds), scb_fd_);
@@ -530,6 +566,18 @@ ClientImpl::CreateSubscriber(const std::string &channel_name,
     channel->AllocateChecksumBuffer();
   }
 
+  if (absl::Status fd_status =
+          CheckFdIndex(fds, sub_resp.ccb_fd_index(), "ccb_fd",
+                       "CreateSubscriberResponse");
+      !fd_status.ok()) {
+    return fd_status;
+  }
+  if (absl::Status fd_status =
+          CheckFdIndex(fds, sub_resp.bcb_fd_index(), "bcb_fd",
+                       "CreateSubscriberResponse");
+      !fd_status.ok()) {
+    return fd_status;
+  }
   SharedMemoryFds channel_fds(std::move(fds[sub_resp.ccb_fd_index()]),
                               std::move(fds[sub_resp.bcb_fd_index()]));
   if (absl::Status status = channel->Map(std::move(channel_fds), scb_fd_);

--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -105,24 +105,36 @@ absl::Status ClientChannel::Map(SharedMemoryFds fds,
       scb_fd.Fd(), sizeof(SystemControlBlock), PROT_READ | PROT_WRITE, "SCB"));
   if (scb_ == MAP_FAILED) {
     return absl::InternalError(absl::StrFormat(
-        "Failed to map SystemControlBlock: %s", strerror(errno)));
+        "Failed to map SystemControlBlock: %s (scb_fd=%d, ccb_fd=%d, "
+        "bcb_fd=%d, scb_size=%zu, ccb_size=%zu, bcb_size=%zu)",
+        strerror(errno), scb_fd.Fd(), fds.ccb.Fd(), fds.bcb.Fd(),
+        sizeof(SystemControlBlock), CcbSize(num_slots_),
+        sizeof(BufferControlBlock)));
   }
 
   ccb_ = reinterpret_cast<ChannelControlBlock *>(MapMemory(
       fds.ccb.Fd(), CcbSize(num_slots_), PROT_READ | PROT_WRITE, "CCB"));
   if (ccb_ == MAP_FAILED) {
+    int mmap_errno = errno;
     UnmapMemory(scb_, sizeof(SystemControlBlock), "SCB");
     return absl::InternalError(absl::StrFormat(
-        "Failed to map ChannelControlBlock: %s", strerror(errno)));
+        "Failed to map ChannelControlBlock: %s (scb_fd=%d, ccb_fd=%d, "
+        "bcb_fd=%d, ccb_size=%zu)",
+        strerror(mmap_errno), scb_fd.Fd(), fds.ccb.Fd(), fds.bcb.Fd(),
+        CcbSize(num_slots_)));
   }
 
   bcb_ = reinterpret_cast<BufferControlBlock *>(MapMemory(
       fds.bcb.Fd(), sizeof(BufferControlBlock), PROT_READ | PROT_WRITE, "BCB"));
   if (bcb_ == MAP_FAILED) {
+    int mmap_errno = errno;
     UnmapMemory(scb_, sizeof(SystemControlBlock), "SCB");
     UnmapMemory(ccb_, CcbSize(num_slots_), "CCB");
     return absl::InternalError(absl::StrFormat(
-        "Failed to map BufferControlBlock: %s", strerror(errno)));
+        "Failed to map BufferControlBlock: %s (scb_fd=%d, ccb_fd=%d, "
+        "bcb_fd=%d, bcb_size=%zu)",
+        strerror(mmap_errno), scb_fd.Fd(), fds.ccb.Fd(), fds.bcb.Fd(),
+        sizeof(BufferControlBlock)));
   }
   if (debug_) {
     printf("Channel mapped: scb: %p, ccb: %p\n", scb_, ccb_);

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -89,6 +89,15 @@ uint64_t ExpectedSplitBufferVirtualMemoryUsage(int num_slots,
          AlignPage(slot_size) * static_cast<uint64_t>(num_slots);
 }
 
+subspace::PublisherOptions PubOpts(int32_t slot_size = 0,
+                                   int32_t num_slots = 0) {
+  return subspace::PublisherOptions()
+      .SetSlotSize(slot_size)
+      .SetNumSlots(num_slots);
+}
+
+subspace::SubscriberOptions SubOpts() { return subspace::SubscriberOptions(); }
+
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 absl::StatusOr<toolbelt::FileDescriptor> CreateTestMemfd(const char *name,
                                                          size_t size) {
@@ -125,12 +134,12 @@ subspace::SplitBufferCallbacks MakeTestSplitBufferCallbacks(
                                     static_cast<size_t>(
                                         metadata.allocation_size)});
     state->allocate_count++;
-    return subspace::SplitBufferMapping{
-        .handle = handle,
-        .address = address,
-        .size = static_cast<size_t>(metadata.allocation_size),
-        .private_data = address,
-    };
+    subspace::SplitBufferMapping mapping;
+    mapping.handle = handle;
+    mapping.address = address;
+    mapping.size = static_cast<size_t>(metadata.allocation_size);
+    mapping.private_data = address;
+    return mapping;
   };
   callbacks.map =
       [state](const subspace::SplitBufferMetadata &metadata)
@@ -140,11 +149,11 @@ subspace::SplitBufferCallbacks MakeTestSplitBufferCallbacks(
       return absl::NotFoundError("split buffer handle not found");
     }
     state->map_count++;
-    return subspace::SplitBufferMapping{
-        .handle = metadata.handle,
-        .address = it->second.memory.get(),
-        .size = it->second.size,
-    };
+    subspace::SplitBufferMapping mapping;
+    mapping.handle = metadata.handle;
+    mapping.address = it->second.memory.get();
+    mapping.size = it->second.size;
+    return mapping;
   };
   callbacks.unmap = [state](const subspace::SplitBufferMetadata &,
                             const subspace::SplitBufferMapping &mapping)
@@ -177,14 +186,13 @@ static void SigQuitHandler(int signum) {
 }
 
 TEST_F(ClientTest, InetAddressSupportsAbslHash) {
-  struct sockaddr_in addr = {
+  struct sockaddr_in addr = {};
 #if defined(__APPLE__)
-    .sin_len = sizeof(int),
+  addr.sin_len = sizeof(int);
 #endif
-    .sin_family = AF_INET,
-    .sin_port = htons(1234),
-    .sin_addr = {.s_addr = htonl(0x12345678)}
-  };
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(1234);
+  addr.sin_addr.s_addr = htonl(0x12345678);
 
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
       toolbelt::InetAddress(),
@@ -356,7 +364,7 @@ TEST_F(ClientTest, CreateVirtualPublisherWithType) {
   InitClient(client);
   {
     absl::StatusOr<Publisher> pub = client.CreatePublisher(
-        "dave0", 256, 100, {.type = "foobar", .mux = "mainmux"});
+        "dave0", 256, 100, PubOpts().SetType("foobar").SetMux("mainmux"));
     std::cerr << pub.status() << std::endl;
     ASSERT_OK(pub);
     ASSERT_EQ("foobar", pub->Type());
@@ -367,7 +375,7 @@ TEST_F(ClientTest, CreateVirtualPublisherWithType) {
   // Create again with different type.
   {
     absl::StatusOr<Publisher> pub = client.CreatePublisher(
-        "dave0", 256, 10, {.type = "foobar1", .mux = "mainmux"});
+        "dave0", 256, 10, PubOpts().SetType("foobar1").SetMux("mainmux"));
     ASSERT_OK(pub);
     ASSERT_EQ("foobar1", pub->Type());
   }
@@ -381,19 +389,20 @@ TEST_F(ClientTest, TooManyVirtualPublishers) {
   std::vector<Publisher> pubs;
   for (int i = 0; i < kMuxCapacity - 1; i++) {
     absl::StatusOr<Publisher> pub = client.CreatePublisher(
-        "dave0", 256, 10, {.type = "foobar", .mux = "mainmux"});
+        "dave0", 256, 10, PubOpts().SetType("foobar").SetMux("mainmux"));
     ASSERT_OK(pub);
     ASSERT_EQ("foobar", pub->Type());
     pubs.push_back(std::move(*pub));
   }
   // Publisher on the mux will fail
   absl::StatusOr<Publisher> mux_pub =
-      client.CreatePublisher("mainmux", 256, 10, {.type = "foobar"});
+      client.CreatePublisher("mainmux", 256, 10,
+                             PubOpts().SetType("foobar"));
   ASSERT_FALSE(mux_pub.ok());
 
   // One more virtual publisher will fail.
   absl::StatusOr<Publisher> pub = client.CreatePublisher(
-      "dave0", 256, 10, {.type = "foobar", .mux = "mainmux"});
+      "dave0", 256, 10, PubOpts().SetType("foobar").SetMux("mainmux"));
   ASSERT_FALSE(pub.ok());
 }
 
@@ -401,18 +410,19 @@ TEST_F(ClientTest, CreateVirtualPublisherMuxMismatch) {
   subspace::Client client;
   InitClient(client);
   absl::StatusOr<Publisher> pub = client.CreatePublisher(
-      "dave0", 256, 100, {.type = "foobar", .mux = "mainmux"});
+      "dave0", 256, 100, PubOpts().SetType("foobar").SetMux("mainmux"));
   ASSERT_OK(pub);
   ASSERT_EQ("foobar", pub->Type());
 
   // Different mux.
   absl::StatusOr<Publisher> pub2 = client.CreatePublisher(
-      "dave0", 256, 100, {.type = "foobar", .mux = "diffmux"});
+      "dave0", 256, 100, PubOpts().SetType("foobar").SetMux("diffmux"));
   ASSERT_FALSE(pub2.ok());
 
   // No mux.
   absl::StatusOr<Publisher> pub3 =
-      client.CreatePublisher("dave0", 256, 100, {.type = "foobar"});
+      client.CreatePublisher("dave0", 256, 100,
+                             PubOpts().SetType("foobar"));
   ASSERT_FALSE(pub3.ok());
 
   // Creating a channel with same name as mux should fail.
@@ -427,7 +437,7 @@ TEST_F(ClientTest, CreateMultipleVirtualPublisherSameVchan) {
   int last_vchan = -1;
   for (int i = 0; i < 10; i++) {
     absl::StatusOr<Publisher> pub = client.CreatePublisher(
-        "dave0", 256, 100, {.type = "foobar", .mux = "mainmux"});
+        "dave0", 256, 100, PubOpts().SetType("foobar").SetMux("mainmux"));
     ASSERT_OK(pub);
     if (last_vchan == -1) {
       last_vchan = pub->VirtualChannelId();
@@ -446,7 +456,7 @@ TEST_F(ClientTest, CreateMultipleVirtualPublisherDiffVchan) {
   for (int i = 0; i < 10; i++) {
     std::string name = "dave" + std::to_string(i);
     absl::StatusOr<Publisher> pub = client.CreatePublisher(
-        name, 256, 100, {.type = "foobar", .mux = "mainmux"});
+        name, 256, 100, PubOpts().SetType("foobar").SetMux("mainmux"));
     ASSERT_OK(pub);
     if (last_vchan == -1) {
       last_vchan = pub->VirtualChannelId();
@@ -533,14 +543,15 @@ TEST_F(ClientTest, TooManyVirtualSubscribers) {
 
   // 1 publisher.
   absl::StatusOr<Publisher> pub =
-      client.CreatePublisher("dave0", 256, kNumSlots, {.mux = "foobar"});
+      client.CreatePublisher("dave0", 256, kNumSlots,
+                             PubOpts().SetMux("foobar"));
   ASSERT_OK(pub);
 
   // 6 subscribers.
   std::vector<Subscriber> subs;
   for (int i = 0; i < kNumSlots - 3; i++) {
     absl::StatusOr<Subscriber> sub =
-        client.CreateSubscriber("dave0", {.mux = "foobar"});
+        client.CreateSubscriber("dave0", SubOpts().SetMux("foobar"));
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
   }
@@ -551,7 +562,7 @@ TEST_F(ClientTest, TooManyVirtualSubscribers) {
 
   // One more will fail.
   absl::StatusOr<Subscriber> sub =
-      client.CreateSubscriber("dave0", {.mux = "foobar"});
+      client.CreateSubscriber("dave0", SubOpts().SetMux("foobar"));
   ASSERT_FALSE(sub.ok());
 }
 
@@ -609,17 +620,17 @@ TEST_F(ClientTest, BadPublisherParameters) {
 
   // Fixed size.
   absl::StatusOr<Publisher> pub4 =
-      client.CreatePublisher("dave1", 256, 10, {.fixed_size = true});
+      client.CreatePublisher("dave1", 256, 10, PubOpts().SetFixedSize(true));
   ASSERT_OK(pub4);
 
   // Not fixed size - mismatch fixed size option, same slot size.
   absl::StatusOr<Publisher> pub5 =
-      client.CreatePublisher("dave1", 256, 10, {.fixed_size = false});
+      client.CreatePublisher("dave1", 256, 10, PubOpts().SetFixedSize(false));
   ASSERT_FALSE(pub5.ok());
 
   // Different slot size - we are fixed size, this will fail.
   absl::StatusOr<Publisher> pub6 =
-      client.CreatePublisher("dave1", 512, 10, {.fixed_size = true});
+      client.CreatePublisher("dave1", 512, 10, PubOpts().SetFixedSize(true));
   ASSERT_FALSE(pub6.ok());
 }
 
@@ -636,10 +647,11 @@ TEST_F(ClientTest, CreatePublisherThenSubscriber) {
 TEST_F(ClientTest, CreateVirtualPublisherThenSubscriber) {
   subspace::Client client;
   InitClient(client);
-  auto p = client.CreatePublisher("dave1", 256, 10, {.mux = "foobar"});
+  auto p = client.CreatePublisher("dave1", 256, 10,
+                                  PubOpts().SetMux("foobar"));
   ASSERT_OK(p);
 
-  auto s = client.CreateSubscriber("dave1", {.mux = "foobar"});
+  auto s = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
   ASSERT_OK(s);
 }
 
@@ -647,23 +659,25 @@ TEST_F(ClientTest, CreateVirtualSubscriberThenPublisher) {
   subspace::Client client;
   InitClient(client);
 
-  auto s = client.CreateSubscriber("dave1", {.mux = "foobar"});
+  auto s = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
   ASSERT_OK(s);
-  auto p = client.CreatePublisher("dave1", 256, 10, {.mux = "foobar"});
+  auto p = client.CreatePublisher("dave1", 256, 10,
+                                  PubOpts().SetMux("foobar"));
   ASSERT_OK(p);
 }
 
 TEST_F(ClientTest, CreateVirtualPublisherThenSubscriberMuxMismatch) {
   subspace::Client client;
   InitClient(client);
-  auto p1 = client.CreatePublisher("dave1", 256, 10, {.mux = "foobar"});
+  auto p1 = client.CreatePublisher("dave1", 256, 10,
+                                   PubOpts().SetMux("foobar"));
   ASSERT_OK(p1);
 
-  auto s1 = client.CreateSubscriber("dave1", {.mux = "foobar"});
+  auto s1 = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
   ASSERT_OK(s1);
 
   // Different mux.
-  auto s2 = client.CreateSubscriber("dave1", {.mux = "diffmux"});
+  auto s2 = client.CreateSubscriber("dave1", SubOpts().SetMux("diffmux"));
   ASSERT_FALSE(s2.ok());
 
   // No mux.
@@ -1048,7 +1062,7 @@ TEST_F(ClientTest, PublishSingleMessageWithPrefixAndRead) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .type = "foobar"});
+      "dave6", PubOpts(256, 10).SetType("foobar"));
   ASSERT_OK(pub);
 
   ASSERT_EQ("foobar", pub->TypeView());
@@ -1130,7 +1144,8 @@ TEST_F(ClientTest, PublishSingleMessageAndReadNewest) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6", {.max_active_messages = 2});
+      sub_client.CreateSubscriber("dave6",
+                                  SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   // Another message.
@@ -1161,7 +1176,7 @@ TEST_F(ClientTest, PublishSingleMessageAndReadWithActivation) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .activate = true});
+      "dave6", PubOpts(256, 10).SetActivate(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -1170,7 +1185,7 @@ TEST_F(ClientTest, PublishSingleMessageAndReadWithActivation) {
   absl::StatusOr<const Message> pub_status = pub->PublishMessage(6);
   ASSERT_OK(pub_status);
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "dave6", {.max_active_messages = 2, .pass_activation = true});
+      "dave6", SubOpts().SetMaxActiveMessages(2).SetPassActivation(true));
   ASSERT_OK(sub);
 
   // Read activation message.
@@ -1268,7 +1283,8 @@ TEST_F(ClientTest, VirtualPublishSingleMessageAndRead) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10, {.mux = "mainmux"});
+      pub_client.CreatePublisher("dave6", 256, 10,
+                                 PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1277,7 +1293,7 @@ TEST_F(ClientTest, VirtualPublishSingleMessageAndRead) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6", {.mux = "mainmux"});
+      sub_client.CreateSubscriber("dave6", SubOpts().SetMux("mainmux"));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1307,7 +1323,8 @@ TEST_F(ClientTest, VirtualPublishMultiple) {
   for (int i = 0; i < 10; i++) {
     std::string name = "dave" + std::to_string(i);
     absl::StatusOr<Publisher> pub =
-        pub_client.CreatePublisher(name, 256, 100, {.mux = "mainmux"});
+        pub_client.CreatePublisher(name, 256, 100,
+                                   PubOpts().SetMux("mainmux"));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
@@ -1316,7 +1333,7 @@ TEST_F(ClientTest, VirtualPublishMultiple) {
   for (int i = 0; i < 10; i++) {
     std::string name = "dave" + std::to_string(i);
     absl::StatusOr<Subscriber> sub =
-        sub_client.CreateSubscriber(name, {.mux = "mainmux"});
+        sub_client.CreateSubscriber(name, SubOpts().SetMux("mainmux"));
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
   }
@@ -1378,7 +1395,8 @@ TEST_F(ClientTest, PublishAndResize) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6", {.max_active_messages = 2});
+      sub_client.CreateSubscriber("dave6",
+                                  SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1414,7 +1432,8 @@ TEST_F(ClientTest, PublishVirtualAndResize) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10, {.mux = "mainmux"});
+      pub_client.CreatePublisher("dave6", 256, 10,
+                                 PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1423,7 +1442,7 @@ TEST_F(ClientTest, PublishVirtualAndResize) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "dave6", {.max_active_messages = 2, .mux = "mainmux"});
+      "dave6", SubOpts().SetMaxActiveMessages(2).SetMux("mainmux"));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1477,7 +1496,8 @@ TEST_F(ClientTest, PublishAndResize2) {
 
   // Now create subscriber and read both messages.
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6", {.max_active_messages = 2});
+      sub_client.CreateSubscriber("dave6",
+                                  SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1580,7 +1600,8 @@ TEST_F(ClientTest, PublishAndResizeSubscriberFirst) {
 
   // First create subscriber.
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6", {.max_active_messages = 2});
+      sub_client.CreateSubscriber("dave6",
+                                  SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
   ASSERT_EQ(0, sub->SlotSize()); // No buffers yet.
 
@@ -1621,12 +1642,13 @@ TEST_F(ClientTest, PublishVirtualAndResizeSubscriberFirst) {
 
   // First create subscriber.
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "dave6", {.max_active_messages = 2, .mux = "mainmux"});
+      "dave6", SubOpts().SetMaxActiveMessages(2).SetMux("mainmux"));
   ASSERT_OK(sub);
   ASSERT_EQ(0, sub->SlotSize()); // No buffers yet.
 
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10, {.mux = "mainmux"});
+      pub_client.CreatePublisher("dave6", 256, 10,
+                                 PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1666,7 +1688,7 @@ TEST_F(ClientTest, PublishAndResizeSubscriberConcurrently) {
 
   auto t1 = std::thread([&]() {
     auto client1_pub = *client1.CreatePublisher(
-        channel_name, {.slot_size = 1, .num_slots = 4});
+        channel_name, PubOpts(1, 4));
     for (int i = 1; i < 24; i++) {
       std::size_t size = std::pow(2, i);
       auto buffer = client1_pub.GetMessageBuffer(size);
@@ -1713,8 +1735,7 @@ TEST_F(ClientTest, PublishConcurrentlyFromOneClientToOneSubscriber) {
   ASSERT_OK(pub_client.Init(Socket()));
   for (int i = 0; i < kNumPublishers; ++i) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        channel_name,
-        {.slot_size = 256, .num_slots = 2 * kNumPublishers + 16});
+        channel_name, PubOpts(256, 2 * kNumPublishers + 16));
     ASSERT_OK(pub) << pub.status();
     pubs.emplace_back(std::move(*pub));
   }
@@ -1786,8 +1807,7 @@ TEST_F(ClientTest, PublishConcurrentlyToOneSubscriber) {
       }
       ASSERT_TRUE(connected);
       absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-          channel_name,
-          {.slot_size = 256, .num_slots = 2 * kNumPublishers + 16});
+          channel_name, PubOpts(256, 2 * kNumPublishers + 16));
       ASSERT_OK(pub) << pub.status();
       std::array<char, 16> msg = {};
       auto size = std::snprintf(msg.data(), msg.size(), "M%d", i);
@@ -2291,7 +2311,7 @@ TEST_F(ClientTest, ReliablePublisherActivation) {
           true));
   ASSERT_OK(pub);
   absl::StatusOr<Subscriber> sub = client.CreateSubscriber(
-      "rel_dave", {.reliable = true, .pass_activation = true});
+      "rel_dave", SubOpts().SetReliable(true).SetPassActivation(true));
   ASSERT_OK(sub);
 
   auto &counters = pub->GetChannelCounters();
@@ -2565,7 +2585,7 @@ TEST_F(ClientTest, DroppedMessage) {
   InitClient(client);
 
   absl::StatusOr<Subscriber> sub =
-      client.CreateSubscriber("rel_dave", {.keep_active_message = true});
+      client.CreateSubscriber("rel_dave", SubOpts().SetKeepActiveMessage(true));
   ASSERT_OK(sub);
 
   int num_dropped_messages = 0;
@@ -3057,19 +3077,14 @@ TEST_F(ClientTest, RetirementTrigger1) {
   auto sub_client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> p = pub_client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(p);
   auto pub = std::move(*p);
 
   {
     // You can't create a virtual publisher with notify_retirement.
     absl::StatusOr<Publisher> p2 =
-        pub_client->CreatePublisher("dave6v", {
-                                                  .slot_size = 256,
-                                                  .num_slots = 10,
-                                                  .mux = "/foobar",
-                                                  .notify_retirement = true,
-                                              });
+        pub_client->CreatePublisher("dave6v", PubOpts(256, 10).SetMux("/foobar").SetNotifyRetirement(true));
     ASSERT_FALSE(p2.ok());
   }
   const toolbelt::FileDescriptor &retirement_fd = pub.GetRetirementFd();
@@ -3082,12 +3097,12 @@ TEST_F(ClientTest, RetirementTrigger1) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
   absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3113,7 +3128,9 @@ TEST_F(ClientTest, RetirementTrigger1) {
   ptr2.Reset();
 
   // Read the retirement fd and expect it to contain slot 0.
-  struct pollfd fd = {.fd = retirement_fd.Fd(), .events = POLLIN};
+  struct pollfd fd = {};
+  fd.fd = retirement_fd.Fd();
+  fd.events = POLLIN;
   int e = ::poll(&fd, 1, -1);
   ASSERT_EQ(1, e);
   ASSERT_TRUE(fd.revents & POLLIN);
@@ -3137,19 +3154,19 @@ TEST_F(ClientTest, RetirementTrigger2) {
   auto sub_client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> p = pub_client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(p);
   auto pub = std::move(*p);
 
   const toolbelt::FileDescriptor &retirement_fd = pub.GetRetirementFd();
 
   absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1, .keep_active_message = true});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
   absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1, .keep_active_message = true});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3183,7 +3200,9 @@ TEST_F(ClientTest, RetirementTrigger2) {
   }
 
   // There should be nothing in the retirement fd.
-  struct pollfd fd = {.fd = retirement_fd.Fd(), .events = POLLIN};
+  struct pollfd fd = {};
+  fd.fd = retirement_fd.Fd();
+  fd.events = POLLIN;
   int e = ::poll(&fd, 1, 0);
   ASSERT_EQ(0, e);
   ASSERT_FALSE(fd.revents & POLLIN);
@@ -3244,13 +3263,13 @@ TEST_F(ClientTest, RetirementTrigger3) {
   auto sub_client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> p = pub_client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(p);
   auto pub = std::move(*p);
 
   // Another publisher on a different client.
   absl::StatusOr<Publisher> pp2 = pub2Client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(pp2);
   auto pub2 = std::move(*pp2);
 
@@ -3265,12 +3284,12 @@ TEST_F(ClientTest, RetirementTrigger3) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
   absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3294,7 +3313,9 @@ TEST_F(ClientTest, RetirementTrigger3) {
   ptr2.Reset();
 
   // Read the retirement fd and expect it to contain slot 0.
-  struct pollfd fd = {.fd = retirement_fd.Fd(), .events = POLLIN};
+  struct pollfd fd = {};
+  fd.fd = retirement_fd.Fd();
+  fd.events = POLLIN;
   int e = ::poll(&fd, 1, -1);
   ASSERT_EQ(1, e);
   ASSERT_TRUE(fd.revents & POLLIN);
@@ -3315,13 +3336,13 @@ TEST_F(ClientTest, RetirementTrigger4) {
   auto sub_client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> p = pub_client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(p);
   auto pub = std::move(*p);
 
   // Another publisher on a different client.
   absl::StatusOr<Publisher> pp2 = pub2Client->CreatePublisher(
-      "dave6", {.slot_size = 256, .num_slots = 10, .notify_retirement = true});
+      "dave6", PubOpts(256, 10).SetNotifyRetirement(true));
   ASSERT_OK(pp2);
   auto pub2 = std::move(*pp2);
 
@@ -3330,12 +3351,12 @@ TEST_F(ClientTest, RetirementTrigger4) {
   const toolbelt::FileDescriptor &retirement_fd = pub2.GetRetirementFd();
 
   absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1, .keep_active_message = true});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
   absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", {.max_active_messages = 1, .keep_active_message = true});
+      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3367,7 +3388,9 @@ TEST_F(ClientTest, RetirementTrigger4) {
   }
 
   // There should be nothing in the retirement fd.
-  struct pollfd fd = {.fd = retirement_fd.Fd(), .events = POLLIN};
+  struct pollfd fd = {};
+  fd.fd = retirement_fd.Fd();
+  fd.events = POLLIN;
   int e = ::poll(&fd, 1, 0);
   ASSERT_EQ(0, e);
   ASSERT_FALSE(fd.revents & POLLIN);
@@ -3424,11 +3447,11 @@ TEST_F(ClientTest, ChannelDirectory) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> p1 =
-      client->CreatePublisher("chan1", {.slot_size = 256, .num_slots = 10});
+      client->CreatePublisher("chan1", PubOpts(256, 10));
   ASSERT_OK(p1);
 
   absl::StatusOr<Publisher> p2 =
-      client->CreatePublisher("chan2", {.slot_size = 256, .num_slots = 10});
+      client->CreatePublisher("chan2", PubOpts(256, 10));
   ASSERT_OK(p2);
 
   absl::StatusOr<Subscriber> s1 = client->CreateSubscriber("chan1");
@@ -3481,7 +3504,7 @@ TEST_F(ClientTest, MessageGetters) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan1", {.slot_size = 256, .num_slots = 10, .type = "test-type"});
+      "chan1", PubOpts(256, 10).SetType("test-type"));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan1");
@@ -3510,12 +3533,12 @@ TEST_F(ClientTest, ChecksumVerification) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan1", {.slot_size = 256, .num_slots = 10, .checksum = true});
+      "chan1", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   // Create a second publisher that doesn't calculate a checksum.
   absl::StatusOr<Publisher> pub2 =
-      client->CreatePublisher("chan1", {.slot_size = 256, .num_slots = 10});
+      client->CreatePublisher("chan1", PubOpts(256, 10));
   ASSERT_OK(pub2);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -3525,7 +3548,7 @@ TEST_F(ClientTest, ChecksumVerification) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan1", {.checksum = true});
+      client->CreateSubscriber("chan1", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   {
@@ -3590,7 +3613,7 @@ TEST_F(ClientTest, ChecksumVerification) {
 
   // Create another subscriber with pass checksum errors.
   absl::StatusOr<Subscriber> sub2 = client->CreateSubscriber(
-      "chan1", {.checksum = true, .pass_checksum_errors = true});
+      "chan1", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub2);
 
   // First message will be fine since the checksum is good.
@@ -3631,11 +3654,11 @@ TEST_F(ClientTest, ChecksumCallback) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cb", {.slot_size = 256, .num_slots = 10, .checksum = true});
+      "chan_cb", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cb", {.checksum = true});
+      client->CreateSubscriber("chan_cb", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   auto fake_crc =
@@ -3687,11 +3710,11 @@ TEST_F(ClientTest, ChecksumCallbackPassErrors) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cb_pass", {.slot_size = 256, .num_slots = 10, .checksum = true});
+      "chan_cb_pass", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber(
-      "chan_cb_pass", {.checksum = true, .pass_checksum_errors = true});
+      "chan_cb_pass", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub);
 
   auto fake_crc =
@@ -3729,11 +3752,11 @@ TEST_F(ClientTest, ChecksumCallbackReset) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cb_reset", {.slot_size = 256, .num_slots = 10, .checksum = true});
+      "chan_cb_reset", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cb_reset", {.checksum = true});
+      client->CreateSubscriber("chan_cb_reset", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   auto fake_crc =
@@ -3793,11 +3816,11 @@ TEST_F(ClientTest, ChecksumCallbackPublisherOnly) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cb_pub_only",
-      {.slot_size = 256, .num_slots = 10, .checksum = true});
+      PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cb_pub_only", {.checksum = true});
+      client->CreateSubscriber("chan_cb_pub_only", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   auto fake_crc =
@@ -3833,11 +3856,11 @@ TEST_F(ClientTest, Checksum20Byte) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_ck20",
-      {.slot_size = 256, .num_slots = 10, .checksum = true, .checksum_size = 20});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_ck20", {.checksum = true});
+      client->CreateSubscriber("chan_ck20", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   ASSERT_EQ(128, pub->PrefixSize());
@@ -3898,7 +3921,7 @@ TEST_F(ClientTest, ChecksumSizeDefault) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_def", {.slot_size = 256, .num_slots = 10});
+      "chan_cs_def", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(4, pub->ChecksumSize());
@@ -3910,7 +3933,7 @@ TEST_F(ClientTest, LargeChecksumSize) {
 
   // checksum_size=32 → Aligned<64>(48 + 32) = 128 bytes prefix.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_big", {.slot_size = 256, .num_slots = 10, .checksum_size = 32});
+      "chan_cs_big", PubOpts(256, 10).SetChecksumSize(32));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
   ASSERT_EQ(32, pub->ChecksumSize());
@@ -3921,7 +3944,7 @@ TEST_F(ClientTest, MetadataSize) {
 
   // metadata_size=100 → Aligned<64>(48 + 4 + 100) = Aligned<64>(152) = 192.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta", {.slot_size = 256, .num_slots = 10, .metadata_size = 100});
+      "chan_meta", PubOpts(256, 10).SetMetadataSize(100));
   ASSERT_OK(pub);
   ASSERT_EQ(192, pub->PrefixSize());
   ASSERT_EQ(4, pub->ChecksumSize());
@@ -3933,13 +3956,13 @@ TEST_F(ClientTest, PrefixSizeInconsistent) {
 
   absl::StatusOr<Publisher> pub1 = client->CreatePublisher(
       "chan_ps_incon",
-      {.slot_size = 256, .num_slots = 10, .checksum_size = 20});
+      PubOpts(256, 10).SetChecksumSize(20));
   ASSERT_OK(pub1);
 
   // A second publisher with different sizes should fail.
   absl::StatusOr<Publisher> pub2 = client->CreatePublisher(
       "chan_ps_incon",
-      {.slot_size = 256, .num_slots = 10, .checksum_size = 32});
+      PubOpts(256, 10).SetChecksumSize(32));
   ASSERT_FALSE(pub2.ok());
 }
 
@@ -3954,8 +3977,7 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixIsShared) {
   // First publisher on vchan_a with checksum_size=20, metadata_size=50:
   //   48 + 20 + 50 = 118 → Aligned<64> = 128.
   absl::StatusOr<Publisher> pub_a = client->CreatePublisher(
-      "vchan_a", {.slot_size = 256, .num_slots = 10, .mux = "shared_mux",
-                  .checksum_size = 20, .metadata_size = 50});
+      "vchan_a", PubOpts(256, 10).SetMux("shared_mux").SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub_a);
   ASSERT_EQ(128, pub_a->PrefixSize());
   ASSERT_EQ(20, pub_a->ChecksumSize());
@@ -3964,7 +3986,7 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixIsShared) {
   // A subscriber on a different vchan on the same mux must see the mux's
   // sizes, not the per-vchan defaults (4/0/64).
   absl::StatusOr<Subscriber> sub_b =
-      client->CreateSubscriber("vchan_b", {.mux = "shared_mux"});
+      client->CreateSubscriber("vchan_b", SubOpts().SetMux("shared_mux"));
   ASSERT_OK(sub_b);
   ASSERT_EQ(128, sub_b->PrefixSize());
   ASSERT_EQ(20, sub_b->ChecksumSize());
@@ -3973,21 +3995,18 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixIsShared) {
   // A second publisher on a different vchan on the same mux with matching
   // sizes must succeed and report the same prefix layout.
   absl::StatusOr<Publisher> pub_b = client->CreatePublisher(
-      "vchan_b", {.slot_size = 256, .num_slots = 10, .mux = "shared_mux",
-                  .checksum_size = 20, .metadata_size = 50});
+      "vchan_b", PubOpts(256, 10).SetMux("shared_mux").SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub_b);
   ASSERT_EQ(128, pub_b->PrefixSize());
 
   // A second publisher on yet another vchan with mismatching cs/ms must be
   // rejected, because virtual channels on a mux cannot disagree on layout.
   absl::StatusOr<Publisher> pub_c = client->CreatePublisher(
-      "vchan_c", {.slot_size = 256, .num_slots = 10, .mux = "shared_mux",
-                  .checksum_size = 32});
+      "vchan_c", PubOpts(256, 10).SetMux("shared_mux").SetChecksumSize(32));
   ASSERT_FALSE(pub_c.ok());
 
   absl::StatusOr<Publisher> pub_d = client->CreatePublisher(
-      "vchan_d", {.slot_size = 256, .num_slots = 10, .mux = "shared_mux",
-                  .metadata_size = 100});
+      "vchan_d", PubOpts(256, 10).SetMux("shared_mux").SetMetadataSize(100));
   ASSERT_FALSE(pub_d.ok());
 }
 
@@ -3999,18 +4018,17 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixSubscriberFirst) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Subscriber> sub_a =
-      client->CreateSubscriber("vchan_a", {.mux = "sub_first_mux"});
+      client->CreateSubscriber("vchan_a", SubOpts().SetMux("sub_first_mux"));
   ASSERT_OK(sub_a);
 
   absl::StatusOr<Publisher> pub_a = client->CreatePublisher(
-      "vchan_a", {.slot_size = 256, .num_slots = 10, .mux = "sub_first_mux",
-                  .checksum_size = 20, .metadata_size = 50});
+      "vchan_a", PubOpts(256, 10).SetMux("sub_first_mux").SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub_a);
   ASSERT_EQ(128, pub_a->PrefixSize());
 
   // Subscriber on a sibling vchan should now see the mux's sizes.
   absl::StatusOr<Subscriber> sub_b =
-      client->CreateSubscriber("vchan_b", {.mux = "sub_first_mux"});
+      client->CreateSubscriber("vchan_b", SubOpts().SetMux("sub_first_mux"));
   ASSERT_OK(sub_b);
   ASSERT_EQ(128, sub_b->PrefixSize());
   ASSERT_EQ(20, sub_b->ChecksumSize());
@@ -4022,8 +4040,7 @@ TEST_F(ClientTest, SubscriberGetsSizes) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_sub_sizes",
-      {.slot_size = 256, .num_slots = 10, .checksum_size = 20,
-       .metadata_size = 50});
+      PubOpts(256, 10).SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
@@ -4040,7 +4057,7 @@ TEST_F(ClientTest, MetadataSmall) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_s", {.slot_size = 256, .num_slots = 10, .metadata_size = 8});
+      "chan_meta_s", PubOpts(256, 10).SetMetadataSize(8));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(8, pub->MetadataSize());
@@ -4078,7 +4095,7 @@ TEST_F(ClientTest, MetadataExactFit) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_meta_ex",
-      {.slot_size = 256, .num_slots = 10, .metadata_size = 12});
+      PubOpts(256, 10).SetMetadataSize(12));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
 
@@ -4110,7 +4127,7 @@ TEST_F(ClientTest, MetadataSpillsToSecondChunk) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_meta_sp",
-      {.slot_size = 256, .num_slots = 10, .metadata_size = 13});
+      PubOpts(256, 10).SetMetadataSize(13));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
 
@@ -4142,8 +4159,7 @@ TEST_F(ClientTest, MetadataLargeWithLargeChecksum) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_meta_lg",
-      {.slot_size = 512, .num_slots = 10, .checksum_size = 32,
-       .metadata_size = 200});
+      PubOpts(512, 10).SetChecksumSize(32).SetMetadataSize(200));
   ASSERT_OK(pub);
   ASSERT_EQ(320, pub->PrefixSize());
   ASSERT_EQ(32, pub->ChecksumSize());
@@ -4185,7 +4201,7 @@ TEST_F(ClientTest, ChecksumSizeTooLarge) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_big_fail",
-      {.slot_size = 256, .num_slots = 10, .checksum_size = 0x10000});
+      PubOpts(256, 10).SetChecksumSize(0x10000));
   ASSERT_FALSE(pub.ok());
 }
 
@@ -4194,7 +4210,7 @@ TEST_F(ClientTest, MetadataSizeTooLarge) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_ms_big_fail",
-      {.slot_size = 256, .num_slots = 10, .metadata_size = 0x10000});
+      PubOpts(256, 10).SetMetadataSize(0x10000));
   ASSERT_FALSE(pub.ok());
 }
 
@@ -4203,7 +4219,7 @@ TEST_F(ClientTest, ChecksumSizeAtMax) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_max",
-      {.slot_size = 0x20000, .num_slots = 2, .checksum_size = 0xFFFF});
+      PubOpts(0x20000, 2).SetChecksumSize(0xFFFF));
   ASSERT_OK(pub);
   ASSERT_EQ(0xFFFF, pub->ChecksumSize());
 }
@@ -4213,7 +4229,7 @@ TEST_F(ClientTest, MetadataSizeAtMax) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_ms_max",
-      {.slot_size = 0x20000, .num_slots = 2, .metadata_size = 0xFFFF});
+      PubOpts(0x20000, 2).SetMetadataSize(0xFFFF));
   ASSERT_OK(pub);
   ASSERT_EQ(0xFFFF, pub->MetadataSize());
 }
@@ -4223,7 +4239,7 @@ TEST_F(ClientTest, MetadataZero) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_z", {.slot_size = 256, .num_slots = 10});
+      "chan_meta_z", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(0, pub->MetadataSize());
@@ -4241,7 +4257,7 @@ TEST_F(ClientTest, MetadataMultipleMessages) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_meta_mm",
-      {.slot_size = 256, .num_slots = 10, .metadata_size = 16});
+      PubOpts(256, 10).SetMetadataSize(16));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
@@ -4282,8 +4298,7 @@ TEST_F(ClientTest, ChecksumWithMetadata) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_meta",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .metadata_size = 16});
+      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
   ASSERT_EQ(4, pub->ChecksumSize());
   ASSERT_EQ(16, pub->MetadataSize());
@@ -4291,7 +4306,7 @@ TEST_F(ClientTest, ChecksumWithMetadata) {
   ASSERT_EQ(128, pub->PrefixSize());
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cs_meta", {.checksum = true});
+      client->CreateSubscriber("chan_cs_meta", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4321,12 +4336,11 @@ TEST_F(ClientTest, ChecksumWithMetadataCorruptPayload) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_meta_cp",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .metadata_size = 16});
+      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cs_meta_cp", {.checksum = true});
+      client->CreateSubscriber("chan_cs_meta_cp", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4353,12 +4367,11 @@ TEST_F(ClientTest, ChecksumWithMetadataCorruptMetadata) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_meta_cm",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .metadata_size = 16});
+      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cs_meta_cm", {.checksum = true});
+      client->CreateSubscriber("chan_cs_meta_cm", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4386,12 +4399,11 @@ TEST_F(ClientTest, ChecksumWithMetadataCorruptMetadataPassError) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_meta_pe",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .metadata_size = 16});
+      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber(
-      "chan_cs_meta_pe", {.checksum = true, .pass_checksum_errors = true});
+      "chan_cs_meta_pe", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4423,13 +4435,12 @@ TEST_F(ClientTest, ChecksumIgnoresPrefixPadding) {
   // Padding region is bytes [68..128) relative to prefix start.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_pad",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .metadata_size = 16});
+      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cs_pad", {.checksum = true});
+      client->CreateSubscriber("chan_cs_pad", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4471,15 +4482,14 @@ TEST_F(ClientTest, ChecksumIgnoresPrefixPaddingLargeChecksum) {
   // Padding region is bytes [100..128).
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_pad_lg",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .checksum_size = 20, .metadata_size = 32});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20).SetMetadataSize(32));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
   ASSERT_EQ(20, pub->ChecksumSize());
   ASSERT_EQ(32, pub->MetadataSize());
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cs_pad_lg", {.checksum = true});
+      client->CreateSubscriber("chan_cs_pad_lg", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4765,14 +4775,13 @@ TEST_F(ClientTest, ChecksumAes128CmacWithMetadata) {
   // checksum_size=16 for the 128-bit CMAC output.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .checksum_size = 16, .metadata_size = 24});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
   ASSERT_OK(pub);
   ASSERT_EQ(16, pub->ChecksumSize());
   ASSERT_EQ(24, pub->MetadataSize());
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cmac", {.checksum = true});
+      client->CreateSubscriber("chan_cmac", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   pub->SetChecksumCallback(CmacChecksumCallback);
@@ -4805,12 +4814,11 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptPayload) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_cp",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .checksum_size = 16, .metadata_size = 24});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cmac_cp", {.checksum = true});
+      client->CreateSubscriber("chan_cmac_cp", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   pub->SetChecksumCallback(CmacChecksumCallback);
@@ -4839,12 +4847,11 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptMetadata) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_cm",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .checksum_size = 16, .metadata_size = 24});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_cmac_cm", {.checksum = true});
+      client->CreateSubscriber("chan_cmac_cm", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
   pub->SetChecksumCallback(CmacChecksumCallback);
@@ -4873,12 +4880,11 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptMetadataPassError) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_pe",
-      {.slot_size = 256, .num_slots = 10, .checksum = true,
-       .checksum_size = 16, .metadata_size = 24});
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber(
-      "chan_cmac_pe", {.checksum = true, .pass_checksum_errors = true});
+      "chan_cmac_pe", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub);
 
   pub->SetChecksumCallback(CmacChecksumCallback);
@@ -4910,12 +4916,12 @@ TEST_F(ClientTest, TunnelPublisherSetsCrossMachineFlag) {
 
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
       "tunnel_test1",
-      {.slot_size = 256, .num_slots = 10, .for_tunnel = true});
+      PubOpts(256, 10).SetForTunnel(true));
   ASSERT_OK(pub);
   ASSERT_TRUE(pub->ForTunnel());
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "tunnel_test1", {.for_tunnel = true});
+      "tunnel_test1", SubOpts().SetForTunnel(true));
   ASSERT_OK(sub);
   ASSERT_TRUE(sub->ForTunnel());
 
@@ -4949,7 +4955,7 @@ TEST_F(ClientTest, NonTunnelPublisherDoesNotSetCrossMachineFlag) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "tunnel_test2", {.slot_size = 256, .num_slots = 10});
+      "tunnel_test2", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_FALSE(pub->ForTunnel());
 
@@ -4992,7 +4998,7 @@ TEST_F(ClientTest, InitTwiceFails) {
 
 TEST_F(ClientTest, CheckConnectedBeforeInit) {
   subspace::Client client;
-  auto pub = client.CreatePublisher("no_init_chan", {.slot_size = 64, .num_slots = 4});
+  auto pub = client.CreatePublisher("no_init_chan", PubOpts(64, 4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(), ::testing::HasSubstr("not connected"));
 }
@@ -5000,7 +5006,7 @@ TEST_F(ClientTest, CheckConnectedBeforeInit) {
 TEST_F(ClientTest, ChannelExistsTrue) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub = client.CreatePublisher("exists_test", {.slot_size = 64, .num_slots = 4});
+  auto pub = client.CreatePublisher("exists_test", PubOpts(64, 4));
   ASSERT_OK(pub);
   auto exists = client.ChannelExists("exists_test");
   ASSERT_OK(exists);
@@ -5019,7 +5025,7 @@ TEST_F(ClientTest, GetChannelStatsByName) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("stats_test", {.slot_size = 256, .num_slots = 4}));
+      client.CreatePublisher("stats_test", PubOpts(256, 4)));
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'x', 100);
   auto msg = pub.PublishMessage(100);
@@ -5037,9 +5043,9 @@ TEST_F(ClientTest, GetChannelStatsAll) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub1 = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("allstats1", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("allstats1", PubOpts(64, 4)));
   auto pub2 = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("allstats2", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("allstats2", PubOpts(64, 4)));
 
   auto buf1 = EVAL_AND_ASSERT_OK(pub1.GetMessageBuffer());
   memset(buf1, 'a', 10);
@@ -5072,7 +5078,7 @@ TEST_F(ClientTest, GetChannelCountersByName) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("counters_name", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("counters_name", PubOpts(64, 4)));
   auto counters = client.GetChannelCounters("counters_name");
   ASSERT_OK(counters);
   ASSERT_EQ(1, counters->num_pubs);
@@ -5090,7 +5096,7 @@ TEST_F(ClientTest, GetChannelInfoAll) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("infoall_test", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("infoall_test", PubOpts(64, 4)));
 
   auto all_info = client.GetChannelInfo();
   ASSERT_OK(all_info);
@@ -5111,7 +5117,7 @@ TEST_F(ClientTest, GetCurrentOrdinal) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(
-      pub_client.CreatePublisher("ordinal_test", {.slot_size = 64, .num_slots = 4}));
+      pub_client.CreatePublisher("ordinal_test", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(
       sub_client.CreateSubscriber("ordinal_test"));
 
@@ -5135,7 +5141,7 @@ TEST_F(ClientTest, SetDebugDoesNotCrash) {
   ASSERT_OK(client.Init(Socket()));
   client.SetDebug(true);
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("debug_test", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("debug_test", PubOpts(64, 4)));
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'y', 5);
   ASSERT_OK(pub.PublishMessage(5));
@@ -5150,7 +5156,7 @@ TEST_F(ClientTest, UnreliablePublisherFileDescriptorAndPollFd) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("unreliable_fd", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("unreliable_fd", PubOpts(64, 4)));
   ASSERT_FALSE(pub.IsReliable());
   auto fd = pub.GetFileDescriptor();
   ASSERT_FALSE(fd.Valid());
@@ -5165,7 +5171,7 @@ TEST_F(ClientTest, UnreliablePublisherGetFileDescriptorInvalid) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("unreliable_fd2", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("unreliable_fd2", PubOpts(64, 4)));
   ASSERT_FALSE(pub.IsReliable());
   auto fd = pub.GetFileDescriptor();
   ASSERT_FALSE(fd.Valid());
@@ -5175,7 +5181,7 @@ TEST_F(ClientTest, PublishZeroSizeFails) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("zero_pub", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("zero_pub", PubOpts(64, 4)));
   [[maybe_unused]] auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   auto msg = pub.PublishMessage(0);
   ASSERT_FALSE(msg.ok());
@@ -5198,7 +5204,7 @@ TEST_F(ClientTest, OnSendCallbackSuccess) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("onsend_test", {.slot_size = 256, .num_slots = 4}));
+      client.CreatePublisher("onsend_test", PubOpts(256, 4)));
 
   bool callback_called = false;
   pub.SetOnSendCallback(
@@ -5218,7 +5224,7 @@ TEST_F(ClientTest, OnSendCallbackError) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("onsend_err", {.slot_size = 256, .num_slots = 4}));
+      client.CreatePublisher("onsend_err", PubOpts(256, 4)));
 
   pub.SetOnSendCallback(
       [](void *, int64_t) -> absl::StatusOr<int64_t> {
@@ -5237,7 +5243,7 @@ TEST_F(ClientTest, WaitForUnreliablePublisherFails) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("unreliable_wait", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("unreliable_wait", PubOpts(64, 4)));
   ASSERT_FALSE(pub.IsReliable());
   absl::Status s = pub.Wait();
   ASSERT_FALSE(s.ok());
@@ -5277,7 +5283,7 @@ TEST_F(ClientTest, WaitForSubscriberTimeout) {
 
   // Create pub first so channel exists, then subscriber.
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "sub_timeout", {.slot_size = 64, .num_slots = 4}));
+      "sub_timeout", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("sub_timeout"));
 
   // Read any initial trigger to drain the subscriber fd.
@@ -5313,7 +5319,7 @@ TEST_F(ClientTest, OnReceiveCallbackSuccess) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "onrecv_test", {.slot_size = 256, .num_slots = 4}));
+      "onrecv_test", PubOpts(256, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("onrecv_test"));
 
   bool callback_called = false;
@@ -5341,7 +5347,7 @@ TEST_F(ClientTest, OnReceiveCallbackError) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "onrecv_err", {.slot_size = 256, .num_slots = 4}));
+      "onrecv_err", PubOpts(256, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("onrecv_err"));
 
   sub.SetOnReceiveCallback(
@@ -5376,7 +5382,7 @@ TEST_F(ClientTest, WaitForSubscriberWithExtraFd) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "twofd_test", {.slot_size = 64, .num_slots = 4}));
+      "twofd_test", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("twofd_test"));
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
@@ -5401,7 +5407,7 @@ TEST_F(ClientTest, WaitForSubscriberExtraFdFires) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "twofd_extra", {.slot_size = 64, .num_slots = 4}));
+      "twofd_extra", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("twofd_extra"));
 
   // Drain any initial trigger.
@@ -5506,7 +5512,7 @@ TEST_F(ClientTest, DoubleRegisterResizeCallback) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("double_resize", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("double_resize", PubOpts(64, 4)));
 
   ASSERT_OK(pub.RegisterResizeCallback(
       [](Publisher *, int, int) -> absl::Status { return absl::OkStatus(); }));
@@ -5521,7 +5527,7 @@ TEST_F(ClientTest, UnregisterResizeCallbackNotRegistered) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("unreg_resize", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("unreg_resize", PubOpts(64, 4)));
   absl::Status s = pub.UnregisterResizeCallback();
   ASSERT_FALSE(s.ok());
   EXPECT_THAT(s.message(), ::testing::HasSubstr("No resize callback"));
@@ -5547,7 +5553,7 @@ TEST_F(ClientTest, MessageCopyAndMove) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "msg_copy", {.slot_size = 64, .num_slots = 4}));
+      "msg_copy", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("msg_copy"));
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
@@ -5684,7 +5690,7 @@ TEST_F(ClientTest, ResizeCallbackReturnsError) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("resize_err", {.slot_size = 64, .num_slots = 4}));
+      client.CreatePublisher("resize_err", PubOpts(64, 4)));
 
   ASSERT_OK(pub.RegisterResizeCallback(
       [](Publisher *, int, int) -> absl::Status {
@@ -5704,7 +5710,7 @@ TEST_F(ClientTest, ResizeCallbackReturnsError) {
 
 TEST_F(ClientTest, FreeCreatePublisher) {
   auto pub_or = subspace::CreatePublisher(
-      "free_pub", {.slot_size = 256, .num_slots = 10}, Socket());
+      "free_pub", PubOpts(256, 10), Socket());
   ASSERT_OK(pub_or);
   auto pub = std::move(*pub_or);
   ASSERT_EQ(256, pub.SlotSize());
@@ -5735,7 +5741,7 @@ TEST_F(ClientTest, FreeCreateSubscriber) {
 
 TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {
   auto pub_or = subspace::CreatePublisher(
-      "free_rt", {.slot_size = 256, .num_slots = 10}, Socket());
+      "free_rt", PubOpts(256, 10), Socket());
   ASSERT_OK(pub_or);
   auto pub = std::move(*pub_or);
 
@@ -5756,7 +5762,7 @@ TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {
 
 TEST_F(ClientTest, FreeCreatePublisherBadSocket) {
   auto pub_or = subspace::CreatePublisher(
-      "bad_pub", {.slot_size = 256, .num_slots = 10},
+      "bad_pub", PubOpts(256, 10),
       "/tmp/no_such_subspace_socket");
   ASSERT_FALSE(pub_or.ok());
 }

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -2913,8 +2913,13 @@ TEST_F(ClientTest, FindMessage) {
     ASSERT_OK(buffer);
     char *buf = reinterpret_cast<char *>(*buffer);
     int len = snprintf(buf, 256, "foobar %d", i);
+    subspace::MessagePrefix *prefix = pub->Prefix();
+    ASSERT_NE(nullptr, prefix);
+    prefix->ordinal = static_cast<uint64_t>(i + 1);
+    prefix->timestamp = static_cast<uint64_t>(123456789 + i);
 
-    absl::StatusOr<const Message> pub_status = pub->PublishMessage(len + 1);
+    absl::StatusOr<const Message> pub_status = pub->PublishMessageWithPrefix(
+        len + 1, /*use_slot_id_from_prefix=*/false);
     ASSERT_OK(pub_status);
     msgs.push_back(std::move(*pub_status));
   }

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -1972,13 +1972,14 @@ TEST_F(ClientTest, ExternalPollLoopGetPollFdOnceReadOnce) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
+  constexpr int kNum = 20;
+  constexpr int kNumSlots = kNum + 1;
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber("ext_poll1");
   ASSERT_OK(sub);
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("ext_poll1", 256, 10);
+      pub_client.CreatePublisher("ext_poll1", 256, kNumSlots);
   ASSERT_OK(pub);
 
-  constexpr int kNum = 20;
   std::atomic<int> published{0};
   std::thread publisher([&] {
     for (int i = 0; i < kNum; i++) {
@@ -2023,13 +2024,14 @@ TEST_F(ClientTest, ExternalPollLoopGetPollFdOnceDrainUntilEmpty) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
+  constexpr int kNum = 20;
+  constexpr int kNumSlots = kNum + 1;
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber("ext_poll2");
   ASSERT_OK(sub);
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("ext_poll2", 256, 10);
+      pub_client.CreatePublisher("ext_poll2", 256, kNumSlots);
   ASSERT_OK(pub);
 
-  constexpr int kNum = 20;
   std::thread publisher([&] {
     for (int i = 0; i < kNum; i++) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/client/latency_test.cc
+++ b/client/latency_test.cc
@@ -94,7 +94,7 @@ TEST_F(LatencyTest, MultithreadedSingleChannel) {
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "stress", {.max_active_messages = kNumReceivers + 1});
+      "stress", subspace::SubscriberOptions().SetMaxActiveMessages(kNumReceivers + 1));
   ASSERT_OK(sub);
 
   std::vector<std::thread> receivers;
@@ -182,11 +182,11 @@ TEST_F(LatencyTest, MultithreadedSingleChannelReliable) {
   const int kNumMessages = LatencyValueForSplitBuffers(200000, 20000, 10000);
 
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "rstress", 256, kNumReceivers + 3, {.reliable = true});
+      "rstress", 256, kNumReceivers + 3, subspace::PublisherOptions().SetReliable(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "rstress", {.reliable = true, .max_active_messages = kNumReceivers + 1});
+      "rstress", subspace::SubscriberOptions().SetReliable(true).SetMaxActiveMessages(kNumReceivers + 1));
   ASSERT_OK(sub);
 
   std::vector<std::thread> receivers;
@@ -289,11 +289,11 @@ TEST_F(LatencyTest, MultithreadedReliableLatency) {
   const int kNumMessages = LatencyValueForSplitBuffers(200000, 20000, 10000);
 
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("lstress", 256, 10, {.reliable = true});
+      pub_client.CreatePublisher("lstress", 256, 10, subspace::PublisherOptions().SetReliable(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("lstress", {.reliable = true});
+      sub_client.CreateSubscriber("lstress", subspace::SubscriberOptions().SetReliable(true));
   ASSERT_OK(sub);
 
   uint64_t start_time = toolbelt::Now();
@@ -355,11 +355,11 @@ TEST_F(LatencyTest, MultithreadedReliableLatencyHistogram) {
        num_slots *= 2) {
     std::cerr << "num_slots: " << num_slots << "\n";
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "lstress", 256, num_slots, {.reliable = true});
+        "lstress", 256, num_slots, subspace::PublisherOptions().SetReliable(true));
     ASSERT_OK(pub);
 
     absl::StatusOr<Subscriber> sub =
-        sub_client.CreateSubscriber("lstress", {.reliable = true});
+        sub_client.CreateSubscriber("lstress", subspace::SubscriberOptions().SetReliable(true));
     ASSERT_OK(sub);
 
     uint64_t start_time = toolbelt::Now();
@@ -422,11 +422,11 @@ TEST_F(LatencyTest, MultithreadedUnreliableLatency) {
   const int kNumMessages = LatencyValueForSplitBuffers(2000000, 200000, 50000);
 
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("lustress", 256, 10, {.reliable = false});
+      pub_client.CreatePublisher("lustress", 256, 10, subspace::PublisherOptions().SetReliable(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "lustress", {.reliable = false, .log_dropped_messages = false});
+      "lustress", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
   ASSERT_OK(sub);
 
   uint64_t start_time = toolbelt::Now();
@@ -507,12 +507,12 @@ TEST_F(LatencyTest, PublisherLatency) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "publat", {.reliable = false, .log_dropped_messages = false});
+        "publat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t total_time = 0;
@@ -579,13 +579,13 @@ TEST_F(LatencyTest, PublisherLatencyChecksum) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false, .checksum = true});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false).SetChecksum(true));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
         "publat",
-        {.reliable = false, .log_dropped_messages = false, .checksum = true});
+        ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); opts.SetChecksum(true); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t total_time = 0;
@@ -661,12 +661,12 @@ TEST_F(LatencyTest, PublisherLatencyPayload) {
        num_slots < LatencyValueForSplitBuffers(10000, 2000, 1000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", kMaxPayloadSize, num_slots, {.reliable = false});
+        "publat", kMaxPayloadSize, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "publat", {.reliable = false, .log_dropped_messages = false});
+        "publat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t total_time = 0;
@@ -750,13 +750,13 @@ TEST_F(LatencyTest, PublisherLatencyPayloadChecksum) {
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub =
         pub_client.CreatePublisher("publat", kMaxPayloadSize, num_slots,
-                                   {.reliable = false, .checksum = true});
+                                   subspace::PublisherOptions().SetReliable(false).SetChecksum(true));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
         "publat",
-        {.reliable = false, .log_dropped_messages = false, .checksum = true});
+        ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); opts.SetChecksum(true); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t total_time = 0;
@@ -860,12 +860,12 @@ TEST_F(LatencyTest, PublisherLatencyHistogram) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "publat", {.reliable = false, .log_dropped_messages = false});
+        "publat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     std::vector<uint64_t> latencies;
@@ -957,12 +957,12 @@ TEST_F(LatencyTest, PublisherLatencyHistogramThreadSafe) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "publat", {.reliable = false, .log_dropped_messages = false});
+        "publat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     std::vector<uint64_t> latencies;
@@ -1035,7 +1035,7 @@ TEST_F(LatencyTest, PublisherLatencyMultiSub) {
 
     for (int num_subs = 1; num_subs < sqrt(num_slots); num_subs *= 2) {
       absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-          "publat", 256, num_slots, {.reliable = false});
+          "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
       ASSERT_OK(pub);
 
       std::cerr << num_slots << "," << num_subs << ",";
@@ -1043,7 +1043,7 @@ TEST_F(LatencyTest, PublisherLatencyMultiSub) {
 
       for (int i = 0; i < num_subs; i++) {
         absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-            "publat", {.reliable = false, .log_dropped_messages = false});
+            "publat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
         ASSERT_OK(sub);
         subs.push_back(std::move(*sub));
       }
@@ -1115,13 +1115,13 @@ TEST_F(LatencyTest, VirtualPublisherLatency) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false, .mux = "/foo"});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false).SetMux("/foo"));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
         "publat",
-        {.reliable = false, .log_dropped_messages = false, .mux = "/foo"});
+        ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); opts.SetMux("/foo"); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t total_time = 0;
@@ -1191,7 +1191,7 @@ TEST_F(LatencyTest, VirtualPublisherLatencyMultiSub) {
 
     for (int num_subs = 1; num_subs < sqrt(num_slots); num_subs *= 2) {
       absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-          "publat", 256, num_slots, {.reliable = false, .mux = "/foo"});
+          "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false).SetMux("/foo"));
       ASSERT_OK(pub);
 
       std::cerr << num_slots << "," << num_subs << ",";
@@ -1200,7 +1200,7 @@ TEST_F(LatencyTest, VirtualPublisherLatencyMultiSub) {
       for (int i = 0; i < num_subs; i++) {
         absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
             "publat",
-            {.reliable = false, .log_dropped_messages = false, .mux = "/foo"});
+            ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); opts.SetMux("/foo"); return opts; }()));
         ASSERT_OK(sub);
         subs.push_back(std::move(*sub));
       }
@@ -1272,18 +1272,18 @@ TEST_F(LatencyTest, VirtualPublisherMuxLatency) {
        num_slots < LatencyValueForSplitBuffers(100000, 20000, 3000);
        num_slots = (num_slots)*15 / 10) {
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "publat", 256, num_slots, {.reliable = false, .mux = "/foo"});
+        "publat", 256, num_slots, subspace::PublisherOptions().SetReliable(false).SetMux("/foo"));
     ASSERT_OK(pub);
 
     std::cerr << num_slots << ",";
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
         "publat",
-        {.reliable = false, .log_dropped_messages = false, .mux = "/foo"});
+        ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); opts.SetMux("/foo"); return opts; }()));
     ASSERT_OK(sub);
 
     // Mux subscriber.
     absl::StatusOr<Subscriber> mux_sub = sub_client.CreateSubscriber(
-        "/foo", {.reliable = false, .log_dropped_messages = false});
+        "/foo", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(mux_sub);
 
     uint64_t total_time = 0;
@@ -1354,11 +1354,11 @@ TEST_F(LatencyTest, MultithreadedUnreliableLatencyHistogram) {
        num_slots *= 2) {
     std::cerr << "num_slots: " << num_slots << "\n";
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "lustress", 256, num_slots, {.reliable = false});
+        "lustress", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "lustress", {.reliable = false, .log_dropped_messages = false});
+        "lustress", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     uint64_t start_time = toolbelt::Now();
@@ -1443,11 +1443,11 @@ TEST_F(LatencyTest, MultithreadedUnreliableLatencyPayload) {
   const int kNumMessages = LatencyValueForSplitBuffers(200000, 20000, 10000);
 
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("lustress", 256, 100, {.reliable = false});
+      pub_client.CreatePublisher("lustress", 256, 100, subspace::PublisherOptions().SetReliable(false));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "lustress", {.reliable = false, .log_dropped_messages = false});
+      "lustress", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
   ASSERT_OK(sub);
 
   // Create a subscriber thread to read from the channel and write to random
@@ -1568,11 +1568,11 @@ TEST_F(LatencyTest, MultithreadedUnreliableLatencyPayloadHistogram) {
        num_slots *= 2) {
     std::cerr << "Testing with num_slots: " << num_slots << "\n";
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "lustress", 256, num_slots, {.reliable = false});
+        "lustress", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
 
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "lustress", {.reliable = false, .log_dropped_messages = false});
+        "lustress", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     // Create a subscriber thread to read from the channel and write to random
@@ -1710,7 +1710,7 @@ TEST_F(LatencyTest, ManyChannelsNonMultiplexed) {
   std::vector<Subscriber> subs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        channels[i], {.log_dropped_messages = false});
+        channels[i], ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); return opts; }()));
     // std::cerr << "sub status " << sub.status() << "\n";
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
@@ -1827,7 +1827,7 @@ TEST_F(LatencyTest, ManyChannelsMultiplexed) {
   std::vector<Publisher> pubs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Publisher> pub = pub_clients[i].CreatePublisher(
-        channels[i], kSlotSize, kNumSlots, {.mux = kMux});
+        channels[i], kSlotSize, kNumSlots, subspace::PublisherOptions().SetMux(kMux));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
@@ -1836,7 +1836,7 @@ TEST_F(LatencyTest, ManyChannelsMultiplexed) {
   std::vector<Subscriber> subs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        channels[i], {.log_dropped_messages = false, .mux = kMux});
+        channels[i], ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); opts.SetMux(kMux); return opts; }()));
     // std::cerr << "sub status " << sub.status() << "\n";
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
@@ -1953,14 +1953,14 @@ TEST_F(LatencyTest, ManyChannelsMultiplexedSubscribedToMux) {
   std::vector<Publisher> pubs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Publisher> pub = pub_clients[i].CreatePublisher(
-        channels[i], kSlotSize, kNumSlots, {.mux = kMux});
+        channels[i], kSlotSize, kNumSlots, subspace::PublisherOptions().SetMux(kMux));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
 
   // Create subscriber to multiplexer.
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber(kMux, {.log_dropped_messages = false});
+      sub_client.CreateSubscriber(kMux, ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); return opts; }()));
   // std::cerr << "sub status " << sub.status() << "\n";
   ASSERT_OK(sub);
 
@@ -2062,11 +2062,11 @@ TEST_F(LatencyTest, SubscriberLatency) {
        num_slots += 100) {
     // Create publisher.
     absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-        "sublat", 256, num_slots, {.reliable = false});
+        "sublat", 256, num_slots, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
     // Create subscriber.
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "sublat", {.reliable = false, .log_dropped_messages = false});
+        "sublat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     // Fill channel.
@@ -2103,11 +2103,11 @@ TEST_F(LatencyTest, PubSubLatency) {
        num_messages <= LatencyValueForSplitBuffers(20000, 5000);
        num_messages += 100) {
     absl::StatusOr<Publisher> pub =
-        pub_client.CreatePublisher("pubsublat", 256, 10, {.reliable = false});
+        pub_client.CreatePublisher("pubsublat", 256, 10, subspace::PublisherOptions().SetReliable(false));
     ASSERT_OK(pub);
     // Create subscriber.
     absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-        "pubsublat", {.reliable = false, .log_dropped_messages = false});
+        "pubsublat", ([] { subspace::SubscriberOptions opts; opts.SetReliable(false); opts.SetLogDroppedMessages(false); return opts; }()));
     ASSERT_OK(sub);
 
     // Send and receive messages, measuring time taken.

--- a/client/stress_test.cc
+++ b/client/stress_test.cc
@@ -103,7 +103,7 @@ TEST_F(StressTest, Coroutines) {
       clients[i].pubs.emplace_back(
           EVAL_AND_ASSERT_OK(clients[i].client->CreatePublisher(
               clients[i].channels[j],
-              {.slot_size = 32, .num_slots = kNumSlots})));
+              subspace::PublisherOptions().SetSlotSize(32).SetNumSlots(kNumSlots))));
     }
 
     // Create the subscribers.
@@ -228,7 +228,7 @@ TEST_F(StressTest, Threads) {
       clients[i].pubs.emplace_back(
           EVAL_AND_ASSERT_OK(clients[i].client->CreatePublisher(
               clients[i].channels[j],
-              {.slot_size = 32, .num_slots = kNumSlots})));
+              subspace::PublisherOptions().SetSlotSize(32).SetNumSlots(kNumSlots))));
     }
 
     // Create the subscribers.
@@ -236,7 +236,7 @@ TEST_F(StressTest, Threads) {
       clients[i].subs.emplace_back(
           EVAL_AND_ASSERT_OK(clients[i].client->CreateSubscriber(
               clients[i].channels[j],
-              {.max_active_messages = kMaxActiveMessages})));
+              subspace::SubscriberOptions().SetMaxActiveMessages(kMaxActiveMessages))));
     }
   }
 
@@ -336,13 +336,13 @@ TEST_F(StressTest, ThreadSafety) {
   // Create the publishers.
   for (int j = 0; j < kNumChannels; j++) {
     pubs.emplace_back(EVAL_AND_ASSERT_OK(client->CreatePublisher(
-        channels[j], {.slot_size = 32, .num_slots = kNumSlots})));
+        channels[j], subspace::PublisherOptions().SetSlotSize(32).SetNumSlots(kNumSlots))));
   }
 
   // Create the subscribers.
   for (int j = 0; j < kNumChannels; j++) {
     subs.emplace_back(EVAL_AND_ASSERT_OK(client->CreateSubscriber(
-        channels[j], {.max_active_messages = kMaxActiveMessages})));
+        channels[j], subspace::SubscriberOptions().SetMaxActiveMessages(kMaxActiveMessages))));
   }
 
   std::vector<std::thread> threads;
@@ -423,11 +423,10 @@ TEST_F(StressTest, ActiveMessages) {
   client.channel = "/foobar";
   client.pub = std::make_unique<subspace::Publisher>(
       EVAL_AND_ASSERT_OK(client.client->CreatePublisher(
-          client.channel, {.slot_size = 32, .num_slots = kNumSlots})));
+          client.channel, subspace::PublisherOptions().SetSlotSize(32).SetNumSlots(kNumSlots))));
   client.sub = std::make_unique<subspace::Subscriber>(
       EVAL_AND_ASSERT_OK(client.client->CreateSubscriber(
-          client.channel, {.max_active_messages = kMaxActiveMessages,
-                           .log_dropped_messages = false})));
+          client.channel, ([] { subspace::SubscriberOptions opts; opts.SetMaxActiveMessages(kMaxActiveMessages); opts.SetLogDroppedMessages(false); return opts; }()))));
 
   struct Receiver {
     std::thread thread;
@@ -573,11 +572,10 @@ TEST_F(StressTest, ActiveMessages2) {
   client.channel = "/foobar";
   client.pub = std::make_unique<subspace::Publisher>(
       EVAL_AND_ASSERT_OK(client.client->CreatePublisher(
-          client.channel, {.slot_size = 32, .num_slots = kNumSlots})));
+          client.channel, subspace::PublisherOptions().SetSlotSize(32).SetNumSlots(kNumSlots))));
   client.sub = std::make_unique<subspace::Subscriber>(
       EVAL_AND_ASSERT_OK(client.client->CreateSubscriber(
-          client.channel, {.max_active_messages = kMaxActiveMessages,
-                           .log_dropped_messages = false})));
+          client.channel, ([] { subspace::SubscriberOptions opts; opts.SetMaxActiveMessages(kMaxActiveMessages); opts.SetLogDroppedMessages(false); return opts; }()))));
 
   struct Receiver {
     std::thread thread;
@@ -700,7 +698,7 @@ TEST_F(StressTest, VirtualChannels) {
         subspace::Client::Create(Socket(), absl::StrFormat("client%d", i))));
     absl::StatusOr<Publisher> p = clients[i]->CreatePublisher(
         absl::StrFormat("/foobar/%d", i),
-        {.slot_size = 64, .num_slots = kNumSlots, .mux = "/foobar"});
+        subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(kNumSlots).SetMux("/foobar"));
     ASSERT_OK(p);
     publishers.push_back(std::move(*p));
   }
@@ -774,7 +772,7 @@ TEST_F(StressTest, ManyChannelsNonMultiplexed) {
   std::vector<Publisher> pubs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Publisher> pub = pub_clients[i]->CreatePublisher(
-        channels[i], {.slot_size = kSlotSize, .num_slots = knum_slots});
+        channels[i], subspace::PublisherOptions().SetSlotSize(kSlotSize).SetNumSlots(knum_slots));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
@@ -783,7 +781,7 @@ TEST_F(StressTest, ManyChannelsNonMultiplexed) {
   std::vector<Subscriber> subs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Subscriber> sub = sub_client->CreateSubscriber(
-        channels[i], {.log_dropped_messages = false});
+        channels[i], ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); return opts; }()));
     // std::cerr << "sub status " << sub.status() << "\n";
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
@@ -890,7 +888,7 @@ TEST_F(StressTest, ManyChannelsMultiplexed) {
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Publisher> pub = pub_clients[i]->CreatePublisher(
         channels[i],
-        {.slot_size = kSlotSize, .num_slots = knum_slots, .mux = kMux});
+        subspace::PublisherOptions().SetSlotSize(kSlotSize).SetNumSlots(knum_slots).SetMux(kMux));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
@@ -899,7 +897,7 @@ TEST_F(StressTest, ManyChannelsMultiplexed) {
   std::vector<Subscriber> subs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Subscriber> sub = sub_client->CreateSubscriber(
-        channels[i], {.log_dropped_messages = false, .mux = kMux});
+        channels[i], ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); opts.SetMux(kMux); return opts; }()));
     // std::cerr << "sub status " << sub.status() << "\n";
     ASSERT_OK(sub);
     subs.push_back(std::move(*sub));
@@ -1006,17 +1004,14 @@ TEST_F(StressTest, ManyChannelsMultiplexedSubscribedToMux) {
   std::vector<Publisher> pubs;
   for (int i = 0; i < kNumChannels; i++) {
     absl::StatusOr<Publisher> pub =
-        pub_clients[i]->CreatePublisher(channels[i], {.slot_size = kSlotSize,
-                                                      .num_slots = knum_slots,
-                                                      .activate = true,
-                                                      .mux = kMux});
+        pub_clients[i]->CreatePublisher(channels[i], subspace::PublisherOptions().SetSlotSize(kSlotSize).SetNumSlots(knum_slots).SetActivate(true).SetMux(kMux));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
 
   // Create subscriber to multiplexer.
   absl::StatusOr<Subscriber> sub =
-      sub_client->CreateSubscriber(kMux, {.log_dropped_messages = false});
+      sub_client->CreateSubscriber(kMux, ([] { subspace::SubscriberOptions opts; opts.SetLogDroppedMessages(false); return opts; }()));
   // std::cerr << "sub status " << sub.status() << "\n";
   ASSERT_OK(sub);
 

--- a/client/subscriber.cc
+++ b/client/subscriber.cc
@@ -7,6 +7,13 @@
 namespace subspace {
 namespace details {
 
+static bool ActiveSlotLess(const ActiveSlot &a, const ActiveSlot &b) {
+  if (a.timestamp != b.timestamp) {
+    return a.timestamp < b.timestamp;
+  }
+  return a.ordinal < b.ordinal;
+}
+
 void SubscriberImpl::InitActiveMessages() {
   active_messages_.resize(NumSlots());
   int slot_id = 0;
@@ -258,10 +265,7 @@ MessageSlot *SubscriberImpl::NextSlot(MessageSlot *slot, bool reliable,
     if (!next_slot_cache_valid_ ||
         (!stable_poll_drain && total != next_slot_cached_total_)) {
       CollectVisibleSlots(bits);
-      std::sort(active_slots_.begin(), active_slots_.end(),
-                       [](const ActiveSlot &a, const ActiveSlot &b) {
-                         return a.timestamp < b.timestamp;
-                       });
+      std::sort(active_slots_.begin(), active_slots_.end(), ActiveSlotLess);
       next_slot_cached_total_ = total;
       next_slot_cursor_ = 0;
       next_slot_cache_valid_ = true;
@@ -356,10 +360,7 @@ MessageSlot *SubscriberImpl::LastSlot(MessageSlot *slot, bool reliable,
     CollectVisibleSlots(bits);
 
     // Sort the active slots by timestamp.
-    std::sort(active_slots_.begin(), active_slots_.end(),
-                     [](const ActiveSlot &a, const ActiveSlot &b) {
-                       return a.timestamp < b.timestamp;
-                     });
+    std::sort(active_slots_.begin(), active_slots_.end(), ActiveSlotLess);
 
     ActiveSlot *new_slot = nullptr;
     if (!active_slots_.empty()) {
@@ -408,14 +409,11 @@ MessageSlot *SubscriberImpl::FindActiveSlotByTimestamp(
       MessageSlot *s = &ccb_->slots[i];
       uint64_t refs = s->refs.load(std::memory_order_relaxed);
       if (s->ordinal != 0 && (refs & kPubOwned) == 0) {
-        buffer.push_back({s, 0, Prefix(s)->timestamp});
+        buffer.push_back({s, s->ordinal, Prefix(s)->timestamp, s->vchan_id});
       }
     }
     // Sort by timestamp.
-    std::sort(buffer.begin(), buffer.end(),
-                     [](const ActiveSlot &a, const ActiveSlot &b) {
-                       return a.timestamp < b.timestamp;
-                     });
+    std::sort(buffer.begin(), buffer.end(), ActiveSlotLess);
 
     // Apparently, lower_bound will return the first in the range if
     // the value is less than the whole range.  That's unexpected.
@@ -429,6 +427,9 @@ MessageSlot *SubscriberImpl::FindActiveSlotByTimestamp(
         [](ActiveSlot &s, uint64_t t) { return s.timestamp < t; });
     if (it == buffer.end()) {
       // Not found, nothing changes.
+      return nullptr;
+    }
+    if (it->timestamp != timestamp) {
       return nullptr;
     }
 

--- a/client/syscall_failure_test.cc
+++ b/client/syscall_failure_test.cc
@@ -41,7 +41,7 @@ TEST_F(SyscallFailureTest, MmapFailOnScb) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/mmap_scb_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to map SystemControlBlock"));
@@ -57,7 +57,7 @@ TEST_F(SyscallFailureTest, MmapFailOnCcb) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/mmap_ccb_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to map ChannelControlBlock"));
@@ -75,7 +75,7 @@ TEST_F(SyscallFailureTest, MmapFailOnBcb) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/mmap_bcb_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to map BufferControlBlock"));
@@ -98,7 +98,7 @@ TEST_F(SyscallFailureTest, ShmOpenFail) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/shm_open_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to open shared memory"));
@@ -119,7 +119,7 @@ TEST_F(SyscallFailureTest, FtruncateFailAfterShmOpen) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/ftrunc_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   // On Linux ftruncate is on the shm fd; on POSIX/macOS it's on the shadow file.
   EXPECT_THAT(
@@ -145,7 +145,7 @@ TEST_F(SyscallFailureTest, ChmodFail) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/chmod_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to change permissions"));
@@ -160,7 +160,7 @@ TEST_F(SyscallFailureTest, PollFailWaitForSubscriber) {
   auto client = EVAL_AND_ASSERT_OK(
       subspace::Client::Create(Socket(), "poll_sub_test"));
   auto sub = EVAL_AND_ASSERT_OK(client->CreateSubscriber(
-      "/poll_sub_test", {.max_active_messages = 2}));
+      "/poll_sub_test", subspace::SubscriberOptions().SetMaxActiveMessages(2)));
 
   FailingShim shim;
   shim.poll_fail_countdown = 0;
@@ -182,7 +182,7 @@ TEST_F(SyscallFailureTest, PollFailWaitForReliablePublisher) {
       subspace::Client::Create(Socket(), "poll_pub_test"));
   auto pub = EVAL_AND_ASSERT_OK(client->CreatePublisher(
       "/poll_pub_test",
-      {.slot_size = 64, .num_slots = 4, .reliable = true}));
+      subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4).SetReliable(true)));
 
   FailingShim shim;
   shim.poll_fail_countdown = 0;
@@ -208,7 +208,7 @@ TEST_F(SyscallFailureTest, FstatFailInGetBufferSize) {
 
   // First create a publisher (without the shim) so the channel exists.
   auto pub = EVAL_AND_ASSERT_OK(client->CreatePublisher(
-      "/fstat_test", {.slot_size = 64, .num_slots = 4}));
+      "/fstat_test", subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4)));
 
   // Now publish a message so buffers are created.
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
@@ -246,7 +246,7 @@ TEST_F(SyscallFailureTest, ShimCallCounting) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = EVAL_AND_ASSERT_OK(client->CreatePublisher(
-      "/count_test", {.slot_size = 64, .num_slots = 4}));
+      "/count_test", subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4)));
 
   // Verify that mmap was called at least 3 times (SCB, CCB, BCB).
   EXPECT_GE(shim.mmap_call_count, 3);
@@ -277,7 +277,7 @@ TEST_F(SyscallFailureTest, ShimRestoredAfterGuard) {
   auto client = EVAL_AND_ASSERT_OK(
       subspace::Client::Create(Socket(), "restore_test"));
   auto pub = EVAL_AND_ASSERT_OK(client->CreatePublisher(
-      "/restore_test", {.slot_size = 64, .num_slots = 4}));
+      "/restore_test", subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4)));
   // If the shim wasn't restored, this would have used the FailingShim
   // (which was destroyed) and likely crashed.
 }
@@ -296,7 +296,7 @@ TEST_F(SyscallFailureTest, MmapFailOnBufferMap) {
   ScopedSyscallShim guard(&shim);
 
   auto pub = client->CreatePublisher("/bufmap_test",
-                                     {.slot_size = 64, .num_slots = 4});
+                                     subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4));
   ASSERT_FALSE(pub.ok());
   EXPECT_THAT(pub.status().message(),
               ::testing::HasSubstr("Failed to map shared memory"));

--- a/client/test_fixture.h
+++ b/client/test_fixture.h
@@ -135,7 +135,16 @@ using Message = subspace::Message;
     std::move(*result);                                                        \
   })
 
-#define ASSERT_OK(e) ASSERT_THAT(e, ::absl_testing::IsOk())
+template<typename T>
+std::string StatusToString(const absl::StatusOr<T> &status) {
+  return status.status().ToString();
+}
+
+std::string StatusToString(const absl::Status &status) {
+  return status.ToString();
+}
+
+#define ASSERT_OK(e) ASSERT_THAT(e, ::absl_testing::IsOk()) << StatusToString(e) << " failed"
 
 // Base test fixture that starts a single local Subspace server for the
 // duration of the test suite.  Concrete fixtures inherit from this and

--- a/co20_rpc/client/rpc_client.cc
+++ b/co20_rpc/client/rpc_client.cc
@@ -209,10 +209,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher to channel: %s",
               request_name.c_str());
   auto pub = client_->CreatePublisher(request_name,
-                                      {.slot_size = kRpcRequestSlotSize,
-                                       .num_slots = kRpcRequestNumSlots,
-                                       .reliable = true,
-                                       .type = "subspace.RpcServerRequest"});
+                                      subspace::PublisherOptions().SetSlotSize(kRpcRequestSlotSize).SetNumSlots(kRpcRequestNumSlots).SetReliable(true).SetType("subspace.RpcServerRequest"));
   if (!pub.ok()) {
     co_return absl::InternalError(absl::StrFormat(
         "Failed to create request publisher: %s", pub.status().ToString()));
@@ -221,7 +218,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
   auto sub = client_->CreateSubscriber(
       absl::StrFormat("/rpc/%s/response", service_),
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!sub.ok()) {
     co_return absl::InternalError(absl::StrFormat(
         "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -258,7 +255,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
     auto pub = client_->CreatePublisher(
         method.request_channel().name(), m->slot_size, m->num_slots,
-        {.reliable = true, .type = method.request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method.request_channel().type()));
     if (!pub.ok()) {
       co_return absl::InternalError(absl::StrFormat(
           "Failed to create request publisher: %s", pub.status().ToString()));
@@ -268,7 +265,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
     auto sub = client_->CreateSubscriber(
         method.response_channel().name(),
-        {.reliable = true, .type = method.response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method.response_channel().type()));
     if (!sub.ok()) {
       co_return absl::InternalError(absl::StrFormat(
           "Failed to create response subscriber: %s",
@@ -281,9 +278,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
       auto cpub = client_->CreatePublisher(method.cancel_channel(),
                                            kCancelChannelSlotSize,
                                            kCancelChannelNumSlots,
-                                           {
-                                               .reliable = true,
-                                           });
+                                           subspace::PublisherOptions().SetReliable(true));
       if (!cpub.ok()) {
         co_return absl::InternalError(absl::StrFormat(
             "Failed to create cancel publisher: %s",

--- a/co20_rpc/server/rpc_server.cc
+++ b/co20_rpc/server/rpc_server.cc
@@ -183,9 +183,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating subscriber for %s",
               request_name.c_str());
   auto receiver = client_->CreateSubscriber(
-      request_name, {.reliable = true,
-                     .type = "subspace.RpcServerRequest",
-                     .max_active_messages = 1});
+      request_name, subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerRequest").SetMaxActiveMessages(1));
   if (!receiver.ok()) {
     return receiver.status();
   }
@@ -196,10 +194,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher for %s",
               response_name.c_str());
   auto publisher = client_->CreatePublisher(
-      response_name, {.slot_size = kRpcResponseSlotSize,
-                      .num_slots = kRpcResponseNumSlots,
-                      .reliable = true,
-                      .type = "subspace.RpcServerResponse"});
+      response_name, subspace::PublisherOptions().SetSlotSize(kRpcResponseSlotSize).SetNumSlots(kRpcResponseNumSlots).SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!publisher.ok()) {
     return publisher.status();
   }
@@ -413,7 +408,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Subscriber> sub = client_->CreateSubscriber(
         absl::StrFormat("%s/%d/%d", method->request_channel,
                         session->client_id, session->session_id),
-        {.reliable = true, .type = method->request_type});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->request_type));
     if (!sub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create subscriber for method %s: %s",
@@ -426,10 +421,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Publisher> pub = client_->CreatePublisher(
         absl::StrFormat("%s/%d/%d", method->response_channel,
                         session->client_id, session->session_id),
-        {.slot_size = method->slot_size,
-         .num_slots = method->num_slots,
-         .reliable = true,
-         .type = method->response_type});
+        subspace::PublisherOptions().SetSlotSize(method->slot_size).SetNumSlots(method->num_slots).SetReliable(true).SetType(method->response_type));
     if (!pub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create publisher for method %s: %s",
@@ -444,7 +436,7 @@ RpcServer::CreateSession(uint64_t client_id) {
           client_->CreateSubscriber(
               absl::StrFormat("%s/%d/%d", method->cancel_channel,
                               session->client_id, session->session_id),
-              {.reliable = true, .type = "subspace.RpcCancelRequest"});
+              subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcCancelRequest"));
       if (!cancel_sub.ok()) {
         logger_.Log(toolbelt::LogLevel::kError,
                     "Failed to create cancel subscriber for method %s: %s",

--- a/co20_rpc/server/server_test.cc
+++ b/co20_rpc/server/server_test.cc
@@ -164,13 +164,13 @@ Open([[maybe_unused]] std::shared_ptr<subspace::co20_rpc::RpcServer> server,
 
   auto pub = ctx.client->CreatePublisher(
       "/rpc/Co20TestService/request", 1024, 10,
-      {.reliable = true, .type = "subspace.RpcServerRequest"});
+      subspace::PublisherOptions().SetReliable(true).SetType("subspace.RpcServerRequest"));
   CO_EXPECT_OK(pub);
 
   ctx.pub = std::make_shared<subspace::Publisher>(std::move(*pub));
   auto sub = ctx.client->CreateSubscriber(
       "/rpc/Co20TestService/response",
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   CO_EXPECT_OK(sub);
 
   ctx.sub = std::make_shared<subspace::Subscriber>(std::move(*sub));
@@ -305,12 +305,12 @@ TEST_F(Co20ServerTest, OpenAndCall) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -387,12 +387,12 @@ TEST_F(Co20ServerTest, CallVoidMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -465,12 +465,12 @@ TEST_F(Co20ServerTest, CallError) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -547,12 +547,12 @@ TEST_F(Co20ServerTest, CallAsyncMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -631,12 +631,12 @@ TEST_F(Co20ServerTest, Stream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -716,16 +716,16 @@ TEST_F(Co20ServerTest, CancelStream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto cancel_pub = client.CreatePublisher(
-            method->cancel_channel(), 64, 10, {.reliable = true});
+            method->cancel_channel(), 64, 10, subspace::PublisherOptions().SetReliable(true));
         CO_EXPECT_OK(cancel_pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -25,7 +25,7 @@ cc_library(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
-        "//:qnx": [],
+        "//:qnx": ["-lsocket"],
         "//conditions:default": ["-lrt"],
     }),
     deps = [

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
     deps = [

--- a/common/async/socket.cc
+++ b/common/async/socket.cc
@@ -32,6 +32,8 @@ namespace subspace::async {
 
 namespace {
 
+constexpr bool kSocketDebugEnabled = false;
+
 boost::asio::io_context &IocFromYield(Context yield) {
   return static_cast<boost::asio::io_context &>(
       yield.get_executor().context());
@@ -839,6 +841,16 @@ UnixSocket::SendFds(const std::vector<toolbelt::FileDescriptor> &fds,
     struct iovec iov = {.iov_base = reinterpret_cast<void *>(&num_fds),
                         .iov_len = sizeof(int32_t)};
     size_t fds_size = fds_to_send * sizeof(int);
+    if constexpr (kSocketDebugEnabled) {
+      fprintf(stderr,
+              "SUBSPACE_SHM_DEBUG: SendFds socket=%d total=%zu first=%zu "
+              "count=%zu values=",
+              impl_->fd, fds.size(), first_fd, fds_to_send);
+      for (size_t i = first_fd; i < first_fd + fds_to_send; i++) {
+        fprintf(stderr, "%s%d", i == first_fd ? "" : ",", fds[i].Fd());
+      }
+      fprintf(stderr, "\n");
+    }
     struct msghdr msg = {};
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
@@ -910,16 +922,65 @@ absl::Status UnixSocket::ReceiveFds(std::vector<toolbelt::FileDescriptor> &fds,
     if (n == 0) {
       return absl::InternalError("EOF from socket while reading fds");
     }
-    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
-    if (cmsg == nullptr) {
-      return absl::OkStatus();
+    if constexpr (kSocketDebugEnabled) {
+      fprintf(stderr,
+              "SUBSPACE_SHM_DEBUG: ReceiveFds socket=%d n=%zd total_fds=%d "
+              "msg_flags=0x%x msg_controllen=%zu\n",
+              impl_->fd, n, total_fds, msg.msg_flags,
+              static_cast<size_t>(msg.msg_controllen));
     }
-    int *fdptr = reinterpret_cast<int *>(CMSG_DATA(cmsg));
-    int num_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
-    for (int i = 0; i < num_fds; i++) {
-      fds.emplace_back(fdptr[i]);
+    if ((msg.msg_flags & MSG_CTRUNC) != 0) {
+      return absl::InternalError(
+          "Control data was truncated while reading fds from unix socket");
     }
-    num_fds_received += num_fds;
+
+    bool saw_rights = false;
+    for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr;
+         cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+      if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+        if constexpr (kSocketDebugEnabled) {
+          fprintf(stderr,
+                  "SUBSPACE_SHM_DEBUG: ReceiveFds skipping cmsg level=%d "
+                  "type=%d len=%zu\n",
+                  cmsg->cmsg_level, cmsg->cmsg_type,
+                  static_cast<size_t>(cmsg->cmsg_len));
+        }
+        continue;
+      }
+      saw_rights = true;
+      if (cmsg->cmsg_len < CMSG_LEN(0)) {
+        return absl::InternalError(absl::StrFormat(
+            "Invalid SCM_RIGHTS control length %zu while reading fds",
+            static_cast<size_t>(cmsg->cmsg_len)));
+      }
+      size_t data_len = cmsg->cmsg_len - CMSG_LEN(0);
+      if constexpr (kSocketDebugEnabled) {
+        fprintf(stderr,
+                "SUBSPACE_SHM_DEBUG: ReceiveFds SCM_RIGHTS len=%zu "
+                "data_len=%zu\n",
+                static_cast<size_t>(cmsg->cmsg_len), data_len);
+      }
+      if (data_len % sizeof(int) != 0) {
+        return absl::InternalError(absl::StrFormat(
+            "Misaligned SCM_RIGHTS control length %zu while reading fds",
+            static_cast<size_t>(cmsg->cmsg_len)));
+      }
+      int *fdptr = reinterpret_cast<int *>(CMSG_DATA(cmsg));
+      int num_fds = static_cast<int>(data_len / sizeof(int));
+      for (int i = 0; i < num_fds; i++) {
+        if constexpr (kSocketDebugEnabled) {
+          fprintf(stderr, "SUBSPACE_SHM_DEBUG: ReceiveFds fd[%d]=%d\n",
+                  num_fds_received + i, fdptr[i]);
+        }
+        fds.emplace_back(fdptr[i]);
+      }
+      num_fds_received += num_fds;
+    }
+    if (!saw_rights && total_fds > 0) {
+      return absl::InternalError(absl::StrFormat(
+          "Expected %d fds from unix socket but received no SCM_RIGHTS message",
+          total_fds));
+    }
     if (num_fds_received >= total_fds) {
       break;
     }

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -10,13 +10,14 @@
 #include "toolbelt/mutex.h"
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #if defined(__APPLE__)
 #include <sys/posix_shm.h>
-#include <sys/stat.h>
 #endif
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_replace.h"
 #include <cassert>
+#include <cstdlib>
 #include <inttypes.h>
 #include <mutex>
 #include <unistd.h>
@@ -30,6 +31,42 @@ namespace subspace {
 // is only valid when NDEBUG is not defined (in debug mode).
 #define DEBUG_MMAPS 0
 
+namespace {
+
+bool ShmDebugEnabled() {
+  const char *value = getenv("SUBSPACE_SHM_DEBUG");
+  return value != nullptr && value[0] != '\0' && value[0] != '0';
+}
+
+void PrintFdDebug(const char *operation, const char *purpose, int fd,
+                  size_t size, int prot, void *result, int saved_errno) {
+  struct stat st {};
+  int fstat_result = fstat(fd, &st);
+  int fstat_errno = errno;
+  int flags = fcntl(fd, F_GETFL);
+  int fcntl_errno = errno;
+
+  fprintf(stderr,
+          "SUBSPACE_SHM_DEBUG: %s purpose=%s fd=%d size=%zu prot=0x%x "
+          "result=%p errno=%d (%s) fstat=%d",
+          operation, purpose, fd, size, prot, result, saved_errno,
+          saved_errno == 0 ? "none" : strerror(saved_errno), fstat_result);
+  if (fstat_result == 0) {
+    fprintf(stderr, " mode=0%o file_size=%lld", static_cast<unsigned>(st.st_mode),
+            static_cast<long long>(st.st_size));
+  } else {
+    fprintf(stderr, " fstat_errno=%d (%s)", fstat_errno, strerror(fstat_errno));
+  }
+  if (flags >= 0) {
+    fprintf(stderr, " fd_flags=0x%x", flags);
+  } else {
+    fprintf(stderr, " fcntl_errno=%d (%s)", fcntl_errno, strerror(fcntl_errno));
+  }
+  fprintf(stderr, "\n");
+}
+
+} // namespace
+
 #if !NDEBUG && DEBUG_MMAPS
 // NOTE: due to C++'s undefined initialization and destruction order
 // these can't be actual instances.  They will be allocated on the
@@ -40,7 +77,13 @@ static std::mutex *region_lock;
 
 void *MapMemory(int fd, size_t size, int prot,
                 [[maybe_unused]] const char *purpose) {
+  errno = 0;
   void *p = GetSyscallShim().mmap_fn(NULL, size, prot, MAP_SHARED, fd, 0);
+  int saved_errno = errno;
+  if (p == MAP_FAILED || ShmDebugEnabled()) {
+    PrintFdDebug("mmap", purpose, fd, size, prot, p, saved_errno);
+  }
+  errno = saved_errno;
 #if SHOW_MMAPS
   printf("%d: mapping %s with size %zd: %p -> %p\n", getpid(), purpose, size, p,
          reinterpret_cast<char *>(p) + size);
@@ -62,6 +105,12 @@ void *MapMemory(int fd, size_t size, int prot,
 
 void UnmapMemory(void *p, size_t size,
                  [[maybe_unused]] const char *purpose) {
+  if (p == nullptr || p == MAP_FAILED) {
+    fprintf(stderr, "SUBSPACE_SHM_DEBUG: skipping munmap of invalid %s mapping "
+                    "at %p with size %zu\n",
+            purpose, p, size);
+    return;
+  }
 #if SHOW_MMAPS
   printf("%d: unmapping %s with size %zd: %p -> %p\n", getpid(), purpose, size,
          p, reinterpret_cast<char *>(p) + size);

--- a/common/channel.h
+++ b/common/channel.h
@@ -24,7 +24,7 @@
 namespace subspace {
 
 // Shared-memory backends.  These name the *mechanism*, not the platform:
-//   POSIX  - a named shm_open object plus a /tmp shadow file (BSD/macOS/QNX).
+//   POSIX  - a named shm_open object plus a /tmp shadow file.
 //   LINUX  - a named /dev/shm object (mapped by name, server-free).
 //   MEMFD  - an anonymous memfd_create object (no name; the fd is passed to
 //            other clients via the server).  This is a Linux mechanism that

--- a/common/split_buffer.cc
+++ b/common/split_buffer.cc
@@ -28,10 +28,11 @@ namespace {
 
 absl::Status WriteAll(int fd, const std::string &contents,
                       const std::string &path) {
+  auto &shim = GetSyscallShim();
   const char *p = contents.data();
   size_t remaining = contents.size();
   while (remaining > 0) {
-    ssize_t n = write(fd, p, remaining);
+    ssize_t n = shim.write_fn(fd, p, remaining);
     if (n < 0) {
       if (errno == EINTR) {
         continue;
@@ -44,6 +45,28 @@ absl::Status WriteAll(int fd, const std::string &contents,
     p += n;
   }
   return absl::OkStatus();
+}
+
+absl::Status WriteMetadataContents(const std::string &path,
+                                   const std::string &contents) {
+  auto &shim = GetSyscallShim();
+  int fd = shim.open_fn(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  if (fd == -1) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to create split buffer metadata %s: %s", path,
+        strerror(errno)));
+  }
+
+  absl::Status status = WriteAll(fd, contents, path);
+  if (shim.close_fn(fd) == -1 && status.ok()) {
+    status = absl::InternalError(absl::StrFormat(
+        "Failed to close split buffer metadata %s: %s", path,
+        strerror(errno)));
+  }
+  if (!status.ok()) {
+    shim.unlink_fn(path.c_str());
+  }
+  return status;
 }
 
 uint64_t StableHash64(const std::string &value) {
@@ -97,30 +120,22 @@ absl::Status WriteSplitBufferMetadataFile(
     return absl::InternalError("Failed to serialize split buffer metadata");
   }
 
+  auto &shim = GetSyscallShim();
   std::string tmp = metadata.shadow_file + ".tmp";
-  int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
-  if (fd == -1) {
-    return absl::InternalError(absl::StrFormat(
-        "Failed to create split buffer metadata %s: %s", tmp,
-        strerror(errno)));
-  }
-
-  absl::Status status = WriteAll(fd, contents, tmp);
-  if (close(fd) == -1 && status.ok()) {
-    status = absl::InternalError(absl::StrFormat(
-        "Failed to close split buffer metadata %s: %s", tmp,
-        strerror(errno)));
-  }
+  absl::Status status = WriteMetadataContents(tmp, contents);
   if (!status.ok()) {
-    unlink(tmp.c_str());
     return status;
   }
 
-  if (rename(tmp.c_str(), metadata.shadow_file.c_str()) == -1) {
-    unlink(tmp.c_str());
+  if (shim.rename_fn(tmp.c_str(), metadata.shadow_file.c_str()) == -1) {
+    int saved_errno = errno;
+    shim.unlink_fn(tmp.c_str());
+    if (saved_errno == EXDEV) {
+      return WriteMetadataContents(metadata.shadow_file, contents);
+    }
     return absl::InternalError(absl::StrFormat(
         "Failed to publish split buffer metadata %s: %s",
-        metadata.shadow_file, strerror(errno)));
+        metadata.shadow_file, strerror(saved_errno)));
   }
   return absl::OkStatus();
 }
@@ -267,8 +282,8 @@ absl::Status DestroySplitSharedMemoryBuffer(
         "Failed to unlink split buffer object %s: %s", metadata.object_name,
         strerror(errno)));
   }
-  if (unlink(metadata.shadow_file.c_str()) == -1 && errno != ENOENT &&
-      status.ok()) {
+  if (GetSyscallShim().unlink_fn(metadata.shadow_file.c_str()) == -1 &&
+      errno != ENOENT && status.ok()) {
     status = absl::InternalError(absl::StrFormat(
         "Failed to remove split buffer metadata %s: %s", metadata.shadow_file,
         strerror(errno)));

--- a/common/split_buffer_test.cc
+++ b/common/split_buffer_test.cc
@@ -4,9 +4,12 @@
 
 #include "common/channel.h"
 #include "common/split_buffer.h"
+#include "common/syscall_shim.h"
+#include "common/syscall_shim_test_helper.h"
 
 #include "gtest/gtest.h"
 
+#include <cerrno>
 #include <fcntl.h>
 #include <string>
 #include <sys/stat.h>
@@ -47,6 +50,11 @@ SplitBufferMetadata TestMetadata(const std::string &suffix) {
   return metadata;
 }
 
+int RenameFailsWithExdev(const char *, const char *) {
+  errno = EXDEV;
+  return -1;
+}
+
 TEST(SplitBufferTest, WritesAndReadsMetadata) {
   SplitBufferMetadata metadata = TestMetadata("metadata");
   (void)unlink(metadata.shadow_file.c_str());
@@ -55,6 +63,33 @@ TEST(SplitBufferTest, WritesAndReadsMetadata) {
   auto read_metadata = ReadSplitBufferMetadataFile(metadata.shadow_file);
   ASSERT_TRUE(read_metadata.ok()) << read_metadata.status();
 
+  EXPECT_EQ(read_metadata->channel_name, metadata.channel_name);
+  EXPECT_EQ(read_metadata->session_id, metadata.session_id);
+  EXPECT_EQ(read_metadata->buffer_index, metadata.buffer_index);
+  EXPECT_EQ(read_metadata->slot_id, metadata.slot_id);
+  EXPECT_EQ(read_metadata->is_prefix, metadata.is_prefix);
+  EXPECT_EQ(read_metadata->full_size, metadata.full_size);
+  EXPECT_EQ(read_metadata->allocation_size, metadata.allocation_size);
+  EXPECT_EQ(read_metadata->handle, metadata.handle);
+  EXPECT_EQ(read_metadata->shadow_file, metadata.shadow_file);
+  EXPECT_EQ(read_metadata->object_name, metadata.object_name);
+
+  (void)unlink(metadata.shadow_file.c_str());
+}
+
+TEST(SplitBufferTest, WritesMetadataWhenAtomicRenameReturnsExdev) {
+  SplitBufferMetadata metadata = TestMetadata("metadata_exdev");
+  (void)unlink(metadata.shadow_file.c_str());
+
+  SyscallShim shim;
+  shim.rename_fn = RenameFailsWithExdev;
+  {
+    testing::ScopedSyscallShim scoped_shim(&shim);
+    ASSERT_TRUE(WriteSplitBufferMetadataFile(metadata).ok());
+  }
+
+  auto read_metadata = ReadSplitBufferMetadataFile(metadata.shadow_file);
+  ASSERT_TRUE(read_metadata.ok()) << read_metadata.status();
   EXPECT_EQ(read_metadata->channel_name, metadata.channel_name);
   EXPECT_EQ(read_metadata->session_id, metadata.session_id);
   EXPECT_EQ(read_metadata->buffer_index, metadata.buffer_index);

--- a/common/syscall_shim.h
+++ b/common/syscall_shim.h
@@ -7,6 +7,7 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -37,6 +38,8 @@ struct SyscallShim {
   int (*chown_fn)(const char *, uid_t, gid_t) = ::chown;
   ssize_t (*write_fn)(int, const void *, size_t) = ::write;
   ssize_t (*read_fn)(int, void *, size_t) = ::read;
+  int (*rename_fn)(const char *, const char *) = ::rename;
+  int (*unlink_fn)(const char *) = ::unlink;
 
   SyscallShim();
 };

--- a/coro_rpc/client/rpc_client.cc
+++ b/coro_rpc/client/rpc_client.cc
@@ -205,10 +205,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher to channel: %s",
               request_name.c_str());
   auto pub = client_->CreatePublisher(request_name,
-                                      {.slot_size = kRpcRequestSlotSize,
-                                       .num_slots = kRpcRequestNumSlots,
-                                       .reliable = true,
-                                       .type = "subspace.RpcServerRequest"});
+                                      subspace::PublisherOptions().SetSlotSize(kRpcRequestSlotSize).SetNumSlots(kRpcRequestNumSlots).SetReliable(true).SetType("subspace.RpcServerRequest"));
   if (!pub.ok()) {
     co_return absl::InternalError(absl::StrFormat(
         "Failed to create request publisher: %s", pub.status().ToString()));
@@ -217,7 +214,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
   auto sub = client_->CreateSubscriber(
       absl::StrFormat("/rpc/%s/response", service_),
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!sub.ok()) {
     co_return absl::InternalError(absl::StrFormat(
         "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -254,7 +251,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
     auto pub = client_->CreatePublisher(
         method.request_channel().name(), m->slot_size, m->num_slots,
-        {.reliable = true, .type = method.request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method.request_channel().type()));
     if (!pub.ok()) {
       co_return absl::InternalError(absl::StrFormat(
           "Failed to create request publisher: %s", pub.status().ToString()));
@@ -264,7 +261,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
 
     auto sub = client_->CreateSubscriber(
         method.response_channel().name(),
-        {.reliable = true, .type = method.response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method.response_channel().type()));
     if (!sub.ok()) {
       co_return absl::InternalError(absl::StrFormat(
           "Failed to create response subscriber: %s",
@@ -277,9 +274,7 @@ RpcClient::OpenService(std::chrono::nanoseconds timeout) {
       auto cpub = client_->CreatePublisher(method.cancel_channel(),
                                            kCancelChannelSlotSize,
                                            kCancelChannelNumSlots,
-                                           {
-                                               .reliable = true,
-                                           });
+                                           subspace::PublisherOptions().SetReliable(true));
       if (!cpub.ok()) {
         co_return absl::InternalError(absl::StrFormat(
             "Failed to create cancel publisher: %s",

--- a/coro_rpc/server/rpc_server.cc
+++ b/coro_rpc/server/rpc_server.cc
@@ -182,9 +182,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating subscriber for %s",
               request_name.c_str());
   auto receiver = client_->CreateSubscriber(
-      request_name, {.reliable = true,
-                     .type = "subspace.RpcServerRequest",
-                     .max_active_messages = 1});
+      request_name, subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerRequest").SetMaxActiveMessages(1));
   if (!receiver.ok()) {
     return receiver.status();
   }
@@ -195,10 +193,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher for %s",
               response_name.c_str());
   auto publisher = client_->CreatePublisher(
-      response_name, {.slot_size = kRpcResponseSlotSize,
-                      .num_slots = kRpcResponseNumSlots,
-                      .reliable = true,
-                      .type = "subspace.RpcServerResponse"});
+      response_name, subspace::PublisherOptions().SetSlotSize(kRpcResponseSlotSize).SetNumSlots(kRpcResponseNumSlots).SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!publisher.ok()) {
     return publisher.status();
   }
@@ -417,7 +412,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Subscriber> sub = client_->CreateSubscriber(
         absl::StrFormat("%s/%d/%d", method->request_channel,
                         session->client_id, session->session_id),
-        {.reliable = true, .type = method->request_type});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->request_type));
     if (!sub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create subscriber for method %s: %s",
@@ -430,10 +425,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Publisher> pub = client_->CreatePublisher(
         absl::StrFormat("%s/%d/%d", method->response_channel,
                         session->client_id, session->session_id),
-        {.slot_size = method->slot_size,
-         .num_slots = method->num_slots,
-         .reliable = true,
-         .type = method->response_type});
+        subspace::PublisherOptions().SetSlotSize(method->slot_size).SetNumSlots(method->num_slots).SetReliable(true).SetType(method->response_type));
     if (!pub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create publisher for method %s: %s",
@@ -448,7 +440,7 @@ RpcServer::CreateSession(uint64_t client_id) {
           client_->CreateSubscriber(
               absl::StrFormat("%s/%d/%d", method->cancel_channel,
                               session->client_id, session->session_id),
-              {.reliable = true, .type = "subspace.RpcCancelRequest"});
+              subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcCancelRequest"));
       if (!cancel_sub.ok()) {
         logger_.Log(toolbelt::LogLevel::kError,
                     "Failed to create cancel subscriber for method %s: %s",

--- a/coro_rpc/server/server_test.cc
+++ b/coro_rpc/server/server_test.cc
@@ -183,13 +183,13 @@ Open([[maybe_unused]] std::shared_ptr<subspace::coro_rpc::RpcServer> server,
 
   auto pub = ctx.client->CreatePublisher(
       "/rpc/CoroTestService/request", 1024, 10,
-      {.reliable = true, .type = "subspace.RpcServerRequest"});
+      subspace::PublisherOptions().SetReliable(true).SetType("subspace.RpcServerRequest"));
   CO_EXPECT_OK(pub);
 
   ctx.pub = std::make_shared<subspace::Publisher>(std::move(*pub));
   auto sub = ctx.client->CreateSubscriber(
       "/rpc/CoroTestService/response",
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   CO_EXPECT_OK(sub);
 
   ctx.sub = std::make_shared<subspace::Subscriber>(std::move(*sub));
@@ -327,12 +327,12 @@ TEST_F(CoroServerTest, OpenAndCall) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -410,12 +410,12 @@ TEST_F(CoroServerTest, CallVoidMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -489,12 +489,12 @@ TEST_F(CoroServerTest, CallError) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -572,12 +572,12 @@ TEST_F(CoroServerTest, CallAsyncMethod) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -657,12 +657,12 @@ TEST_F(CoroServerTest, Stream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -743,16 +743,16 @@ TEST_F(CoroServerTest, CancelStream) {
             method->request_channel().name(),
             method->request_channel().slot_size(),
             method->request_channel().num_slots(),
-            {.reliable = true, .type = method->request_channel().type()});
+            subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
         CO_EXPECT_OK(pub);
 
         auto cancel_pub = client.CreatePublisher(
-            method->cancel_channel(), 64, 10, {.reliable = true});
+            method->cancel_channel(), 64, 10, subspace::PublisherOptions().SetReliable(true));
         CO_EXPECT_OK(cancel_pub);
 
         auto sub = client.CreateSubscriber(
             method->response_channel().name(),
-            {.reliable = true, .type = method->response_channel().type()});
+            subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
         CO_EXPECT_OK(sub);
 
         auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));

--- a/manual_tests/BUILD.bazel
+++ b/manual_tests/BUILD.bazel
@@ -21,6 +21,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -45,6 +46,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -69,6 +71,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -92,6 +95,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -114,6 +118,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -136,6 +141,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -159,6 +165,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )

--- a/rpc/client/rpc_client.cc
+++ b/rpc/client/rpc_client.cc
@@ -158,10 +158,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher to channel: %s",
               request_name.c_str());
   auto pub = client_->CreatePublisher(request_name,
-                                      {.slot_size = kRpcRequestSlotSize,
-                                       .num_slots = kRpcRequestNumSlots,
-                                       .reliable = true,
-                                       .type = "subspace.RpcServerRequest"});
+                                      subspace::PublisherOptions().SetSlotSize(kRpcRequestSlotSize).SetNumSlots(kRpcRequestNumSlots).SetReliable(true).SetType("subspace.RpcServerRequest"));
   if (!pub.ok()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to create request publisher: %s", pub.status().ToString()));
@@ -170,7 +167,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
   auto sub = client_->CreateSubscriber(
       absl::StrFormat("/rpc/%s/response", service_),
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!sub.ok()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -208,7 +205,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
     auto pub = client_->CreatePublisher(
         method.request_channel().name(), m->slot_size, m->num_slots,
-        {.reliable = true, .type = method.request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method.request_channel().type()));
     if (!pub.ok()) {
       return absl::InternalError(absl::StrFormat(
           "Failed to create request publisher: %s", pub.status().ToString()));
@@ -218,7 +215,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
 
     auto sub = client_->CreateSubscriber(
         method.response_channel().name(),
-        {.reliable = true, .type = method.response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method.response_channel().type()));
     if (!sub.ok()) {
       return absl::InternalError(absl::StrFormat(
           "Failed to create response subscriber: %s", sub.status().ToString()));
@@ -230,9 +227,7 @@ absl::Status RpcClient::OpenService(std::chrono::nanoseconds timeout,
       auto cpub = client_->CreatePublisher(method.cancel_channel(),
                                            kCancelChannelSlotSize,
                                            kCancelChannelNumSlots,
-                                           {
-                                               .reliable = true,
-                                           });
+                                           subspace::PublisherOptions().SetReliable(true));
       if (!cpub.ok()) {
         return absl::InternalError(absl::StrFormat(
             "Failed to create cancel publisher: %s", cpub.status().ToString()));

--- a/rpc/server/rpc_server.cc
+++ b/rpc/server/rpc_server.cc
@@ -184,9 +184,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating subscriber for %s",
               request_name.c_str());
   auto receiver = client_->CreateSubscriber(
-      request_name, {.reliable = true,
-                     .type = "subspace.RpcServerRequest",
-                     .max_active_messages = 1});
+      request_name, subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerRequest").SetMaxActiveMessages(1));
   if (!receiver.ok()) {
     return receiver.status();
   }
@@ -197,10 +195,7 @@ absl::Status RpcServer::CreateChannels() {
   logger_.Log(toolbelt::LogLevel::kDebug, "Creating publisher for %s",
               response_name.c_str());
   auto publisher = client_->CreatePublisher(
-      response_name, {.slot_size = kRpcResponseSlotSize,
-                      .num_slots = kRpcResponseNumSlots,
-                      .reliable = true,
-                      .type = "subspace.RpcServerResponse"});
+      response_name, subspace::PublisherOptions().SetSlotSize(kRpcResponseSlotSize).SetNumSlots(kRpcResponseNumSlots).SetReliable(true).SetType("subspace.RpcServerResponse"));
   if (!publisher.ok()) {
     return publisher.status();
   }
@@ -425,7 +420,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Subscriber> sub = client_->CreateSubscriber(
         absl::StrFormat("%s/%d/%d", method->request_channel, session->client_id,
                         session->session_id),
-        {.reliable = true, .type = method->request_type});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->request_type));
     if (!sub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create subscriber for method %s: %s",
@@ -438,10 +433,7 @@ RpcServer::CreateSession(uint64_t client_id) {
     absl::StatusOr<subspace::Publisher> pub = client_->CreatePublisher(
         absl::StrFormat("%s/%d/%d", method->response_channel,
                         session->client_id, session->session_id),
-        {.slot_size = method->slot_size,
-         .num_slots = method->num_slots,
-         .reliable = true,
-         .type = method->response_type});
+        subspace::PublisherOptions().SetSlotSize(method->slot_size).SetNumSlots(method->num_slots).SetReliable(true).SetType(method->response_type));
     if (!pub.ok()) {
       logger_.Log(toolbelt::LogLevel::kError,
                   "Failed to create publisher for method %s: %s",
@@ -457,7 +449,7 @@ RpcServer::CreateSession(uint64_t client_id) {
           client_->CreateSubscriber(
               absl::StrFormat("%s/%d/%d", method->cancel_channel,
                               session->client_id, session->session_id),
-              {.reliable = true, .type = "subspace.RpcCancelRequest"});
+              subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcCancelRequest"));
       if (!cancel_sub.ok()) {
         logger_.Log(toolbelt::LogLevel::kError,
                     "Failed to create cancel subscriber for method %s: %s",

--- a/rpc/server/server_test.cc
+++ b/rpc/server/server_test.cc
@@ -265,13 +265,13 @@ static void Open(std::shared_ptr<subspace::RpcServer> /*server*/,
 
   auto pub = ctx.client->CreatePublisher(
       "/rpc/TestService/request", 1024, 10,
-      {.reliable = true, .type = "subspace.RpcServerRequest"});
+      subspace::PublisherOptions().SetReliable(true).SetType("subspace.RpcServerRequest"));
   ASSERT_OK(pub);
 
   ctx.pub = std::make_shared<subspace::Publisher>(std::move(*pub));
   auto sub = ctx.client->CreateSubscriber(
       "/rpc/TestService/response",
-      {.reliable = true, .type = "subspace.RpcServerResponse"});
+      subspace::SubscriberOptions().SetReliable(true).SetType("subspace.RpcServerResponse"));
   ASSERT_OK(sub);
 
   ctx.sub = std::make_shared<subspace::Subscriber>(std::move(*sub));
@@ -409,7 +409,7 @@ TEST_F(ServerTest, OpenAndCallNoResponseRead) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     std::cerr << "publishing " << req.DebugString();
@@ -462,14 +462,14 @@ TEST_F(ServerTest, OpenAndCall) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     std::cerr << "subscribing to " << method->response_channel().name()
               << std::endl;
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     std::cerr << "publishing " << req.DebugString();
@@ -552,12 +552,12 @@ TEST_F(ServerTest, CallAsyncMethod) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     auto buffer = pub->GetMessageBuffer(int32_t(req.ByteSizeLong()));
@@ -632,12 +632,12 @@ TEST_F(ServerTest, CallVoidMethod) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     std::cerr << "publishing " << req.DebugString();
@@ -721,12 +721,12 @@ TEST_F(ServerTest, CallError) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     std::cerr << "publishing " << req.DebugString();
@@ -811,14 +811,14 @@ TEST_F(ServerTest, Stream) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     std::cerr << "subscribing to " << method->response_channel().name()
               << std::endl;
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     std::cerr << "publishing " << req.DebugString();
@@ -907,18 +907,18 @@ TEST_F(ServerTest, CancelStream) {
     auto pub = client.CreatePublisher(
         method->request_channel().name(), method->request_channel().slot_size(),
         method->request_channel().num_slots(),
-        {.reliable = true, .type = method->request_channel().type()});
+        subspace::PublisherOptions().SetReliable(true).SetType(method->request_channel().type()));
     ASSERT_OK(pub);
 
     auto cancel_pub = client.CreatePublisher(method->cancel_channel(), 64, 10,
-                                             {.reliable = true});
+                                             subspace::PublisherOptions().SetReliable(true));
     ASSERT_OK(cancel_pub);
 
     std::cerr << "subscribing to " << method->response_channel().name()
               << std::endl;
     auto sub = client.CreateSubscriber(
         method->response_channel().name(),
-        {.reliable = true, .type = method->response_channel().type()});
+        subspace::SubscriberOptions().SetReliable(true).SetType(method->response_channel().type()));
     ASSERT_OK(sub);
 
     std::cerr << "publishing " << req.DebugString();

--- a/rust_client/cross_lang_ffi.cc
+++ b/rust_client/cross_lang_ffi.cc
@@ -43,13 +43,12 @@ CppPublisherHandle cpp_test_create_publisher_with_split(
     int num_slots, int32_t checksum_size, int32_t metadata_size,
     bool use_split_buffers) {
   auto *client = static_cast<subspace::Client *>(client_handle);
-  subspace::PublisherOptions opts{
-      .slot_size = slot_size,
-      .num_slots = num_slots,
-      .checksum_size = checksum_size,
-      .metadata_size = metadata_size,
-      .use_split_buffers = use_split_buffers,
-  };
+  subspace::PublisherOptions opts;
+  opts.SetSlotSize(slot_size)
+      .SetNumSlots(num_slots)
+      .SetChecksumSize(checksum_size)
+      .SetMetadataSize(metadata_size)
+      .SetUseSplitBuffers(use_split_buffers);
   auto status_or = client->CreatePublisher(channel, opts);
   if (!status_or.ok()) {
     return nullptr;
@@ -89,8 +88,8 @@ CppSubscriberHandle cpp_test_create_subscriber(CppClientHandle client_handle,
                                                const char *channel,
                                                bool checksum) {
   auto *client = static_cast<subspace::Client *>(client_handle);
-  subspace::SubscriberOptions opts{};
-  opts.checksum = checksum;
+  subspace::SubscriberOptions opts;
+  opts.SetChecksum(checksum);
   auto status_or = client->CreateSubscriber(channel, opts);
   if (!status_or.ok()) {
     return nullptr;

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -56,6 +56,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog", "-ldl"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt", "-ldl"],
     }),
 )

--- a/server/server.cc
+++ b/server/server.cc
@@ -639,13 +639,15 @@ void Server::CleanupAfterSession() {
       (void)std::filesystem::remove(entry.path());
     }
   }
-  // Remove all files in /tmp that contain .scb., .ccb. or .bcb. in the name.
-  std::string ccb_shm_prefix = absl::StrFormat(".%d.ccb.", session_id_);
-  std::string bcb_shm_prefix = absl::StrFormat(".%d.bcb.", session_id_);
+  // Remove shadow files for the session's POSIX shm objects.
+  std::string session_shm_prefix =
+      absl::StrFormat("%08x.", static_cast<uint32_t>(session_id_));
   for (const auto &entry : std::filesystem::directory_iterator("/tmp")) {
     std::string filename = entry.path().filename().string();
-    if (filename.find(ccb_shm_prefix) != std::string::npos ||
-        filename.find(bcb_shm_prefix) != std::string::npos) {
+    if (filename.rfind(session_shm_prefix, 0) == 0 &&
+        (filename.find(".scb.") != std::string::npos ||
+         filename.find(".ccb.") != std::string::npos ||
+         filename.find(".bcb.") != std::string::npos)) {
       (void)std::filesystem::remove(entry.path());
       // There is also a shm segment with the same name as the file.
       (void)shm_unlink(entry.path().filename().c_str());
@@ -686,7 +688,8 @@ void Server::CleanupFilesystem() {
   // Remove all files in /tmp that contain .scb., .ccb. or .bcb. in the name.
   for (const auto &entry : std::filesystem::directory_iterator("/tmp")) {
     std::string filename = entry.path().filename().string();
-    if (filename.find(".ccb.") != std::string::npos ||
+    if (filename.find(".scb.") != std::string::npos ||
+        filename.find(".ccb.") != std::string::npos ||
         filename.find(".bcb.") != std::string::npos) {
       (void)std::filesystem::remove(entry.path());
       // There is also a shm segment with the same name as the file.
@@ -805,7 +808,7 @@ absl::Status Server::Run(int num_asio_threads) {
       CleanupFilesystem();
     }
     absl::StatusOr<SystemControlBlock *> scb =
-        CreateSystemControlBlock(scb_fd_);
+        CreateSystemControlBlock(scb_fd_, session_id_);
     if (!scb.ok()) {
       return absl::InternalError(absl::StrFormat(
           "Failed to create SystemControlBlock in shared memory: %s",

--- a/server/server.cc
+++ b/server/server.cc
@@ -7,6 +7,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "client/client.h"
+#include "common/split_buffer.h"
 #include "client_handler.h"
 #include "proto/subspace.pb.h"
 #include "toolbelt/clock.h"
@@ -47,6 +48,40 @@ static bool ChannelUsesSplitBuffers(const ServerChannel *channel) {
   return split_channel->HasSplitBufferOptions() &&
          split_channel->GetSplitBufferOptions().use_split_buffers;
 }
+
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
+static bool CleanupSplitBufferMetadataFile(const std::filesystem::path &path) {
+  absl::StatusOr<SplitBufferMetadata> metadata =
+      ReadSplitBufferMetadataFile(path.string());
+  if (!metadata.ok() || metadata->object_name.empty()) {
+    return false;
+  }
+
+  (void)DestroySplitSharedMemoryBuffer(*metadata);
+  return true;
+}
+
+static void CleanupPosixShadowFile(const std::filesystem::path &path) {
+  auto status = Channel::PosixSharedMemoryName(path.string());
+  if (status.ok()) {
+    (void)shm_unlink(status->c_str());
+  }
+  (void)std::filesystem::remove(path);
+}
+
+static void CleanupSubspaceTmpFile(const std::filesystem::path &path) {
+  if (CleanupSplitBufferMetadataFile(path)) {
+    return;
+  }
+  CleanupPosixShadowFile(path);
+}
+
+static void CleanupSplitBufferObjectFile(const std::filesystem::path &path) {
+  std::string object_name = path.filename().string();
+  (void)shm_unlink(object_name.c_str());
+  (void)std::filesystem::remove(path);
+}
+#endif
 
 static bool ChannelUsesSplitBuffersOverBridge(const ServerChannel *channel) {
   const ServerChannel *split_channel = SplitBufferOptionsChannel(channel);
@@ -618,25 +653,19 @@ void Server::ForeachChannel(std::function<void(ServerChannel *)> func) {
 
 void Server::CleanupAfterSession() {
   std::string session_shm_file_prefix =
-      "subspace_." + std::to_string(session_id_);
+      "subspace_" + std::to_string(session_id_);
 
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   // Android uses anonymous fd-backed shared memory; there are no shm files to
   // remove for a session.
 
 #elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
-  // Remove all files starting with "subspace_SESSION" in /tmp.  These refer to
-  // shared memory segments names "subspace_INODE".
+  // Remove this session's /tmp shadow files.  Split-buffer metadata shadows are
+  // parsed first so their paired subspace_sb_* shm objects can be removed too.
   for (const auto &entry : std::filesystem::directory_iterator("/tmp")) {
     if (entry.path().filename().string().rfind(session_shm_file_prefix, 0) ==
         0) {
-      // Extrace the node and remove the shared memory segment.
-      // The name of the shared memory segment is "subspace_<inode>".
-      auto status = Channel::PosixSharedMemoryName(entry.path().string());
-      if (status.ok()) {
-        shm_unlink(status->c_str());
-      }
-      (void)std::filesystem::remove(entry.path());
+      CleanupSubspaceTmpFile(entry.path());
     }
   }
   // Remove shadow files for the session's POSIX shm objects.
@@ -672,17 +701,14 @@ void Server::CleanupFilesystem() {
   // remove.
 
 #elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
-  // Remove all files starting with "subspace_" in /tmp.  These refer to
-  // shared memory segments names "subspace_INODE".
+  // Remove Subspace /tmp artifacts.  Split-buffer metadata shadows are parsed
+  // before deletion so their paired subspace_sb_* shm objects can be removed.
   for (const auto &entry : std::filesystem::directory_iterator("/tmp")) {
-    if (entry.path().filename().string().rfind("subspace_", 0) == 0) {
-      // Extrace the node and remove the shared memory segment.
-      // The name of the shared memory segment is "subspace_<inode>".
-      auto status = Channel::PosixSharedMemoryName(entry.path().string());
-      if (status.ok()) {
-        shm_unlink(status->c_str());
-      }
-      (void)std::filesystem::remove(entry.path());
+    std::string filename = entry.path().filename().string();
+    if (filename.rfind("subspace_sb_", 0) == 0) {
+      CleanupSplitBufferObjectFile(entry.path());
+    } else if (filename.rfind("subspace_", 0) == 0) {
+      CleanupSubspaceTmpFile(entry.path());
     }
   }
   // Remove all files in /tmp that contain .scb., .ccb. or .bcb. in the name.

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -29,7 +29,7 @@ ServerChannel::~ServerChannel() {
 static absl::StatusOr<void *> CreateSharedMemory(int id, const char *suffix,
                                                  int64_t size, bool map,
                                                  toolbelt::FileDescriptor &fd,
-                                                 [[maybe_unused]] int session_id = 0) {
+                                                 [[maybe_unused]] uint64_t session_id = 0) {
   char shm_file[NAME_MAX]; // Unique file in file system.
   int tmpfd;
 
@@ -70,19 +70,13 @@ static absl::StatusOr<void *> CreateSharedMemory(int id, const char *suffix,
 
 #else
   char *shm_name;          // Name passed to shm_* (starts with /)
-#if defined(__linux__)
-  // On Linux we have actual files in /dev/shm so we can create a unique file.
-  snprintf(shm_file, sizeof(shm_file), "/dev/shm/%d.%s.XXXXXX", id, suffix);
-  tmpfd = mkstemp(shm_file);
-  shm_name = shm_file + 8; // After /dev/shm
-#else
-  // On other systems (BSD, MacOS, etc), we need to use a file in /tmp.
-  // This is just used to ensure uniqueness.
-  snprintf(shm_file, sizeof(shm_file), "/tmp/%d.%d.%s.XXXXXX", session_id, id,
-           suffix);
+  // Create a shadow file in /tmp for uniqueness.  The shm object name is
+  // derived from this path and unlinked while the shadow file stays around for
+  // lifetime/cleanup bookkeeping.
+  snprintf(shm_file, sizeof(shm_file), "/tmp/%08x.%d.%s.XXXXXX",
+           static_cast<uint32_t>(session_id), id, suffix);
   tmpfd = mkstemp(shm_file);
   shm_name = shm_file + 4; // After /tmp
-#endif
   // Remove any existing shared memory.
   shm_unlink(shm_name);
 
@@ -123,9 +117,9 @@ static absl::StatusOr<void *> CreateSharedMemory(int id, const char *suffix,
 }
 
 absl::StatusOr<SystemControlBlock *>
-CreateSystemControlBlock(toolbelt::FileDescriptor &fd) {
+CreateSystemControlBlock(toolbelt::FileDescriptor &fd, uint64_t session_id) {
   absl::StatusOr<void *> s = CreateSharedMemory(
-      0, "scb", sizeof(SystemControlBlock), /*map=*/true, fd, 0);
+      0, "scb", sizeof(SystemControlBlock), /*map=*/true, fd, session_id);
   if (!s.ok()) {
     return s.status();
   }

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -29,7 +29,7 @@ class ClientHandler;
 class Server;
 
 absl::StatusOr<SystemControlBlock *>
-CreateSystemControlBlock(toolbelt::FileDescriptor &fd);
+CreateSystemControlBlock(toolbelt::FileDescriptor &fd, uint64_t session_id);
 
 struct ResizeInfo {
   int old_slot_size;

--- a/shadow/BUILD.bazel
+++ b/shadow/BUILD.bazel
@@ -37,6 +37,7 @@ cc_binary(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt"],
     }),
 )
@@ -65,6 +66,7 @@ cc_test(
         "//:macos_arm64": [],
         "//:macos_default": [],
         "//:android": ["-llog", "-ldl"],
+        "//:qnx": [],
         "//conditions:default": ["-lrt", "-ldl"],
     }),
 )

--- a/shadow/shadow_test.cc
+++ b/shadow/shadow_test.cc
@@ -9,6 +9,7 @@
 #include "server/server.h"
 #include "shadow/shadow.h"
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <arpa/inet.h>
 #include <chrono>
 #include <csignal>
@@ -650,12 +651,30 @@ TEST_F(ShadowRecoveryTest, SplitBufferMessageDataSurvivesRecovery) {
     ASSERT_THAT(pub->PublishMessage(kPayloadLen), IsOk());
   }
 
-  // Wait for the shadow to learn about the channel and its split buffers.
+  // Wait for the shadow to learn about the channel and all data split-buffer
+  // slots.  Seeing just one registration is not enough; a fast restart can
+  // otherwise race the remaining registration events.
   ASSERT_TRUE(WaitForShadowState([this]() {
     return shadow_->WithChannels([](auto &channels) {
       auto it = channels.find("shadow_split_data");
-      return it != channels.end() && it->second.use_split_buffers &&
-             !it->second.client_buffers.empty();
+      if (it == channels.end() || !it->second.use_split_buffers) {
+        return false;
+      }
+      for (uint32_t slot_id = 0; slot_id < 4; ++slot_id) {
+        auto slot_registered =
+            std::find_if(it->second.client_buffers.begin(),
+                         it->second.client_buffers.end(),
+                         [slot_id](const subspace::RegisteredClientBuffer
+                                       &buffer) {
+                           return buffer.metadata.buffer_index == 0 &&
+                                  buffer.metadata.slot_id == slot_id &&
+                                  !buffer.metadata.is_prefix;
+                         });
+        if (slot_registered == it->second.client_buffers.end()) {
+          return false;
+        }
+      }
+      return true;
     });
   }));
 

--- a/shadow/shadow_test.cc
+++ b/shadow/shadow_test.cc
@@ -701,7 +701,7 @@ TEST_F(ShadowRecoveryTest, ShadowTracksPlaceholderRemap) {
   sub_client.SetThreadSafe(true);
   ASSERT_THAT(sub_client.Init(RecoveryServerSocket()), IsOk());
   auto sub = sub_client.CreateSubscriber("shadow_placeholder_remap",
-                                         {.max_active_messages = 2});
+                                         subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_THAT(sub, IsOk());
   ASSERT_TRUE(sub->IsPlaceholder());
 
@@ -1426,7 +1426,7 @@ TEST_F(BridgeShadowRecoveryTest, BridgeRecoversAfterServerRestart) {
 
   auto pub = client0.CreatePublisher(
       "/bridge_recovery_chan",
-      {.slot_size = 256, .num_slots = 10, .local = false});
+      subspace::PublisherOptions().SetSlotSize(256).SetNumSlots(10).SetLocal(false));
   ASSERT_THAT(pub, IsOk());
 
   // Client 1 on server 1: create a subscriber.
@@ -1435,7 +1435,7 @@ TEST_F(BridgeShadowRecoveryTest, BridgeRecoversAfterServerRestart) {
   ASSERT_THAT(client1.Init(BridgeServer1Socket()), IsOk());
 
   auto sub = client1.CreateSubscriber("/bridge_recovery_chan",
-                                      {.max_active_messages = 2});
+                                      subspace::SubscriberOptions().SetMaxActiveMessages(2));
   ASSERT_THAT(sub, IsOk());
 
   // Wait for bridge to be established.  Server 1's BridgeReceiverCoroutine


### PR DESCRIPTION
## Summary
- Avoid Linux-only `-lrt` linkopts on QNX by adding a QNX platform select branch.
- Replace `PublisherOptions` and `SubscriberOptions` designated initializers with setter-based construction across tests, RPC clients/servers, and C/Rust wrapper glue.
- Keep C wrapper defaults compatible with older compilers while preserving option defaults.

## Test plan
- `bazelisk build //client:latency_test //client:stress_test //rpc/client:rpc_client //coro_rpc/client:rpc_client //co20_rpc/client:rpc_client //asio_rpc/client:rpc_client //c_client:subspace_c_client //rust_client:cross_lang_ffi`
- `bazelisk test //client:client_test //client:bridge_test //client:asio_client_test //client:syscall_failure_test //shadow:shadow_test //rpc/server:server_test //rpc/client:client_test //coro_rpc/server:server_test //coro_rpc/client:client_test //co20_rpc/server:server_test //co20_rpc/client:client_test //asio_rpc/server:server_test //asio_rpc/client:client_test //c_client:client_test`
- `bazelisk test //rust_client:client_test`