### PR TITLE
Place POSIX shadow files in /tmp on QNX, not the cwd

### DIFF
--- a/common/channel.cc
+++ b/common/channel.cc
@@ -170,13 +170,19 @@ std::string Channel::BufferSharedMemoryName(uint64_t session_id,
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   return absl::StrFormat("subspace_%d_%s_%d", session_id, sanitized_name,
                          buffer_index);
-#elif defined(__APPLE__)
-  // Since you can't actually see any shared memory names in the MacOS
-  // filesystem we need to use /tmp to create a shadow file that is mapped to a
-  // shared memory name.
+#elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX
+  // In POSIX mode (macOS and QNX) the shared memory object name is derived
+  // from a "shadow" file on disk: its length records the buffer's true size
+  // (fstat on the shm object itself is page-aligned) and its inode is used to
+  // name the shm object (see PosixSharedMemoryName).  This is an actual
+  // filesystem path, so anchor it in /tmp; a bare relative name would create
+  // the shadow file in the process's current working directory and, worse,
+  // would make the server's cleanup miss it (and leak the shm object) whenever
+  // the server and publisher run from different directories.
   return absl::StrFormat("/tmp/subspace_%d_%s_%d", session_id, sanitized_name,
                          buffer_index);
 #else
+  // Linux (/dev/shm): this is a shm_open object name, not a filesystem path.
   return absl::StrFormat("subspace_%d_%s_%d", session_id, sanitized_name,
                          buffer_index);
 #endif


### PR DESCRIPTION
## Summary
On QNX, `subspace_<sessionid>_<channel>_<index>` files were being created in the current working directory of whatever process created a buffer, rather than in `/tmp`.

These are the POSIX-mode **shadow files**: in `SUBSPACE_SHMEM_MODE_POSIX` (macOS and QNX) the shared memory object is named/sized via a small on-disk file (its length records the buffer's true size, since `fstat` on the shm object is page-aligned, and its inode names the shm object — see `PosixSharedMemoryName`).

The bug was in `Channel::BufferSharedMemoryName`: it only special-cased `__APPLE__` for the `/tmp/` prefix. QNX (also POSIX mode) fell through to the generic branch and returned a **bare relative name**, so:
- The shadow file landed in the process's cwd instead of `/tmp`.
- The server's cleanup, keyed off `/tmp`, missed these files and leaked the underlying shm object whenever the server and publishers ran from different working directories.

## Fix
Key the `/tmp/` shadow-file path on `SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX` so it applies to both macOS and QNX. The Linux `/dev/shm` path is an `shm_open` object name (not a filesystem path) and is left untouched.

## Test plan
- [x] `bazelisk test //... --config=macos_arm64` (POSIX mode) — all pass; macOS shadow-file path unchanged (still `/tmp`).
- [ ] Verify on QNX that shadow files now appear under `/tmp` and are cleaned up on channel/session teardown.