### PR TITLE
Expose split callback fd registration

### DIFF
--- a/c_client/subspace.cc
+++ b/c_client/subspace.cc
@@ -170,6 +170,8 @@ SubspaceSplitBufferInfo ToCInfo(const subspace::SplitBufferMetadata &metadata) {
       .full_size = metadata.full_size,
       .allocation_size = metadata.allocation_size,
       .handle = metadata.handle,
+      .registration_fd = metadata.registration_fd,
+      .map_offset = metadata.map_offset,
   };
 }
 
@@ -178,7 +180,9 @@ ToCMapping(const subspace::SplitBufferMapping &mapping) {
   return {.handle = mapping.handle,
           .address = mapping.address,
           .size = mapping.size,
-          .private_data = mapping.private_data};
+          .private_data = mapping.private_data,
+          .fd = mapping.fd,
+          .map_offset = mapping.map_offset};
 }
 
 subspace::SplitBufferMapping
@@ -186,7 +190,9 @@ ToCppMapping(const SubspaceSplitBufferMapping &mapping) {
   return {.handle = mapping.handle,
           .address = mapping.address,
           .size = mapping.size,
-          .private_data = mapping.private_data};
+          .private_data = mapping.private_data,
+          .fd = mapping.fd,
+          .map_offset = mapping.map_offset};
 }
 
 subspace::SplitBufferCallbacks

--- a/c_client/subspace.h
+++ b/c_client/subspace.h
@@ -111,6 +111,8 @@ typedef struct {
   uint64_t full_size;
   uint64_t allocation_size;
   uintptr_t handle;
+  int registration_fd;
+  int64_t map_offset;
 } SubspaceSplitBufferInfo;
 
 typedef struct {
@@ -118,6 +120,8 @@ typedef struct {
   void *address;
   size_t size;
   void *private_data;
+  int fd;
+  int64_t map_offset;
 } SubspaceSplitBufferMapping;
 
 typedef struct {

--- a/client/client.cc
+++ b/client/client.cc
@@ -111,6 +111,7 @@ static void ToProto(const ClientBufferHandleMetadata &metadata,
   proto->set_shadow_file(metadata.shadow_file);
   proto->set_object_name(metadata.object_name);
   proto->set_allocator(ToProtoAllocator(metadata.allocator));
+  proto->set_map_offset(metadata.map_offset);
 }
 
 static ClientBufferHandleMetadata
@@ -127,6 +128,7 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   metadata.shadow_file = proto.shadow_file();
   metadata.object_name = proto.object_name();
   metadata.allocator = FromProtoAllocator(proto.allocator());
+  metadata.map_offset = proto.map_offset();
   return metadata;
 }
 

--- a/client/client_channel.cc
+++ b/client/client_channel.cc
@@ -54,7 +54,8 @@ ClientBufferHandleMetadata ClientBufferFromSplitMetadata(
           .handle = metadata.handle,
           .shadow_file = metadata.shadow_file,
           .object_name = metadata.object_name,
-          .allocator = allocator};
+          .allocator = allocator,
+          .map_offset = metadata.map_offset};
 }
 
 [[maybe_unused]] SplitBufferMetadata SplitMetadataFromClientBuffer(
@@ -68,7 +69,8 @@ ClientBufferHandleMetadata ClientBufferFromSplitMetadata(
           .allocation_size = metadata.allocation_size,
           .handle = metadata.handle,
           .shadow_file = metadata.shadow_file,
-          .object_name = metadata.object_name};
+          .object_name = metadata.object_name,
+          .map_offset = metadata.map_offset};
 }
 
 } // namespace
@@ -446,6 +448,7 @@ absl::StatusOr<toolbelt::FileDescriptor>
 ClientChannel::CreateMemfdBuffer(const std::string &filename, size_t size) {
   return CreateAnonymousSharedMemory(filename, size);
 }
+#endif
 
 absl::StatusOr<RegisteredClientBuffer>
 ClientChannel::GetRegisteredClientBuffer(uint32_t buffer_index, bool is_prefix,
@@ -484,7 +487,6 @@ ClientChannel::GetRegisteredClientBuffer(uint32_t buffer_index, bool is_prefix,
   }
   return status;
 }
-#endif
 
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_LINUX
 absl::StatusOr<toolbelt::FileDescriptor>
@@ -725,6 +727,10 @@ ClientChannel::CreateSplitBufferSet(size_t buffer_index, size_t full_size,
       slot_private_data = mapping->private_data;
       metadata.handle = slot_handle;
       metadata.allocation_size = slot_mapped_size;
+      metadata.map_offset = mapping->map_offset;
+      if (mapping->fd >= 0) {
+        slot_fd.emplace(mapping->fd, /*owned=*/false);
+      }
     } else {
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
       // Create and register our own memfd, then adopt the server's first-wins
@@ -881,6 +887,7 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
     }
     SplitBufferMetadata metadata =
         SplitMetadataFromClientBuffer(registered->metadata);
+    metadata.registration_fd = registered->fd.Fd();
 #else
     std::string shadow_file = absl::StrFormat("%s_slot_%d", metadata_base, slot);
     auto metadata_or = ReadSplitBufferMetadataFileWithRetry(shadow_file);
@@ -893,7 +900,22 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
     uintptr_t slot_handle = metadata.handle;
     uint64_t slot_mapped_size = payload_size;
     void *slot_private_data = nullptr;
+    std::optional<toolbelt::FileDescriptor> registered_fd;
     if (SplitBuffersCallbacks().map) {
+#if SUBSPACE_SHMEM_MODE != SUBSPACE_SHMEM_MODE_MEMFD
+      absl::StatusOr<RegisteredClientBuffer> registered =
+          GetRegisteredClientBuffer(static_cast<uint32_t>(buffer_index),
+                                    /*is_prefix=*/false,
+                                    static_cast<uint32_t>(slot));
+      if (!registered.ok()) {
+        return registered.status();
+      }
+      metadata = SplitMetadataFromClientBuffer(registered->metadata);
+      registered_fd.emplace(std::move(registered->fd));
+#endif
+      if (registered_fd.has_value()) {
+        metadata.registration_fd = registered_fd->Fd();
+      }
       auto mapping = SplitBuffersCallbacks().map(metadata);
       if (!mapping.ok()) {
         return mapping.status();
@@ -925,6 +947,9 @@ ClientChannel::OpenSplitBufferSet(size_t buffer_index, size_t full_size,
       slot_addr = *addr;
       slot_handle = static_cast<uintptr_t>(slot_fd.Fd());
       buffer->split_fds.push_back(std::move(slot_fd));
+    }
+    if (registered_fd.has_value()) {
+      buffer->split_fds.push_back(std::move(*registered_fd));
     }
     buffer->split_handles[slot] = slot_handle;
     buffer->split_slot_buffers[slot] = slot_addr;

--- a/client/client_channel.h
+++ b/client/client_channel.h
@@ -367,10 +367,11 @@ protected:
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
   absl::StatusOr<toolbelt::FileDescriptor>
   CreateMemfdBuffer(const std::string &filename, size_t size);
+#endif
   absl::StatusOr<RegisteredClientBuffer>
   GetRegisteredClientBuffer(uint32_t buffer_index, bool is_prefix,
                             uint32_t slot_id);
-#elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_LINUX
+#if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_LINUX
   absl::StatusOr<toolbelt::FileDescriptor>
   CreateLinuxBuffer(const std::string &filename, size_t size);
 #elif SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_POSIX

--- a/common/client_buffer.h
+++ b/common/client_buffer.h
@@ -51,6 +51,7 @@ struct ClientBufferHandleMetadata {
   std::string shadow_file;
   std::string object_name;
   ClientBufferAllocatorKind allocator = ClientBufferAllocatorKind::kUnspecified;
+  int64_t map_offset = 0;
 };
 
 struct RegisteredClientBuffer {

--- a/common/split_buffer.cc
+++ b/common/split_buffer.cc
@@ -93,6 +93,7 @@ SplitBufferMetadata SplitBufferMetadataFromProto(
   metadata.handle = static_cast<uintptr_t>(proto.handle());
   metadata.shadow_file = proto.shadow_file();
   metadata.object_name = proto.object_name();
+  metadata.map_offset = proto.map_offset();
   return metadata;
 }
 
@@ -108,6 +109,7 @@ void SplitBufferMetadataToProto(const SplitBufferMetadata &metadata,
   proto->set_handle(static_cast<uint64_t>(metadata.handle));
   proto->set_shadow_file(metadata.shadow_file);
   proto->set_object_name(metadata.object_name);
+  proto->set_map_offset(metadata.map_offset);
 }
 
 absl::Status WriteSplitBufferMetadataFile(

--- a/common/split_buffer.h
+++ b/common/split_buffer.h
@@ -27,6 +27,8 @@ struct SplitBufferMetadata {
   uintptr_t handle = 0;
   std::string shadow_file;
   std::string object_name;
+  int registration_fd = -1;
+  int64_t map_offset = 0;
 };
 
 struct SplitBufferMapping {
@@ -34,6 +36,8 @@ struct SplitBufferMapping {
   void *address = nullptr;
   size_t size = 0;
   void *private_data = nullptr;
+  int fd = -1;
+  int64_t map_offset = 0;
 };
 
 struct SplitBufferCallbacks {

--- a/proto/subspace.proto
+++ b/proto/subspace.proto
@@ -158,6 +158,7 @@ message ClientBufferHandleMetadataProto {
   string shadow_file = 9;
   string object_name = 10;
   ClientBufferAllocator allocator = 11;
+  int64 map_offset = 12;
 }
 
 message RegisterClientBufferRequest {

--- a/rust_client/src/channel.rs
+++ b/rust_client/src/channel.rs
@@ -389,6 +389,7 @@ impl BufferSet {
                         .copied()
                         .unwrap_or(self.slot_size) as usize,
                     private_data: self.split_private_data.get(slot).copied().unwrap_or(0),
+                    map_offset: metadata.map_offset,
                 };
                 if self.uses_split_callbacks
                     && self.owns_split_buffers

--- a/rust_client/src/publisher.rs
+++ b/rust_client/src/publisher.rs
@@ -746,6 +746,7 @@ impl PublisherImpl {
             handle: 0,
             shadow_file: prefix_name.clone(),
             object_name: split_buffer_object_name(&prefix_name),
+            map_offset: 0,
         };
 
         let prefix_fd = match create_split_shared_memory_buffer(&prefix_metadata)? {
@@ -780,6 +781,7 @@ impl PublisherImpl {
                 handle: 0,
                 shadow_file: shadow_file.clone(),
                 object_name: split_buffer_object_name(&shadow_file),
+                map_offset: 0,
             };
             let slot_fd;
             let slot_addr;
@@ -804,6 +806,7 @@ impl PublisherImpl {
                 slot_private_data = mapping.private_data;
                 metadata.handle = slot_handle;
                 metadata.allocation_size = slot_mapped_size;
+                metadata.map_offset = mapping.map_offset;
             } else {
                 slot_fd = create_split_shared_memory_buffer(&metadata)?.ok_or_else(|| {
                     SubspaceError::Internal(format!(

--- a/rust_client/src/split_buffer.rs
+++ b/rust_client/src/split_buffer.rs
@@ -23,6 +23,7 @@ pub struct SplitBufferMetadata {
     pub handle: u64,
     pub shadow_file: String,
     pub object_name: String,
+    pub map_offset: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -31,6 +32,7 @@ pub struct SplitBufferMapping {
     pub address: *mut u8,
     pub size: usize,
     pub private_data: usize,
+    pub map_offset: i64,
 }
 
 impl Default for SplitBufferMapping {
@@ -40,6 +42,7 @@ impl Default for SplitBufferMapping {
             address: std::ptr::null_mut(),
             size: 0,
             private_data: 0,
+            map_offset: 0,
         }
     }
 }
@@ -94,6 +97,7 @@ impl SplitBufferMetadata {
             shadow_file: self.shadow_file.clone(),
             object_name: self.object_name.clone(),
             allocator,
+            map_offset: self.map_offset,
         }
     }
 }
@@ -111,6 +115,7 @@ impl From<proto::ClientBufferHandleMetadataProto> for SplitBufferMetadata {
             handle: proto.handle,
             shadow_file: proto.shadow_file,
             object_name: proto.object_name,
+            map_offset: proto.map_offset,
         }
     }
 }

--- a/rust_client/tests/client_test.rs
+++ b/rust_client/tests/client_test.rs
@@ -748,6 +748,7 @@ fn integration_split_buffer_callbacks_allocate_map_unmap_and_free_payload_slots(
                     address,
                     size: metadata.allocation_size as usize,
                     private_data: address as usize,
+                    map_offset: 0,
                 })
             })
             .set_split_buffer_free_callback(move |_metadata, mapping| {
@@ -772,6 +773,7 @@ fn integration_split_buffer_callbacks_allocate_map_unmap_and_free_payload_slots(
                     address,
                     size,
                     private_data: 0,
+                    map_offset: 0,
                 })
             })
             .set_split_buffer_unmap_callback(move |_metadata, mapping| {

--- a/server/client_handler.cc
+++ b/server/client_handler.cc
@@ -57,6 +57,7 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   metadata.shadow_file = proto.shadow_file();
   metadata.object_name = proto.object_name();
   metadata.allocator = FromProtoAllocator(proto.allocator());
+  metadata.map_offset = proto.map_offset();
   return metadata;
 }
 
@@ -73,6 +74,7 @@ void ToProto(const ClientBufferHandleMetadata &metadata,
   proto->set_shadow_file(metadata.shadow_file);
   proto->set_object_name(metadata.object_name);
   proto->set_allocator(ToProtoAllocator(metadata.allocator));
+  proto->set_map_offset(metadata.map_offset);
 }
 
 SplitBufferOptions

--- a/server/shadow_replicator.cc
+++ b/server/shadow_replicator.cc
@@ -56,6 +56,7 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   metadata.shadow_file = proto.shadow_file();
   metadata.object_name = proto.object_name();
   metadata.allocator = FromProtoAllocator(proto.allocator());
+  metadata.map_offset = proto.map_offset();
   return metadata;
 }
 
@@ -72,6 +73,7 @@ void ToProto(const ClientBufferHandleMetadata &metadata,
   proto->set_shadow_file(metadata.shadow_file);
   proto->set_object_name(metadata.object_name);
   proto->set_allocator(ToProtoAllocator(metadata.allocator));
+  proto->set_map_offset(metadata.map_offset);
 }
 
 } // namespace

--- a/shadow/shadow.cc
+++ b/shadow/shadow.cc
@@ -57,6 +57,7 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   metadata.shadow_file = proto.shadow_file();
   metadata.object_name = proto.object_name();
   metadata.allocator = FromProtoAllocator(proto.allocator());
+  metadata.map_offset = proto.map_offset();
   return metadata;
 }
 
@@ -73,6 +74,7 @@ void ToProto(const ClientBufferHandleMetadata &metadata,
   proto->set_shadow_file(metadata.shadow_file);
   proto->set_object_name(metadata.object_name);
   proto->set_allocator(ToProtoAllocator(metadata.allocator));
+  proto->set_map_offset(metadata.map_offset);
 }
 
 } // namespace


### PR DESCRIPTION
Allow split-buffer callbacks to register shareable fds and pass the returned fd/offset metadata to subscriber map callbacks.