### PR TITLE
Fix attaching publisher corrupting resized buffer sizes

### DIFF
--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -78,8 +78,17 @@ ClientBufferHandleMetadata ClientBufferFromSplitMetadata(
 absl::StatusOr<std::string>
 ClientChannel::CreatePosixSharedMemoryFile(const std::string &filename,
                                            off_t size) {
-  // Create a file in /tmp and make it the same size as the shared memory.  This
-  // will not actually allocate any disk space.
+  // Create a file in /tmp whose size records the real size of the shared memory
+  // segment (fstat on the shm object returns a page-aligned size, so the shadow
+  // file is the authoritative record; see GetBufferSize).  This will not
+  // actually allocate any disk space.
+  //
+  // Only set the size if it has not been set yet.  Several publishers may open
+  // the same buffer's shadow file: the one that creates the buffer sizes it,
+  // and a publisher attaching later must not resize it.  In particular a
+  // publisher joining with a smaller requested slot size must not shrink a
+  // buffer that an earlier publisher already created larger (e.g. after a
+  // resize), which would corrupt the recorded buffer size.
   auto &shim = GetSyscallShim();
   int fd = shim.open_fn(filename.c_str(), O_RDWR | O_CREAT, 0666);
   if (fd < 0) {
@@ -87,11 +96,20 @@ ClientChannel::CreatePosixSharedMemoryFile(const std::string &filename,
         absl::StrFormat("Failed to open shadow file %s: %s", filename.c_str(),
                         strerror(errno)));
   }
-  if (shim.ftruncate_fn(fd, size) < 0) {
+  struct stat sb;
+  if (shim.fstat_fn(fd, &sb) < 0) {
     shim.close_fn(fd);
     return absl::InternalError(
-        absl::StrFormat("Failed to truncate shadow file %s to size %zd: %s",
-                        filename.c_str(), size, strerror(errno)));
+        absl::StrFormat("Failed to stat shadow file %s: %s", filename.c_str(),
+                        strerror(errno)));
+  }
+  if (sb.st_size == 0 && size > 0) {
+    if (shim.ftruncate_fn(fd, size) < 0) {
+      shim.close_fn(fd);
+      return absl::InternalError(
+          absl::StrFormat("Failed to truncate shadow file %s to size %zd: %s",
+                          filename.c_str(), size, strerror(errno)));
+    }
   }
   shim.close_fn(fd);
 

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -238,6 +238,37 @@ TEST_F(ClientTest, Resize1) {
   ASSERT_EQ(512, pub->SlotSize());
 }
 
+TEST_F(ClientTest, AttachingPublisherPreservesResizedSlotSize) {
+  subspace::Client client1;
+  InitClient(client1);
+  subspace::PublisherOptions options = PubOpts(256, 10);
+  options.SetUseSplitBuffers(false);
+
+  absl::StatusOr<Publisher> pub1 =
+      client1.CreatePublisher("attach_preserves_resize", options);
+  ASSERT_OK(pub1);
+  ASSERT_OK(pub1->GetMessageBuffer(300));
+  ASSERT_EQ(512, pub1->SlotSize());
+  pub1->CancelPublish();
+
+  absl::StatusOr<const subspace::ChannelInfo> info =
+      client1.GetChannelInfo("attach_preserves_resize");
+  ASSERT_OK(info);
+  ASSERT_EQ(512u, info->slot_size);
+
+  subspace::Client client2;
+  InitClient(client2);
+  absl::StatusOr<Publisher> pub2 =
+      client2.CreatePublisher("attach_preserves_resize", options);
+  ASSERT_OK(pub2);
+  EXPECT_EQ(512, pub2->SlotSize());
+
+  absl::StatusOr<const subspace::ChannelInfo> updated_info =
+      client1.GetChannelInfo("attach_preserves_resize");
+  ASSERT_OK(updated_info);
+  EXPECT_EQ(512u, updated_info->slot_size);
+}
+
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 TEST(AndroidBufferRegistrationTest, FailedRegistrationRollsBackNumBuffers) {
   constexpr int kNumSlots = 2;

--- a/client/publisher.cc
+++ b/client/publisher.cc
@@ -41,29 +41,39 @@ absl::Status PublisherImpl::CreateOrAttachBuffers(uint64_t final_slot_size) {
         continue;
       }
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
+      bool opened_existing_buffer = buffer_index < size_t(num_buffers);
       absl::StatusOr<toolbelt::FileDescriptor> shm_fd =
-          buffer_index < size_t(num_buffers)
+          opened_existing_buffer
               ? OpenBuffer(buffer_index)
               : CreateBuffer(buffer_index, final_buffer_size);
 #else
+      bool opened_existing_buffer = false;
       auto shm_fd = CreateBuffer(buffer_index, final_buffer_size);
 #endif
       if (!shm_fd.ok()) {
         return shm_fd.status();
       }
       if (!shm_fd->Valid()) {
-        // This means that the file in /dev/shm already exists so we need to
-        // attach to it.
+        // The named shared memory already exists so we attach to it instead of
+        // creating it.
+        opened_existing_buffer = true;
         shm_fd = OpenBuffer(buffer_index);
         if (!shm_fd.ok()) {
           return shm_fd.status();
         }
+      }
+      if (opened_existing_buffer) {
+        // Attaching to a buffer another publisher already created.  Its real
+        // size may be larger than our requested size (for example the channel
+        // was resized before we joined), so use the buffer's actual size and
+        // record it under its own index rather than clobbering a neighbouring
+        // slot with our smaller requested size.
         auto size = GetBufferSize(*shm_fd, buffer_index);
         if (!size.ok()) {
           return size.status();
         }
-        absl::StatusOr<char *> addr;
         current_slot_size = BufferSizeToSlotSize(*size);
+        absl::StatusOr<char *> addr;
         if (current_slot_size > 0) {
           addr = MapBuffer(*shm_fd, *size, BufferMapMode::kReadWrite);
           if (!addr.ok()) {
@@ -76,12 +86,11 @@ absl::Status PublisherImpl::CreateOrAttachBuffers(uint64_t final_slot_size) {
             std::make_unique<BufferSet>(*size, current_slot_size, *addr);
         buffer_set->fd = std::move(*shm_fd);
         buffers_.push_back(std::move(buffer_set));
-        bcb_->sizes[buffers_.size()].store(final_buffer_size,
-                                           std::memory_order_relaxed);
+        bcb_->sizes[buffer_index].store(*size, std::memory_order_relaxed);
       } else {
-        // We successfully created the /dev/shm file.
-        bcb_->sizes[buffers_.size()].store(final_buffer_size,
-                                           std::memory_order_relaxed);
+        // We successfully created the shared memory.
+        bcb_->sizes[buffer_index].store(final_buffer_size,
+                                        std::memory_order_relaxed);
         auto addr =
             MapBuffer(*shm_fd, final_buffer_size, BufferMapMode::kReadWrite);
         if (!addr.ok()) {


### PR DESCRIPTION
## Summary

Properly fixes the bug that cursor bot PR #103 targeted. When a channel is
resized and a later publisher attaches to the existing buffers, both the
joining publisher's `SlotSize()` and the server-reported channel info could
report the smaller *joining* slot size instead of the resized one.

Two independent bugs combine to produce this, and both are fixed here:

1. **BCB size indexing / attach detection** (`client/publisher.cc`).
   `CreateOrAttachBuffers` stored the size at `bcb_->sizes[buffers_.size()]`
   *after* `push_back` (an off-by-one that wrote the *next* buffer's slot) and
   stored the joining publisher's requested `final_buffer_size` rather than the
   attached buffer's real size. The MEMFD path additionally treated an opened,
   already-registered buffer like a freshly created one. Now the real buffer
   size is recorded under its own `buffer_index`, and attaching vs. creating is
   distinguished explicitly for all shared-memory backends.

2. **POSIX shadow-file shrink** (`client/client_channel.cc`).
   On POSIX the shadow file's size is the authoritative record of a buffer's
   size (`fstat` on the shm object returns a page-aligned size).
   `CreatePosixSharedMemoryFile` unconditionally `ftruncate`d that shadow file
   to the caller's requested size, so a publisher attaching with a *smaller*
   slot size shrank a buffer an earlier publisher had created *larger* (after a
   resize). `GetBufferSize` then read the shrunken size back. The shadow file is
   now sized **only when it has not been sized yet**, so an attaching publisher
   never resizes an existing buffer, while a fresh buffer is still sized by its
   creator.

The server derives channel slot size from `bcb_->sizes[num_buffers-1]`, so both
bugs also skewed `GetChannelInfo`.

### Why PR #103 was not enough

PR #103 fixed only the first half (index/MEMFD). Its own regression test passed
on the Linux/memfd path the bot validated, but **failed on the POSIX
shared-memory backend** (macOS and the default non-memfd path CI runs), because
the shadow-file shrink in (2) still corrupted the recorded size. That is why it
was excluded from the combined bug-fix PR and redone here.

### Backends

- **POSIX**: fixes (1) + (2).
- **Linux (`/dev/shm`)**: fixes (1); it uses `O_EXCL` + `fstat` on the shm fd so
  it never had the shrink bug.
- **MEMFD (Android / `--config=linux_memfd`)**: fixes (1), matching PR #103's
  already-validated change.

## Test plan

Run locally on macOS arm64 (POSIX backend):

- [x] `bazelisk test //client:client_test --test_filter=ClientTest.AttachingPublisherPreservesResizedSlotSize` (was failing, now passes)
- [x] `bazelisk test //... --config=macos_arm64` (25 tests pass)
- [x] Split-buffer variant: `//client:client_test //c_client:client_test --test_arg=--use_split_buffers`
- [x] Asio backend `//client:client_test //client:bridge_test`

Not runnable on macOS: the Linux `--config=linux_memfd` matrix (covers the MEMFD
path); its publisher-side change mirrors the previously validated PR #103.