### PR TITLE
Fix subscriber count after channel remap

### DIFF
--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -942,6 +942,43 @@ TEST_F(ClientTest, PlaceholderSubscriberLearnsSplitBuffersOnReload) {
   EXPECT_NE(reinterpret_cast<const void *>(sub_prefix), msg->buffer);
 }
 
+TEST_F(ClientTest, PlaceholderSubscriberReloadRebuildsCcbSubscriberCount) {
+  subspace::Client pub_client;
+  subspace::Client sub_client;
+  ASSERT_OK(pub_client.Init(Socket()));
+  ASSERT_OK(sub_client.Init(Socket()));
+
+  constexpr char kChannel[] = "placeholder_subscriber_count";
+  absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(kChannel);
+  ASSERT_OK(sub);
+  ASSERT_TRUE(sub->IsPlaceholder());
+
+  absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(kChannel, 128, 4);
+  ASSERT_OK(pub);
+
+  subspace::ServerChannel *server_channel = Server()->FindChannel(kChannel);
+  ASSERT_NE(nullptr, server_channel);
+  server_channel->GetCcb()->subscribers.ClearAll();
+  server_channel->GetCcb()->num_subs = subspace::SubscriberCounter();
+  ASSERT_EQ(0, pub->NumSubscribers());
+
+  absl::StatusOr<Message> empty = sub->ReadMessage();
+  ASSERT_OK(empty);
+  ASSERT_EQ(0, empty->length);
+  EXPECT_FALSE(sub->IsPlaceholder());
+  EXPECT_EQ(1, sub->NumSubscribers());
+  EXPECT_EQ(1, pub->NumSubscribers());
+
+  absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
+  ASSERT_OK(buffer);
+  std::memcpy(*buffer, "count", 5);
+  ASSERT_OK(pub->PublishMessage(5));
+
+  absl::StatusOr<Message> msg = sub->ReadMessage();
+  ASSERT_OK(msg);
+  ASSERT_EQ(5, msg->length);
+}
+
 TEST_F(ClientTest, RejectsMixedSplitBufferPublisherOptions) {
   subspace::Client client;
   InitClient(client);

--- a/common/channel.h
+++ b/common/channel.h
@@ -466,12 +466,14 @@ public:
   std::string BufferSharedMemoryName(uint64_t session_id,
                                      int buffer_index) const;
 
-  void RegisterSubscriber(int sub_id, int vchan_id, bool is_new) {
+  void RegisterSubscriber(int sub_id, int vchan_id, bool /*is_new*/) {
     ccb_->subscribers.Set(sub_id);
     ccb_->sub_vchan_ids[sub_id] = vchan_id;
-    if (is_new) {
-      ccb_->num_subs.AddSubscriber(vchan_id);
-    }
+    SubscriberCounter num_subs;
+    ccb_->subscribers.Traverse([this, &num_subs](size_t id) {
+      num_subs.AddSubscriber(ccb_->sub_vchan_ids[id]);
+    });
+    ccb_->num_subs = num_subs;
   }
 
   int GetSubVchanId(int32_t i) const { return ccb_->sub_vchan_ids[i]; }

--- a/server/server.cc
+++ b/server/server.cc
@@ -1197,6 +1197,7 @@ absl::Status Server::RemapChannel(ServerChannel *channel, int slot_size,
   }
   channel->SetLastKnownSlotSize(slot_size);
   channel->SetSharedMemoryFds(std::move(*fds));
+  channel->RegisterExistingSubscribers();
   // Remapping replaces the CCB/BCB FDs; shadow recovery must receive the
   // refreshed descriptors instead of retaining the placeholder mappings.
   ForEachShadow([channel](const std::unique_ptr<ShadowReplicator> &s) {

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -260,11 +260,6 @@ absl::StatusOr<SharedMemoryFds>
 ServerChannel::Allocate(const toolbelt::FileDescriptor &scb_fd,
                         [[maybe_unused]] int slot_size, int num_slots,
                         int initial_ordinal) {
-  SubscriberCounter num_subs;
-
-  if (scb_ != nullptr) {
-    num_subs = ccb_->num_subs;
-  }
   // Unmap existing memory.
   Unmap();
 
@@ -298,7 +293,7 @@ ServerChannel::Allocate(const toolbelt::FileDescriptor &scb_fd,
     return p.status();
   }
   ccb_ = reinterpret_cast<ChannelControlBlock *>(*p);
-  ccb_->num_subs = num_subs;
+  ccb_->num_subs = SubscriberCounter();
 
   // Create buffer control block.
   p = CreateSharedMemory(channel_id_, "bcb", sizeof(BufferControlBlock),
@@ -477,6 +472,22 @@ ServerChannel::AddSubscriber(ClientHandler *handler, bool is_reliable,
   SubscriberUser *result = sub.get();
   AddUser(*user_id, std::move(sub));
   return result;
+}
+
+void ServerChannel::RegisterExistingSubscribers() {
+  for (auto &[id, user] : users_) {
+    if (user == nullptr || !user->IsSubscriber()) {
+      continue;
+    }
+    RegisterSubscriber(id, GetVirtualChannelId(), /*is_new=*/true);
+  }
+}
+
+void ChannelMultiplexer::RegisterExistingSubscribers() {
+  ServerChannel::RegisterExistingSubscribers();
+  for (VirtualChannel *vchan : virtual_channels_) {
+    vchan->RegisterExistingSubscribers();
+  }
 }
 
 void ServerChannel::TriggerAllSubscribers() {

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -217,6 +217,7 @@ public:
   absl::StatusOr<SubscriberUser *>
   AddSubscriber(ClientHandler *handler, bool is_reliable, bool is_bridge,
                 bool for_tunnel, int max_active_messages);
+  virtual void RegisterExistingSubscribers();
 
   virtual std::string Type() const { return Channel::Type(); }
   virtual void SetType(const std::string &type) { Channel::SetType(type); }
@@ -473,6 +474,7 @@ public:
   void RemoveVirtualChannel(VirtualChannel *vchan);
 
   bool IsMux() const override { return true; }
+  void RegisterExistingSubscribers() override;
   bool IsEmpty() const override {
     return virtual_channels_.empty() && ServerChannel::IsEmpty();
   }


### PR DESCRIPTION
## Summary
- Re-register existing subscribers into a fresh CCB after placeholder channel remap.
- Rebuild the CCB subscriber count from registered subscriber bits to keep reload registration idempotent.
- Add a regression test for placeholder subscriber reload restoring CCB subscriber counts.

## Test plan
- bazelisk test //client:client_test --test_filter=ClientTest.PlaceholderSubscriberReloadRebuildsCcbSubscriberCount --test_output=errors
- bazelisk test //client:client_test --test_filter=ClientTest.CreateSubscriberThenPublisher:ClientTest.PublishAndResizeSubscriberFirst:ClientTest.PublishVirtualAndResizeSubscriberFirst:ClientTest.PlaceholderSubscriberLearnsSplitBuffersOnReload --test_output=errors
- bazelisk test //server:server_test --test_output=errors