### PR TITLE
Automate publishing releases to the Bazel Central Registry

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,7 @@
+# Publish to BCR configuration.
+#
+# The MODULE.bazel that is published lives at the repository root, so the
+# default moduleRoots of ["."] is correct and no configuration is required
+# here.  This file is intentionally (almost) empty; see
+# https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates for the
+# available options (e.g. moduleRoots for multi-module repos).

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://github.com/dallison/subspace",
+  "maintainers": [
+    {
+      "name": "Dave Allison",
+      "email": "david.s.allison@gmail.com",
+      "github": "dallison",
+      "github_user_id": 1817319
+    }
+  ],
+  "repository": [
+    "github:dallison/subspace"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,34 @@
+matrix:
+  platform:
+  - macos_arm64
+  - ubuntu2204
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@subspace//client:subspace_client'
+    - '@subspace//c_client:subspace_c_client'
+    - '@subspace//server:subspace_server'
+bcr_test_module:
+  module_path: .
+  matrix:
+    platform:
+    - macos_arm64
+    - ubuntu2204
+    bazel:
+    - 8.x
+    - 9.x
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+      - //client:client_test
+      - //c_client:client_test
+      - //client:bridge_test

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,45 @@
+name: Publish to BCR
+
+# Mirrors each GitHub release of Subspace to the Bazel Central Registry by
+# opening a pull request against bazelbuild/bazel-central-registry.  The entry
+# is generated from the templates in the .bcr/ folder of this repository.
+#
+# The old "Publish to BCR" GitHub App was discontinued on 2026-06-30; this uses
+# its replacement, the bazel-contrib/publish-to-bcr reusable workflow.
+#
+# One-time setup required for this to work (see the PR description):
+#   * A fork of bazelbuild/bazel-central-registry must exist at
+#     dallison/bazel-central-registry (this is where the PR branch is pushed).
+#   * A repository secret named BCR_PUBLISH_TOKEN must contain a *classic*
+#     Personal Access Token (fine-grained PATs cannot open pull requests
+#     against public repositories) with the "repo" and "workflow" scopes, able
+#     to push to the fork and open a PR against bazelbuild/bazel-central-registry.
+
+on:
+  release:
+    types: [published]
+  # Allow re-publishing a specific existing tag by hand, e.g. to retry after a
+  # transient failure or after fixing the .bcr templates.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: The release tag to publish to the BCR (e.g. 2.10.0)
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.2
+    with:
+      tag_name: ${{ inputs.tag_name || github.event.release.tag_name }}
+      # Fork of bazelbuild/bazel-central-registry that the PR branch is pushed to.
+      registry_fork: dallison/bazel-central-registry
+      # The release archive is uploaded by the existing release process rather
+      # than by bazel-contrib's release workflow, so entry-file attestation is
+      # not produced here (matching the existing Subspace BCR entries).  Flip to
+      # true (and re-add the id-token/attestations permissions below) to enable.
+      attest: false
+    permissions:
+      contents: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
Adds automation so that every published GitHub release of Subspace automatically opens a PR against the Bazel Central Registry (BCR), instead of the entry being added by hand.

This uses the `bazel-contrib/publish-to-bcr` **reusable workflow**. (The old "Publish to BCR" GitHub App was discontinued on 2026-06-30, so the App is no longer an option.)

### What's added
- `.github/workflows/publish.yaml` — triggers on `release: published` (plus a manual `workflow_dispatch` with a `tag_name` input to re-publish a tag). It calls `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.2`, pushing the entry branch to a registry fork and opening the PR.
- `.bcr/` templates that generate the registry entry:
  - `source.template.json` — resolves to the uploaded `subspace-<tag>.tar.gz` release asset with `strip_prefix: subspace-<version>`. Verified to reproduce the existing `modules/subspace/2.9.0/source.json` byte-for-byte (integrity is auto-computed by the workflow).
  - `presubmit.yml` — copied verbatim from the known-good `modules/subspace/2.9.0/presubmit.yml` (`verify_targets` building the client/c_client/server libs + `bcr_test_module` running the client/bridge tests, on macos_arm64 + ubuntu2204, Bazel 8.x/9.x).
  - `metadata.template.json` — Dave Allison / dallison, homepage + repo, empty `versions` (the workflow appends).
  - `config.yml` — documents that the module root is `.` (default); no config needed.
- `attest: false` — the release tarball is uploaded by the existing release process (not bazel-contrib's release workflow) and the existing BCR entries have no attestations, so entry-file attestation is intentionally left off. Easy to flip on later.

Because subspace is **already in BCR through 2.9.0**, these templates are built to reproduce exactly what BCR CI already accepts, minimising the chance of a failed first automated run.

## Required one-time setup (maintainer)
These cannot be done from this PR and must be set up on the `dallison` account:
1. **Fork the registry**: create `dallison/bazel-central-registry` (fork of `bazelbuild/bazel-central-registry`).
2. **Add the secret** `BCR_PUBLISH_TOKEN` (repo Settings -> Secrets and variables -> Actions): a **classic** PAT (fine-grained PATs cannot open PRs against public repos) with `repo` + `workflow` scopes, able to push to the fork and open a PR upstream.

## How it will work
Cut a release (e.g. tag `2.10.0`) with the `subspace-2.10.0.tar.gz` asset attached -> the workflow runs -> a PR is opened on `bazelbuild/bazel-central-registry` adding `modules/subspace/2.10.0`. BCR maintainers still review/merge that PR (automation gets you to a green PR, it doesn't bypass review).

## Test plan
- [x] JSON/YAML of all added files validated.
- [x] `source.template.json` substituted for 2.9.0 matches the live BCR `source.json`.
- [x] `presubmit.yml` matches the live BCR 2.9.0 presubmit.
- [ ] After merge + fork/secret setup: cut a test release (or use `workflow_dispatch` on an existing tag) and confirm a registry PR is opened.