### PR TITLE
Add explicit publisher buffer leases

### DIFF
--- a/.cursor/skills/subspace-clients/SKILL.md
+++ b/.cursor/skills/subspace-clients/SKILL.md
@@ -117,6 +117,26 @@ with subscriber.read_message_object() as msg:
     print(msg.ordinal, msg.timestamp, msg.buffer)
 ```
 
+For multiple in-flight unpublished slots, configure and use explicit leases:
+
+```python
+options = subspace.PublisherOptions()
+options.set_slot_size(4096)
+options.set_num_slots(16)
+options.set_max_outstanding_slot_leases(3)
+publisher = client.create_publisher("camera", options=options)
+
+lease = publisher.acquire_buffer_lease()
+if lease is not None:
+    lease.buffer[:len(payload)] = payload
+    publisher.publish_buffer_lease(lease, len(payload))
+```
+
+`release_buffer_lease(lease)` discards an unpublished lease, while
+`reclaim_buffer_lease(slot_id)` reacquires a retired slot. Use
+`SubscriberOptions.set_max_subscribers(n)` to establish a server-enforced
+channel subscriber limit.
+
 ## Rust Client
 
 The Rust crate name is `subspace_client`.
@@ -154,6 +174,29 @@ loop {
     // Process data.
 }
 ```
+
+For multiple in-flight unpublished slots:
+
+```rust
+let options = PublisherOptions::new()
+    .set_slot_size(4096)
+    .set_num_slots(16)
+    .set_max_outstanding_slot_leases(3);
+let publisher = client.create_publisher("camera", &options).unwrap();
+
+if let Some(mut lease) = publisher.acquire_buffer_lease().unwrap() {
+    unsafe {
+        lease.as_mut_slice()[..payload.len()].copy_from_slice(payload);
+    }
+    publisher
+        .publish_buffer_lease(&lease, payload.len() as i64)
+        .unwrap();
+}
+```
+
+Rust also exposes `release_buffer_lease`, `reclaim_buffer_lease`,
+lease-scoped metadata, `set_notify_retirement_on_forced_reuse`, and
+`SubscriberOptions::set_max_subscribers`.
 
 ## Java Client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG.md
 
+## Unreleased
+
+### Publisher Buffer Leases
+- Added explicit C++, C, Python, and Rust APIs to acquire multiple unpublished
+  publisher slots, publish or release individual leases, and reject stale lease
+  tokens.
+- Added exact-slot reclamation from retirement notifications and per-lease
+  metadata access.
+- Added `max_outstanding_slot_leases` and
+  `notify_retirement_on_forced_reuse` publisher options.
+- Hardened lease concurrency and lifetime handling: C++ metadata lookup is
+  synchronized, Python exported views cannot mutate reused slots, and Rust
+  clone teardown and publisher locking are ownership- and unwind-safe.
+
+### Channel Admission
+- Added server-enforced `max_subscribers` limits, including virtual channels
+  sharing a multiplexer.
+- Channel capacity now reserves every publisher's maximum lease budget and
+  every subscriber's maximum active-message budget.
+- Lease budgets and subscriber limits survive shadow-server recovery.
+
+### Split Buffers
+- QNX and macOS split-buffer shared-memory object names now use the portable
+  leading-slash form required by `shm_open`.
+
 ## Subspace Version 2.2.0
 
 ### Client API Improvements

--- a/README.md
+++ b/README.md
@@ -507,18 +507,25 @@ auto pub_or = client->CreatePublisher(
         .SetNotifyRetirementOnForcedReuse(false));
 auto pub = *std::move(pub_or);
 
-auto lease_or = pub.AcquireBufferLease();
+auto lease_or = pub.AcquireScopedBufferLease();
 if (!lease_or.ok() || !*lease_or) {
     // Error, or no slot is currently available.
     return;
 }
-subspace::PublisherBufferLease lease = *lease_or;
-std::memcpy(lease.buffer, payload, payload_size);
-auto metadata = pub.GetMetadata(lease);
+subspace::ScopedPublisherBufferLease lease = *std::move(lease_or);
+std::memcpy(lease.buffer(), payload, payload_size);
+auto metadata = lease.GetMetadata();
 
-auto status = pub.PublishBufferLease(lease, payload_size);
-// Or discard an unpublished lease with pub.ReleaseBufferLease(lease).
+auto status = lease.Publish(payload_size);
+// Or call lease.Release(). If neither is called, destruction releases it.
 ```
+
+`ScopedPublisherBufferLease` is the recommended C++ interface. It releases an
+active unpublished lease when it leaves scope, and successful `Publish()`,
+`PublishCopy()`, or `Release()` invalidates it. The originating `Publisher`
+must not be moved or destroyed while its scoped leases are alive. The raw
+`PublisherBufferLease` API remains available for integrations that manage the
+lifecycle themselves.
 
 The Python API exposes the same lifecycle with a writable staging
 `memoryview`. The requested bytes are copied into the leased shared-memory
@@ -578,6 +585,9 @@ public:
     absl::StatusOr<const Message> PublishMessage(int64_t message_size);
 
     // Explicit unpublished-slot leases
+    absl::StatusOr<ScopedPublisherBufferLease> AcquireScopedBufferLease();
+    absl::StatusOr<ScopedPublisherBufferLease> ReclaimScopedBufferLease(
+        int32_t slot_id);
     absl::StatusOr<PublisherBufferLease> AcquireBufferLease();
     absl::StatusOr<PublisherBufferLease> ReclaimBufferLease(int32_t slot_id);
     absl::StatusOr<const Message> PublishBufferLease(

--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ It has the following features:
 1.	No communication with server for message transfer.
 1.	Message type agnostic transmission – bring your own serialization.
 2.  Channel types, meaningful to user, not system.
-1.	Single lock POSIX shared memory channels
+1.	Lock-free shared memory data
 1.	Both unreliable and reliable communications between publishers and subscribers.
 1.	Ability to read the next or newest message in a channel.
 1.	File-descriptor-based event triggers.
 1.	Optional split payload buffers for external allocators and memory pools.
+1.	Explicit multi-slot publisher buffer leases with exact-slot reclamation.
+1.	Server-enforced publisher and subscriber limits with lease-aware channel capacity.
 1.	Automatic UDP discovery and TCP bridging of channels between servers, plus optional TCP unicast discovery for bridging across NAT/VMs/emulators.
 1.	Shadow process for crash recovery -- the server can restart and resume without losing shared memory state.
 1.	Shared and weak pointers for message references.
@@ -40,6 +42,7 @@ It has the following features:
 See the file docs/subspace.pdf for full documentation.  Additional documentation:
 - [Checksums and User Metadata](docs/checksums-and-metadata.md)
 - [Split Buffers](docs/split-buffers.md)
+- [Publisher Buffer Leases](docs/publisher-buffer-leases.md)
 - [C Client API](docs/c-client.md)
 - [Client Architecture](docs/client-architecture.md)
 - [Server Architecture](docs/server-architecture.md)
@@ -485,6 +488,83 @@ MyMessageType* msg = reinterpret_cast<MyMessageType*>(span.data());
 pub.PublishMessage(sizeof(MyMessageType));
 ```
 
+### Explicit Publisher Buffer Leases
+
+The C++, C, Python, and Rust clients can explicitly lease several unpublished
+slots instead of using the implicit single-buffer workflow. This is useful for
+asynchronous producers and external memory pipelines. Configure the maximum
+before creating the publisher:
+
+```cpp
+auto pub_or = client->CreatePublisher(
+    "camera",
+    subspace::PublisherOptions()
+        .SetSlotSize(4096)
+        .SetNumSlots(16)
+        .SetMetadataSize(16)
+        .SetMaxOutstandingSlotLeases(3)
+        .SetNotifyRetirement(true)
+        .SetNotifyRetirementOnForcedReuse(false));
+auto pub = *std::move(pub_or);
+
+auto lease_or = pub.AcquireBufferLease();
+if (!lease_or.ok() || !*lease_or) {
+    // Error, or no slot is currently available.
+    return;
+}
+subspace::PublisherBufferLease lease = *lease_or;
+std::memcpy(lease.buffer, payload, payload_size);
+auto metadata = pub.GetMetadata(lease);
+
+auto status = pub.PublishBufferLease(lease, payload_size);
+// Or discard an unpublished lease with pub.ReleaseBufferLease(lease).
+```
+
+The Python API exposes the same lifecycle with a writable staging
+`memoryview`. The requested bytes are copied into the leased shared-memory
+slot by `publish_buffer_lease()`:
+
+```python
+options = subspace.PublisherOptions()
+options.set_slot_size(4096)
+options.set_num_slots(16)
+options.set_max_outstanding_slot_leases(3)
+
+pub = client.create_publisher("camera", options=options)
+lease = pub.acquire_buffer_lease()
+if lease is not None:
+    lease.buffer[:len(payload)] = payload
+    pub.publish_buffer_lease(lease, len(payload))
+```
+
+Rust returns the same temporary-unavailability result as `Ok(None)`:
+
+```rust
+let options = PublisherOptions::new()
+    .set_slot_size(4096)
+    .set_num_slots(16)
+    .set_max_outstanding_slot_leases(3);
+let publisher = client.create_publisher("camera", &options)?;
+
+if let Some(mut lease) = publisher.acquire_buffer_lease()? {
+    unsafe {
+        lease.as_mut_slice()[..payload.len()].copy_from_slice(payload);
+    }
+    publisher.publish_buffer_lease(&lease, payload.len() as i64)?;
+}
+```
+
+Publishing or releasing invalidates the lease. Its `lease_id` prevents a stale
+token from operating on a reused slot. When retirement notifications are
+enabled, read an `int32_t` slot ID from `GetRetirementFd()` and pass it to
+`ReclaimBufferLease(slot_id)` to reacquire that exact retired slot with a new
+lease ID.
+
+An empty lease is a temporary availability result, not an error. Do not mix the
+explicit lease workflow with the implicit `GetMessageBuffer()` workflow on the
+same publisher. See [Publisher Buffer Leases](docs/publisher-buffer-leases.md)
+for lifecycle, retirement, capacity, and C API details.
+
 ### Publisher Methods
 
 ```cpp
@@ -496,6 +576,14 @@ public:
     
     // Publish a message
     absl::StatusOr<const Message> PublishMessage(int64_t message_size);
+
+    // Explicit unpublished-slot leases
+    absl::StatusOr<PublisherBufferLease> AcquireBufferLease();
+    absl::StatusOr<PublisherBufferLease> ReclaimBufferLease(int32_t slot_id);
+    absl::StatusOr<const Message> PublishBufferLease(
+        const PublisherBufferLease &lease, int64_t message_size);
+    absl::Status ReleaseBufferLease(const PublisherBufferLease &lease);
+    absl::Span<std::byte> GetMetadata(const PublisherBufferLease &lease);
     
     // Cancel a publish (releases lock in thread-safe mode)
     void CancelPublish();
@@ -777,7 +865,8 @@ Unreliable channels provide best-effort delivery with no guarantees. If a subscr
 
 **Characteristics:**
 - Messages may be dropped if subscriber is slow
-- Publishers never block (always get a slot immediately)
+- The implicit publish path keeps a slot reserved, so publishers normally get a buffer immediately
+- Explicit lease acquisition can temporarily return an empty lease when every reusable slot is subscriber-held or already leased
 - Lower memory usage
 - Highest performance
 
@@ -803,6 +892,22 @@ You can mix reliable and unreliable publishers/subscribers on the same channel:
 - **Reliable subscriber + Unreliable publisher**: Best effort (may drop)
 - **Unreliable subscriber + Reliable publisher**: May drop if slow
 - **Unreliable subscriber + Unreliable publisher**: Best effort, may drop
+
+### Channel Capacity
+
+For unreliable channels, the server reserves each publisher's configured lease
+budget and each subscriber's active-message budget:
+
+```text
+sum(max_outstanding_slot_leases) + sum(max_active_messages)
+    <= num_slots - 1
+```
+
+Admission fails if adding a publisher or subscriber would exceed that limit.
+This guarantees that a publisher below its lease limit can acquire another
+lease even when subscribers hold their maximum active messages. Capacity is
+aggregated across virtual channels sharing a multiplexer. With the default
+single lease per publisher, this preserves the previous capacity behavior.
 
 ## PublisherOptions
 
@@ -855,6 +960,8 @@ auto pub = client->CreatePublisher("channel",
 | `vchan_id` / `SetVchanId()` | `int` | `-1` | Virtual channel ID (-1 for server-assigned). |
 | `activate` / `SetActivate()` | `bool` | `false` | If true, channel is activated even if unreliable. |
 | `notify_retirement` / `SetNotifyRetirement()` | `bool` | `false` | If true, notify when slots are retired. |
+| `max_outstanding_slot_leases` / `SetMaxOutstandingSlotLeases()` | `int32_t` | `1` | Maximum unpublished slots owned through `AcquireBufferLease()`. This does not change the implicit `GetMessageBuffer()` workflow. |
+| `notify_retirement_on_forced_reuse` / `SetNotifyRetirementOnForcedReuse()` | `bool` | `true` | Include notifications caused by an unreliable publisher forcibly reusing an unread slot. Set false when retirement notifications drive exact-slot reclamation. |
 | `checksum` / `SetChecksum()` | `bool` | `false` | If true, calculate checksums for all messages. |
 | `checksum_size` / `SetChecksumSize()` | `int32_t` | `4` | Number of bytes reserved for the checksum (starting at the `checksum` field of `MessagePrefix`). Default 4 for CRC32. Increase for larger checksums (e.g. 20 for SHA-1). |
 | `metadata_size` / `SetMetadataSize()` | `int32_t` | `0` | Number of bytes of user metadata stored immediately after the checksum area. Accessible via `Publisher::GetMetadata()` / `Subscriber::GetMetadata()`. |
@@ -871,6 +978,8 @@ auto pub = client->CreatePublisher("channel",
 - `int VchanId() const`
 - `bool Activate() const`
 - `bool NotifyRetirement() const`
+- `int32_t MaxOutstandingSlotLeases() const`
+- `bool NotifyRetirementOnForcedReuse() const`
 - `bool Checksum() const`
 - `int32_t ChecksumSize() const`
 - `int32_t MetadataSize() const`
@@ -1023,6 +1132,7 @@ auto sub = client->CreateSubscriber("channel",
 | `type` / `SetType()` | `std::string` | `""` | User-defined message type identifier. Must match publisher type. |
 | `max_active_messages` / `SetMaxActiveMessages()` | `int` | `1` | Maximum number of active messages (shared_ptrs) that can be held simultaneously. |
 | `max_active_messages` / `SetMaxSharedPtrs()` | `int` | `0` | Alias: sets max_active_messages to n+1. |
+| `max_subscribers` / `SetMaxSubscribers()` | `int32_t` | `0` | Server-enforced channel subscriber limit; 0 means unlimited. The first subscriber establishes the value and later subscribers must use the same value. |
 | `log_dropped_messages` / `SetLogDroppedMessages()` | `bool` | `true` | If true, log when messages are dropped. |
 | `bridge` / `SetBridge()` | `bool` | `false` | Internal: marks this as a bridge subscriber. |
 | `mux` / `SetMux()` | `std::string` | `""` | Multiplexer name for virtual channels. |
@@ -1037,6 +1147,7 @@ auto sub = client->CreateSubscriber("channel",
 - `const std::string& Type() const`
 - `int MaxActiveMessages() const`
 - `int MaxSharedPtrs() const`
+- `int MaxSubscribers() const`
 - `bool LogDroppedMessages() const`
 - `bool IsBridge() const`
 - `const std::string& Mux() const`
@@ -1205,12 +1316,17 @@ SubspacePublisherOptions pub_opts = subspace_publisher_options_default(1024, 10)
 // pub_opts.reliable = false
 // pub_opts.fixed_size = false
 // pub_opts.activate = false
+// pub_opts.max_outstanding_slot_leases = 1
+// pub_opts.notify_retirement_on_forced_reuse = true
 // pub_opts.checksum_size = 4   (CRC32)
 // pub_opts.metadata_size = 0   (no user metadata)
 
 // Customize options
 pub_opts.reliable = true;
 pub_opts.fixed_size = false;
+pub_opts.max_outstanding_slot_leases = 3;
+pub_opts.notify_retirement = true;
+pub_opts.notify_retirement_on_forced_reuse = false;
 pub_opts.type.type = "MyMessageType";
 pub_opts.type.type_length = strlen(pub_opts.type.type);
 pub_opts.checksum_size = 20;   // e.g. 20-byte digest
@@ -1231,12 +1347,14 @@ if (pub.publisher == NULL) {
 SubspaceSubscriberOptions sub_opts = subspace_subscriber_options_default();
 // sub_opts.reliable = false
 // sub_opts.max_active_messages = 1
+// sub_opts.max_subscribers = 0  (no explicit limit)
 // sub_opts.pass_activation = false
 // sub_opts.log_dropped_messages = false
 
 // Customize options
 sub_opts.reliable = true;
 sub_opts.max_active_messages = 10;
+sub_opts.max_subscribers = 4;
 sub_opts.type.type = "MyMessageType";
 sub_opts.type.type_length = strlen(sub_opts.type.type);
 
@@ -1278,6 +1396,34 @@ if (pub_status.length == 0) {
 // pub_status.ordinal contains the message sequence number
 // pub_status.timestamp contains the publish timestamp
 ```
+
+### Publishing with Explicit Leases
+
+```c
+SubspacePublisherBufferLease lease =
+    subspace_acquire_publisher_buffer(pub);
+if (lease.buffer == NULL) {
+    if (subspace_has_error()) {
+        fprintf(stderr, "Lease failed: %s\n", subspace_get_last_error());
+    }
+    // Otherwise no slot is currently available; wait for retirement and retry.
+    return;
+}
+
+memcpy(lease.buffer, payload, payload_size);
+size_t metadata_size = 0;
+void *metadata =
+    subspace_get_publisher_buffer_metadata(pub, lease, &metadata_size);
+
+SubspaceMessage status =
+    subspace_publish_publisher_buffer(pub, lease, payload_size);
+// Or discard it with subspace_release_publisher_buffer(pub, lease).
+```
+
+If retirement notifications are enabled,
+`subspace_get_publisher_retirement_fd()` emits `int32_t` slot IDs.
+`subspace_reclaim_publisher_buffer(pub, slot_id)` reacquires the exact retired
+slot with a new lease token.
 
 ### Reading Messages
 
@@ -1503,6 +1649,12 @@ This is a quick reference for the most common calls. See
 - `SubspaceMessageBuffer subspace_get_message_buffer(SubspacePublisher publisher, size_t max_size)`
 - `const SubspaceMessage subspace_publish_message(SubspacePublisher publisher, size_t messageSize)`
 - `bool subspace_cancel_publish(SubspacePublisher publisher)`
+- `SubspacePublisherBufferLease subspace_acquire_publisher_buffer(SubspacePublisher publisher)`
+- `SubspacePublisherBufferLease subspace_reclaim_publisher_buffer(SubspacePublisher publisher, int32_t slot_id)`
+- `const SubspaceMessage subspace_publish_publisher_buffer(SubspacePublisher publisher, SubspacePublisherBufferLease lease, size_t message_size)`
+- `bool subspace_release_publisher_buffer(SubspacePublisher publisher, SubspacePublisherBufferLease lease)`
+- `void *subspace_get_publisher_buffer_metadata(SubspacePublisher publisher, SubspacePublisherBufferLease lease, size_t *metadata_size)`
+- `int subspace_get_publisher_retirement_fd(SubspacePublisher publisher)`
 - `bool subspace_wait_for_publisher(SubspacePublisher publisher)`
 - `bool subspace_wait_for_publisher_with_timeout(SubspacePublisher publisher, uint64_t timeout_ms)`
 - `int subspace_wait_for_publisher_with_fd(SubspacePublisher publisher, int fd)`
@@ -1588,6 +1740,8 @@ assert_eq!(msg.length, 5);
 - Full pub/sub support: unreliable and reliable channels, read-next and
   read-newest modes, activation messages, virtual channels.
 - Checksums (built-in CRC32 or custom callbacks) and per-message user metadata.
+- Explicit multi-slot publisher leases with exact-slot reclamation.
+- Server-enforced subscriber limits and lease-aware capacity admission.
 - File-descriptor-based `wait()` for integration with event loops and `poll()`.
 - Slot retirement notification for reliable publishers.
 - Runs on Linux and macOS (ARM64 and x86_64).
@@ -1779,7 +1933,7 @@ its full state from whichever shadow is available.
 - Shared memory mappings -- buffers remain intact in `/dev/shm` (Linux) or
   POSIX shared memory (macOS).
 - Publisher and subscriber metadata (IDs, trigger FDs, reliability settings,
-  tunnel flags).
+  tunnel flags, publisher lease budgets, and subscriber limits).
 - The session ID, so clients can detect a server restart and reclaim their
   connections.
 

--- a/c_client/client_test.cc
+++ b/c_client/client_test.cc
@@ -522,6 +522,138 @@ TEST_F(ClientTest, MuxAndChecksumOptions) {
   ASSERT_TRUE(subspace_remove_client(&sub_client));
 }
 
+TEST_F(ClientTest, ExplicitSplitBufferLeasesRetireAndReclaimExactSlot) {
+  SubspaceClient pub_client =
+      subspace_create_client_with_socket(Socket().c_str());
+  SubspaceClient sub_client =
+      subspace_create_client_with_socket(Socket().c_str());
+  ASSERT_NE(nullptr, pub_client.client);
+  ASSERT_NE(nullptr, sub_client.client);
+
+  TestCSplitBufferState split_state;
+  SubspacePublisherOptions pub_opts =
+      subspace_publisher_options_default(128, 6);
+  pub_opts.use_split_buffers = true;
+  pub_opts.notify_retirement = true;
+  pub_opts.notify_retirement_on_forced_reuse = false;
+  pub_opts.max_outstanding_slot_leases = 3;
+  pub_opts.metadata_size = 8;
+  pub_opts.split_callbacks = {
+      .allocate = TestCSplitAllocate,
+      .map = TestCSplitMap,
+      .unmap = TestCSplitUnmap,
+      .free = TestCSplitFree,
+      .user_data = &split_state,
+  };
+  SubspacePublisher pub =
+      subspace_create_publisher(pub_client, "c_explicit_leases", pub_opts);
+  ASSERT_NE(nullptr, pub.publisher) << subspace_get_last_error();
+
+  SubspaceSubscriberOptions sub_opts = subspace_subscriber_options_default();
+  sub_opts.max_active_messages = 2;
+  sub_opts.split_callbacks = pub_opts.split_callbacks;
+  SubspaceSubscriber sub =
+      subspace_create_subscriber(sub_client, "c_explicit_leases", sub_opts);
+  ASSERT_NE(nullptr, sub.subscriber) << subspace_get_last_error();
+
+  SubspacePublisherBufferLease leases[3];
+  for (int i = 0; i < 3; ++i) {
+    leases[i] = subspace_acquire_publisher_buffer(pub);
+    ASSERT_NE(nullptr, leases[i].buffer) << subspace_get_last_error();
+    EXPECT_EQ(128U, leases[i].buffer_size);
+    for (int j = 0; j < i; ++j) {
+      EXPECT_NE(leases[j].buffer, leases[i].buffer);
+      EXPECT_NE(leases[j].slot_id, leases[i].slot_id);
+    }
+  }
+  SubspacePublisherBufferLease exhausted =
+      subspace_acquire_publisher_buffer(pub);
+  EXPECT_EQ(nullptr, exhausted.buffer);
+  EXPECT_FALSE(subspace_has_error());
+
+  size_t metadata_size = 0;
+  void *metadata =
+      subspace_get_publisher_buffer_metadata(pub, leases[1], &metadata_size);
+  ASSERT_NE(nullptr, metadata);
+  ASSERT_EQ(8U, metadata_size);
+  memcpy(metadata, "lease-md", 8);
+  memcpy(leases[1].buffer, "lease-two", 9);
+
+  SubspaceMessage published =
+      subspace_publish_publisher_buffer(pub, leases[1], 9);
+  ASSERT_EQ(9, published.length) << subspace_get_last_error();
+  EXPECT_EQ(leases[1].slot_id, published.slot_id);
+
+  ASSERT_TRUE(subspace_wait_for_subscriber_with_timeout(sub, 1000));
+  SubspaceMessage received = subspace_read_message(sub);
+  ASSERT_EQ(9, received.length);
+  EXPECT_EQ(0, memcmp(received.buffer, "lease-two", 9));
+
+  int retirement_fd = subspace_get_publisher_retirement_fd(pub);
+  ASSERT_GE(retirement_fd, 0);
+  struct pollfd poll_fd = {.fd = retirement_fd, .events = POLLIN};
+  EXPECT_EQ(0, poll(&poll_fd, 1, 0));
+
+  ASSERT_TRUE(subspace_free_message(&received));
+  ASSERT_EQ(1, poll(&poll_fd, 1, 1000));
+  int32_t retired_slot = -1;
+  ASSERT_EQ(ssize_t(sizeof(retired_slot)),
+            read(retirement_fd, &retired_slot, sizeof(retired_slot)));
+  ASSERT_EQ(leases[1].slot_id, retired_slot);
+
+  SubspacePublisherBufferLease reclaimed =
+      subspace_reclaim_publisher_buffer(pub, retired_slot);
+  ASSERT_NE(nullptr, reclaimed.buffer) << subspace_get_last_error();
+  EXPECT_EQ(leases[1].buffer, reclaimed.buffer);
+  EXPECT_NE(leases[1].lease_id, reclaimed.lease_id);
+
+  EXPECT_FALSE(subspace_release_publisher_buffer(pub, leases[1]));
+  EXPECT_TRUE(subspace_has_error());
+  EXPECT_TRUE(subspace_release_publisher_buffer(pub, leases[0]));
+  EXPECT_TRUE(subspace_release_publisher_buffer(pub, leases[2]));
+  EXPECT_TRUE(subspace_release_publisher_buffer(pub, reclaimed));
+
+  ASSERT_TRUE(subspace_remove_subscriber(&sub));
+  ASSERT_TRUE(subspace_remove_publisher(&pub));
+  ASSERT_TRUE(subspace_remove_client(&pub_client));
+  ASSERT_TRUE(subspace_remove_client(&sub_client));
+}
+
+TEST_F(ClientTest, ExplicitLeaseWithNoSubscribersRetiresImmediately) {
+  SubspaceClient client = subspace_create_client_with_socket(Socket().c_str());
+  ASSERT_NE(nullptr, client.client);
+  SubspacePublisherOptions options =
+      subspace_publisher_options_default(64, 4);
+  options.notify_retirement = true;
+  options.notify_retirement_on_forced_reuse = false;
+  options.max_outstanding_slot_leases = 2;
+  SubspacePublisher pub =
+      subspace_create_publisher(client, "c_no_subscriber_retirement", options);
+  ASSERT_NE(nullptr, pub.publisher) << subspace_get_last_error();
+
+  SubspacePublisherBufferLease lease =
+      subspace_acquire_publisher_buffer(pub);
+  ASSERT_NE(nullptr, lease.buffer);
+  memcpy(lease.buffer, "none", 4);
+  ASSERT_EQ(4, subspace_publish_publisher_buffer(pub, lease, 4).length);
+
+  int fd = subspace_get_publisher_retirement_fd(pub);
+  struct pollfd poll_fd = {.fd = fd, .events = POLLIN};
+  ASSERT_EQ(1, poll(&poll_fd, 1, 1000));
+  int32_t slot_id = -1;
+  ASSERT_EQ(ssize_t(sizeof(slot_id)), read(fd, &slot_id, sizeof(slot_id)));
+  EXPECT_EQ(lease.slot_id, slot_id);
+
+  SubspacePublisherBufferLease reclaimed =
+      subspace_reclaim_publisher_buffer(pub, slot_id);
+  ASSERT_NE(nullptr, reclaimed.buffer);
+  EXPECT_EQ(lease.buffer, reclaimed.buffer);
+  EXPECT_TRUE(subspace_release_publisher_buffer(pub, reclaimed));
+
+  ASSERT_TRUE(subspace_remove_publisher(&pub));
+  ASSERT_TRUE(subspace_remove_client(&client));
+}
+
 TEST_F(ClientTest, ChecksumCallbacks) {
   auto pub_client = subspace_create_client_with_socket(Socket().c_str());
   ASSERT_NE(nullptr, pub_client.client);
@@ -1200,6 +1332,82 @@ TEST_F(ClientTest, SubscriberCallbacks) {
   }
   messages_read.clear();
 
+  ASSERT_TRUE(subspace_remove_subscriber(&sub));
+  ASSERT_TRUE(subspace_remove_publisher(&pub));
+  ASSERT_TRUE(subspace_remove_client(&pub_client));
+  ASSERT_TRUE(subspace_remove_client(&sub_client));
+}
+
+TEST_F(ClientTest, SubscriberCallbacksFromWorkerThread) {
+  messages_read.clear();
+  auto pub_client = subspace_create_client_with_socket(Socket().c_str());
+  auto sub_client = subspace_create_client_with_socket(Socket().c_str());
+  ASSERT_NE(nullptr, pub_client.client);
+  ASSERT_NE(nullptr, sub_client.client);
+
+  SubspaceSubscriberOptions sub_options = CSubscriberOptionsDefault();
+  sub_options.max_subscribers = 1;
+  SubspaceSubscriber sub = subspace_create_subscriber(
+      sub_client, "worker_callback", sub_options);
+  ASSERT_NE(nullptr, sub.subscriber);
+  SubspacePublisher pub = subspace_create_publisher(
+      pub_client, "worker_callback", CPublisherOptionsDefault(256, 4));
+  ASSERT_NE(nullptr, pub.publisher);
+  ASSERT_EQ(1, subspace_get_publisher_num_subscribers(pub, -1));
+  ASSERT_TRUE(subspace_register_subscriber_callback(sub, MessageCallback));
+
+  SubspaceMessageBuffer buffer = subspace_get_message_buffer(pub, 256);
+  ASSERT_NE(nullptr, buffer.buffer);
+  memcpy(buffer.buffer, "foobar", 6);
+  ASSERT_EQ(6, subspace_publish_message(pub, 6).length);
+  bool processed = false;
+  std::thread worker(
+      [&] { processed = subspace_process_all_messages(sub); });
+  worker.join();
+
+  ASSERT_TRUE(processed);
+  ASSERT_EQ(1, messages_read.size());
+  ASSERT_EQ(6, messages_read.front().length);
+  ASSERT_EQ(0, memcmp(messages_read.front().buffer, "foobar", 6));
+  ASSERT_TRUE(subspace_free_message(&messages_read.front()));
+  messages_read.clear();
+
+  ASSERT_TRUE(subspace_remove_subscriber(&sub));
+  ASSERT_TRUE(subspace_remove_publisher(&pub));
+  ASSERT_TRUE(subspace_remove_client(&pub_client));
+  ASSERT_TRUE(subspace_remove_client(&sub_client));
+}
+
+TEST_F(ClientTest, SubscriberLimitStillDeliversMessages) {
+  auto pub_client = subspace_create_client_with_socket(Socket().c_str());
+  auto sub_client = subspace_create_client_with_socket(Socket().c_str());
+  ASSERT_NE(nullptr, pub_client.client);
+  ASSERT_NE(nullptr, sub_client.client);
+
+  SubspaceSubscriberOptions options = CSubscriberOptionsDefault();
+  options.max_subscribers = 1;
+  SubspaceSubscriber sub =
+      subspace_create_subscriber(sub_client, "limited_delivery", options);
+  ASSERT_NE(nullptr, sub.subscriber);
+  SubspacePublisher pub = subspace_create_publisher(
+      pub_client, "limited_delivery", CPublisherOptionsDefault(64, 10));
+  ASSERT_NE(nullptr, pub.publisher);
+
+  SubspaceMessageBuffer buffer = subspace_get_message_buffer(pub, 64);
+  ASSERT_NE(nullptr, buffer.buffer);
+  memcpy(buffer.buffer, "limit", 5);
+  ASSERT_EQ(5, subspace_publish_message(pub, 5).length);
+
+  SubspaceMessage message = {};
+  for (int i = 0; i < 10 && message.length == 0; ++i) {
+    if (message.message != nullptr) {
+      ASSERT_TRUE(subspace_free_message(&message));
+    }
+    message = subspace_read_message(sub);
+  }
+  ASSERT_EQ(5, message.length);
+  ASSERT_EQ(0, memcmp(message.buffer, "limit", 5));
+  ASSERT_TRUE(subspace_free_message(&message));
   ASSERT_TRUE(subspace_remove_subscriber(&sub));
   ASSERT_TRUE(subspace_remove_publisher(&pub));
   ASSERT_TRUE(subspace_remove_client(&pub_client));

--- a/c_client/subspace.cc
+++ b/c_client/subspace.cc
@@ -500,28 +500,14 @@ SubspaceSubscriberOptions subspace_subscriber_options_default(void) {
 SubspacePublisherOptions subspace_publisher_options_default(int32_t slot_size,
                                                             int num_slots) {
   SubspacePublisherOptions options = {
-      slot_size,
-      num_slots,
-      false,
-      false,
-      false,
-      false,
-      false,
-      SubspaceTypeInfo{},
-      false,
-      nullptr,
-      0,
-      -1,
-      false,
-      false,
-      4,
-      0,
-      true,
-      false,
-      false,
-      0,
-      SubspaceSplitBufferCallbacks{},
+      .slot_size = slot_size,
+      .num_slots = num_slots,
   };
+  options.vchan_id = -1;
+  options.max_outstanding_slot_leases = 1;
+  options.notify_retirement_on_forced_reuse = true;
+  options.checksum_size = 4;
+  options.prefer_retired_slots = true;
   return options;
 }
 
@@ -534,6 +520,7 @@ subspace_create_subscriber(SubspaceClient client, const char *channel_name,
       .SetForTunnel(options.for_tunnel)
       .SetType(StringFromPointer(options.type.type, options.type.type_length))
       .SetMaxActiveMessages(options.max_active_messages)
+      .SetMaxSubscribers(options.max_subscribers)
       .SetPassActivation(options.pass_activation)
       .SetReadWrite(options.read_write)
       .SetMux(StringFromPointer(options.mux, options.mux_length))
@@ -578,6 +565,9 @@ SubspacePublisher subspace_create_publisher(SubspaceClient client,
       .SetMux(StringFromPointer(options.mux, options.mux_length))
       .SetVchanId(options.vchan_id)
       .SetNotifyRetirement(options.notify_retirement)
+      .SetMaxOutstandingSlotLeases(options.max_outstanding_slot_leases)
+      .SetNotifyRetirementOnForcedReuse(
+          options.notify_retirement_on_forced_reuse)
       .SetChecksum(options.checksum)
       .SetChecksumSize(options.checksum_size)
       .SetMetadataSize(options.metadata_size)
@@ -965,6 +955,113 @@ bool subspace_cancel_publish(SubspacePublisher publisher) {
   }
   (*PublisherPtr(publisher))->CancelPublish();
   return true;
+}
+
+SubspacePublisherBufferLease
+subspace_acquire_publisher_buffer(SubspacePublisher publisher) {
+  subspace_clear_error();
+  SubspacePublisherBufferLease result = {};
+  result.slot_id = -1;
+  if (publisher.publisher == nullptr) {
+    subspace_set_error("Invalid publisher");
+    return result;
+  }
+  absl::StatusOr<subspace::PublisherBufferLease> lease =
+      (*PublisherPtr(publisher))->AcquireBufferLease();
+  if (!lease.ok()) {
+    subspace_set_error(lease.status().ToString().c_str());
+    return result;
+  }
+  result.buffer = lease->buffer;
+  result.buffer_size = lease->buffer_size;
+  result.slot_id = lease->slot_id;
+  result.lease_id = lease->lease_id;
+  return result;
+}
+
+SubspacePublisherBufferLease
+subspace_reclaim_publisher_buffer(SubspacePublisher publisher,
+                                  int32_t slot_id) {
+  subspace_clear_error();
+  SubspacePublisherBufferLease result = {};
+  result.slot_id = -1;
+  if (publisher.publisher == nullptr) {
+    subspace_set_error("Invalid publisher");
+    return result;
+  }
+  absl::StatusOr<subspace::PublisherBufferLease> lease =
+      (*PublisherPtr(publisher))->ReclaimBufferLease(slot_id);
+  if (!lease.ok()) {
+    subspace_set_error(lease.status().ToString().c_str());
+    return result;
+  }
+  result.buffer = lease->buffer;
+  result.buffer_size = lease->buffer_size;
+  result.slot_id = lease->slot_id;
+  result.lease_id = lease->lease_id;
+  return result;
+}
+
+static subspace::PublisherBufferLease
+ToCppPublisherLease(SubspacePublisherBufferLease lease) {
+  return {
+      .buffer = lease.buffer,
+      .buffer_size = lease.buffer_size,
+      .slot_id = lease.slot_id,
+      .lease_id = lease.lease_id,
+  };
+}
+
+const SubspaceMessage
+subspace_publish_publisher_buffer(SubspacePublisher publisher,
+                                  SubspacePublisherBufferLease lease,
+                                  size_t message_size) {
+  subspace_clear_error();
+  if (publisher.publisher == nullptr) {
+    subspace_set_error("Invalid publisher");
+    return EmptyMessage();
+  }
+  absl::StatusOr<const subspace::Message> message =
+      (*PublisherPtr(publisher))
+          ->PublishBufferLease(ToCppPublisherLease(lease), message_size);
+  if (!message.ok()) {
+    subspace_set_error(message.status().ToString().c_str());
+    return EmptyMessage();
+  }
+  return ToCMessage(*message);
+}
+
+bool subspace_release_publisher_buffer(SubspacePublisher publisher,
+                                       SubspacePublisherBufferLease lease) {
+  subspace_clear_error();
+  if (publisher.publisher == nullptr) {
+    subspace_set_error("Invalid publisher");
+    return false;
+  }
+  absl::Status status = (*PublisherPtr(publisher))
+                            ->ReleaseBufferLease(ToCppPublisherLease(lease));
+  if (!status.ok()) {
+    subspace_set_error(status.ToString().c_str());
+    return false;
+  }
+  return true;
+}
+
+void *subspace_get_publisher_buffer_metadata(
+    SubspacePublisher publisher, SubspacePublisherBufferLease lease,
+    size_t *metadata_size) {
+  subspace_clear_error();
+  if (metadata_size != nullptr) {
+    *metadata_size = 0;
+  }
+  if (publisher.publisher == nullptr || metadata_size == nullptr) {
+    subspace_set_error("Invalid publisher or metadata_size");
+    return nullptr;
+  }
+  absl::Span<std::byte> metadata =
+      (*PublisherPtr(publisher))->GetMetadata(ToCppPublisherLease(lease));
+  *metadata_size = metadata.size();
+  return metadata.empty() ? nullptr : metadata.data();
 }
 
 bool subspace_remove_subscriber(SubspaceSubscriber *subscriber) {

--- a/c_client/subspace.h
+++ b/c_client/subspace.h
@@ -226,6 +226,8 @@ typedef struct {
   size_t mux_length;
   int vchan_id;           // Virtual channel id, or -1 for server-assigned.
   bool notify_retirement; // Notify publisher when slots retire.
+  int32_t max_outstanding_slot_leases; // Explicit unpublished lease limit.
+  bool notify_retirement_on_forced_reuse; // Include publisher-forced reuse.
   bool checksum;          // Calculate and attach message checksums.
   int32_t checksum_size;  // Bytes reserved for checksum (default 4).
   int32_t metadata_size;  // Bytes reserved for user metadata (default 0).
@@ -261,6 +263,7 @@ typedef struct {
   bool for_tunnel;         // Mark subscriptions for external tunnels.
   SubspaceTypeInfo type;   // Type of the message.  This is an opaque string.
   int max_active_messages; // Max number of message that can be active at once.
+  int32_t max_subscribers; // 0 means no explicit subscriber limit.
   bool pass_activation;    // Pass activation message in read.
   bool log_dropped_messages; // Log dropped messages to stderr.
   bool read_write;           // Map buffers writable for this subscriber.
@@ -295,6 +298,15 @@ typedef struct {
   void *buffer;
   size_t buffer_size;
 } SubspaceMessageBuffer;
+
+// A specific publisher-owned slot. The token becomes invalid after publish or
+// release; lease_id prevents stale tokens from operating on a reused slot.
+typedef struct {
+  void *buffer;
+  size_t buffer_size;
+  int32_t slot_id;
+  uint64_t lease_id;
+} SubspacePublisherBufferLease;
 
 // Get the last error message from the subspace library.  This will return
 // a pointer to a string that is owned by the library.  The string will be
@@ -510,6 +522,20 @@ subspace_publish_message_with_prefix(SubspacePublisher publisher,
                                      size_t message_size,
                                      bool use_slot_id_from_prefix);
 bool subspace_cancel_publish(SubspacePublisher publisher);
+
+SubspacePublisherBufferLease
+subspace_acquire_publisher_buffer(SubspacePublisher publisher);
+SubspacePublisherBufferLease
+subspace_reclaim_publisher_buffer(SubspacePublisher publisher, int32_t slot_id);
+const SubspaceMessage
+subspace_publish_publisher_buffer(SubspacePublisher publisher,
+                                  SubspacePublisherBufferLease lease,
+                                  size_t message_size);
+bool subspace_release_publisher_buffer(SubspacePublisher publisher,
+                                       SubspacePublisherBufferLease lease);
+void *subspace_get_publisher_buffer_metadata(
+    SubspacePublisher publisher, SubspacePublisherBufferLease lease,
+    size_t *metadata_size);
 
 // Reliable publishers that cannot send a message at the present time can be
 // waited for using this function.  It will block until the publisher is able to

--- a/client/client.cc
+++ b/client/client.cc
@@ -72,7 +72,7 @@ ClientBufferAllocator ToProtoAllocator(ClientBufferAllocatorKind allocator) {
     return CLIENT_BUFFER_ALLOCATOR_UNSPECIFIED;
   }
 }
-}
+} // namespace
 
 using ClientChannel = details::ClientChannel;
 using SubscriberImpl = details::SubscriberImpl;
@@ -93,8 +93,7 @@ bool DefaultUseSplitBuffers() {
 static uint64_t GetThreadId() {
   pthread_t tid = pthread_self();
   uint64_t id = 0;
-  std::memcpy(&id, &tid,
-              sizeof(tid) < sizeof(id) ? sizeof(tid) : sizeof(id));
+  std::memcpy(&id, &tid, sizeof(tid) < sizeof(id) ? sizeof(tid) : sizeof(id));
   return id;
 }
 
@@ -132,18 +131,18 @@ FromProto(const ClientBufferHandleMetadataProto &proto) {
   return metadata;
 }
 
-static absl::Status CheckFdIndex(
-    const std::vector<toolbelt::FileDescriptor> &fds, int index,
-    const char *field, const char *response_name) {
+static absl::Status
+CheckFdIndex(const std::vector<toolbelt::FileDescriptor> &fds, int index,
+             const char *field, const char *response_name) {
   if (index < 0 || static_cast<size_t>(index) >= fds.size()) {
     return absl::InternalError(absl::StrFormat(
         "%s references fd index %d for %s, but response included %zu fds",
         response_name, index, field, fds.size()));
   }
   if (!fds[static_cast<size_t>(index)].Valid()) {
-    return absl::InternalError(absl::StrFormat(
-        "%s references invalid fd at index %d for %s", response_name, index,
-        field));
+    return absl::InternalError(
+        absl::StrFormat("%s references invalid fd at index %d for %s",
+                        response_name, index, field));
   }
   return absl::OkStatus();
 }
@@ -250,9 +249,8 @@ absl::Status ClientImpl::Init(const std::string &server_socket,
   if (!status.ok()) {
     return status;
   }
-  if (absl::Status fd_status =
-          CheckFdIndex(fds, resp.init().scb_fd_index(), "scb_fd",
-                       "InitResponse");
+  if (absl::Status fd_status = CheckFdIndex(fds, resp.init().scb_fd_index(),
+                                            "scb_fd", "InitResponse");
       !fd_status.ok()) {
     return fd_status;
   }
@@ -405,6 +403,11 @@ ClientImpl::CreatePublisher(const std::string &channel_name,
   if (absl::Status status = CheckConnected(); !status.ok()) {
     return status;
   }
+  if (opts.MaxOutstandingSlotLeases() < 1 ||
+      opts.MaxOutstandingSlotLeases() > opts.NumSlots()) {
+    return absl::InvalidArgumentError(
+        "MaxOutstandingSlotLeases must be between 1 and NumSlots");
+  }
   Request req;
   FillCreatePublisherRequest(req.mutable_create_publisher(), channel_name, opts,
                              -1);
@@ -445,11 +448,11 @@ ClientImpl::CreatePublisher(const std::string &channel_name,
              const toolbelt::FileDescriptor *fd) {
         return RegisterClientBuffer(metadata, fd);
       });
-  channel->SetClientBufferLookupCallback(
-      [this](const std::string &channel_name, uint64_t session_id,
-             uint32_t buffer_index) {
-        return GetClientBuffers(channel_name, session_id, buffer_index);
-      });
+  channel->SetClientBufferLookupCallback([this](const std::string &channel_name,
+                                                uint64_t session_id,
+                                                uint32_t buffer_index) {
+    return GetClientBuffers(channel_name, session_id, buffer_index);
+  });
   channel->SetClientBufferUnregistrationCallback(
       [this](const std::string &channel_name, uint64_t session_id,
              uint32_t buffer_index) {
@@ -461,16 +464,14 @@ ClientImpl::CreatePublisher(const std::string &channel_name,
   channel->SetMetadataSize(ms);
   channel->SetPrefixSize(Channel::ComputePrefixSize(cs, ms));
 
-  if (absl::Status fd_status =
-          CheckFdIndex(fds, pub_resp.ccb_fd_index(), "ccb_fd",
-                       "CreatePublisherResponse");
+  if (absl::Status fd_status = CheckFdIndex(
+          fds, pub_resp.ccb_fd_index(), "ccb_fd", "CreatePublisherResponse");
       !fd_status.ok()) {
     remove_server_publisher();
     return fd_status;
   }
-  if (absl::Status fd_status =
-          CheckFdIndex(fds, pub_resp.bcb_fd_index(), "bcb_fd",
-                       "CreatePublisherResponse");
+  if (absl::Status fd_status = CheckFdIndex(
+          fds, pub_resp.bcb_fd_index(), "bcb_fd", "CreatePublisherResponse");
       !fd_status.ok()) {
     remove_server_publisher();
     return fd_status;
@@ -575,11 +576,11 @@ ClientImpl::CreateSubscriber(const std::string &channel_name,
         return CheckReload(static_cast<ClientChannel *>(c));
       },
       server_user_id_, server_group_id_);
-  channel->SetClientBufferLookupCallback(
-      [this](const std::string &channel_name, uint64_t session_id,
-             uint32_t buffer_index) {
-        return GetClientBuffers(channel_name, session_id, buffer_index);
-      });
+  channel->SetClientBufferLookupCallback([this](const std::string &channel_name,
+                                                uint64_t session_id,
+                                                uint32_t buffer_index) {
+    return GetClientBuffers(channel_name, session_id, buffer_index);
+  });
 
   channel->SetNumSlots(sub_resp.num_slots());
   {
@@ -591,15 +592,13 @@ ClientImpl::CreateSubscriber(const std::string &channel_name,
     channel->AllocateChecksumBuffer();
   }
 
-  if (absl::Status fd_status =
-          CheckFdIndex(fds, sub_resp.ccb_fd_index(), "ccb_fd",
-                       "CreateSubscriberResponse");
+  if (absl::Status fd_status = CheckFdIndex(
+          fds, sub_resp.ccb_fd_index(), "ccb_fd", "CreateSubscriberResponse");
       !fd_status.ok()) {
     return fd_status;
   }
-  if (absl::Status fd_status =
-          CheckFdIndex(fds, sub_resp.bcb_fd_index(), "bcb_fd",
-                       "CreateSubscriberResponse");
+  if (absl::Status fd_status = CheckFdIndex(
+          fds, sub_resp.bcb_fd_index(), "bcb_fd", "CreateSubscriberResponse");
       !fd_status.ok()) {
     return fd_status;
   }
@@ -728,6 +727,152 @@ ClientImpl::GetMessageBufferSpan(PublisherImpl *publisher, int32_t max_size,
                                span_size);
 }
 
+absl::StatusOr<PublisherBufferLease>
+ClientImpl::AcquirePublisherBuffer(PublisherImpl *publisher) {
+  ClientLockGuard guard(this);
+  if (publisher->NumLeases() >= size_t(publisher->MaxOutstandingSlotLeases())) {
+    return PublisherBufferLease{};
+  }
+  if (absl::Status status = ReloadSubscribersIfNecessary(publisher);
+      !status.ok()) {
+    return status;
+  }
+
+  MessageSlot *slot = publisher->CurrentSlot();
+  if (slot != nullptr) {
+    publisher->SetSlot(nullptr);
+  } else {
+    if (publisher->IsReliable() &&
+        publisher->NumSubscribers(publisher->VirtualChannelId()) == 0) {
+      return PublisherBufferLease{};
+    }
+    slot = publisher->IsReliable()
+               ? publisher->FindFreeSlotReliable(publisher->GetPublisherId())
+               : publisher->FindFreeSlotUnreliable(publisher->GetPublisherId());
+  }
+  if (slot == nullptr) {
+    return PublisherBufferLease{};
+  }
+  uint64_t lease_id = publisher->RegisterLease(slot);
+  return PublisherBufferLease{
+      .buffer = publisher->GetBufferAddress(slot),
+      .buffer_size = size_t(publisher->SlotSize(slot)),
+      .slot_id = slot->id,
+      .lease_id = lease_id,
+  };
+}
+
+absl::StatusOr<PublisherBufferLease>
+ClientImpl::ReclaimPublisherBuffer(PublisherImpl *publisher, int32_t slot_id) {
+  ClientLockGuard guard(this);
+  if (publisher->NumLeases() >= size_t(publisher->MaxOutstandingSlotLeases())) {
+    return PublisherBufferLease{};
+  }
+  if (absl::Status status = ReloadSubscribersIfNecessary(publisher);
+      !status.ok()) {
+    return status;
+  }
+  MessageSlot *slot = publisher->ClaimRetiredSlot(slot_id);
+  if (slot == nullptr) {
+    return PublisherBufferLease{};
+  }
+  uint64_t lease_id = publisher->RegisterLease(slot);
+  return PublisherBufferLease{
+      .buffer = publisher->GetBufferAddress(slot),
+      .buffer_size = size_t(publisher->SlotSize(slot)),
+      .slot_id = slot->id,
+      .lease_id = lease_id,
+  };
+}
+
+absl::StatusOr<const Message>
+ClientImpl::PublishPublisherBuffer(PublisherImpl *publisher,
+                                   const PublisherBufferLease &lease,
+                                   int64_t message_size) {
+  ClientLockGuard guard(this);
+  return PublishPublisherBufferInternal(publisher, lease, message_size,
+                                        /*payload=*/nullptr);
+}
+
+absl::StatusOr<const Message>
+ClientImpl::PublishPublisherBufferCopy(PublisherImpl *publisher,
+                                       const PublisherBufferLease &lease,
+                                       absl::Span<const std::byte> payload) {
+  ClientLockGuard guard(this);
+  return PublishPublisherBufferInternal(
+      publisher, lease, static_cast<int64_t>(payload.size()), payload.data());
+}
+
+absl::StatusOr<const Message> ClientImpl::PublishPublisherBufferInternal(
+    PublisherImpl *publisher, const PublisherBufferLease &lease,
+    int64_t message_size, const std::byte *payload) {
+  if (message_size <= 0) {
+    return absl::InvalidArgumentError("Message size must be greater than 0");
+  }
+  MessageSlot *slot = publisher->FindLease(lease.slot_id, lease.lease_id);
+  if (slot == nullptr) {
+    return absl::FailedPreconditionError("Invalid or stale publisher lease");
+  }
+  if (message_size > publisher->SlotSize(slot)) {
+    return absl::InvalidArgumentError("Message size exceeds leased slot size");
+  }
+  if (absl::Status status = ReloadSubscribersIfNecessary(publisher);
+      !status.ok()) {
+    return status;
+  }
+  if (payload != nullptr) {
+    std::memmove(publisher->GetBufferAddress(slot), payload,
+                 static_cast<size_t>(message_size));
+  }
+  if (publisher->on_send_callback_ != nullptr) {
+    absl::StatusOr<int64_t> status_or_size = publisher->on_send_callback_(
+        publisher->GetBufferAddress(slot), message_size);
+    if (!status_or_size.ok()) {
+      return status_or_size.status();
+    }
+    message_size = status_or_size.value();
+  }
+  slot->message_size = message_size;
+  Channel::PublishedMessage msg = publisher->ActivateSlotAndGetAnother(
+      slot, publisher->IsReliable(), /*is_activation=*/false,
+      publisher->GetPublisherId(), /*omit_prefix=*/false,
+      /*use_prefix_slot_id=*/false, publisher->ForTunnel(),
+      /*acquire_next=*/false);
+  publisher->RemoveLease(lease.slot_id);
+  publisher->TriggerSubscribers();
+  if (publisher->NumSubscribers(publisher->VirtualChannelId()) == 0) {
+    publisher->RetirePublishedSlotImmediately(slot);
+  }
+  if (absl::Status status = publisher->UnmapUnusedBuffers(); !status.ok()) {
+    return status;
+  }
+  return Message(message_size, nullptr, msg.ordinal, msg.timestamp,
+                 publisher->VirtualChannelId(), false, lease.slot_id, false);
+}
+
+absl::Status
+ClientImpl::ReleasePublisherBuffer(PublisherImpl *publisher,
+                                   const PublisherBufferLease &lease) {
+  ClientLockGuard guard(this);
+  MessageSlot *slot = publisher->FindLease(lease.slot_id, lease.lease_id);
+  if (slot == nullptr) {
+    return absl::FailedPreconditionError("Invalid or stale publisher lease");
+  }
+  if (!publisher->ReleaseLeasedSlot(slot)) {
+    return absl::InternalError("Failed to release publisher lease");
+  }
+  publisher->RemoveLease(lease.slot_id);
+  return absl::OkStatus();
+}
+
+absl::Span<std::byte>
+ClientImpl::GetPublisherBufferMetadata(PublisherImpl *publisher,
+                                       const PublisherBufferLease &lease) {
+  ClientLockGuard guard(this);
+  MessageSlot *slot = publisher->FindLease(lease.slot_id, lease.lease_id);
+  return publisher->GetMetadata(slot);
+}
+
 absl::StatusOr<const Message>
 ClientImpl::PublishMessage(PublisherImpl *publisher, int64_t message_size) {
   return PublishMessageInternal(publisher, message_size, /*omit_prefix=*/false,
@@ -844,7 +989,8 @@ ClientImpl::WaitForReliablePublisher(PublisherImpl *publisher,
     result = co_->Wait(publisher->GetPollFd().Fd(), POLLIN, timeout_ns);
   } else {
     struct pollfd fd = {.fd = publisher->GetPollFd().Fd(), .events = POLLIN};
-    int e = GetSyscallShim().poll_fn(&fd, 1, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
+    int e = GetSyscallShim().poll_fn(
+        &fd, 1, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
     // Since we are waiting forever will can only get the value 1 from the poll.
     // We will never get 0 since there is no timeout.  Anything else (can only
     // be -1) will be an error.
@@ -907,7 +1053,8 @@ ClientImpl::WaitForReliablePublisher(PublisherImpl *publisher,
     struct pollfd fds[2] = {
         {.fd = publisher->GetPollFd().Fd(), .events = POLLIN},
         {.fd = fd.Fd(), .events = POLLIN}};
-    int e = GetSyscallShim().poll_fn(fds, 2, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
+    int e = GetSyscallShim().poll_fn(
+        fds, 2, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
     if (timeout_ns == 0 && e == 0) {
       return absl::InternalError("Timeout waiting for reliable publisher");
     }
@@ -957,7 +1104,8 @@ absl::Status ClientImpl::WaitForSubscriber(SubscriberImpl *subscriber,
     result = co_->Wait(subscriber->GetPollFd().Fd(), POLLIN, timeout_ns);
   } else {
     struct pollfd fd = {.fd = subscriber->GetPollFd().Fd(), .events = POLLIN};
-    int e = GetSyscallShim().poll_fn(&fd, 1, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
+    int e = GetSyscallShim().poll_fn(
+        &fd, 1, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
     // Since we are waiting forever will can only get the value 1 from the poll.
     // We will never get 0 since there is no timeout.  Anything else (can only
     // be -1) will be an error.
@@ -1009,7 +1157,8 @@ absl::StatusOr<int> ClientImpl::WaitForSubscriber(
     struct pollfd fds[2] = {
         {.fd = subscriber->GetPollFd().Fd(), .events = POLLIN},
         {.fd = fd.Fd(), .events = POLLIN}};
-    int e = GetSyscallShim().poll_fn(fds, 2, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
+    int e = GetSyscallShim().poll_fn(
+        fds, 2, timeout_ns == 0 ? -1 : timeout_ns / 1000000);
     if (timeout_ns == 0 && e == 0) {
       return absl::InternalError("Timeout waiting for subscriber");
     }
@@ -1061,11 +1210,9 @@ ClientImpl::WaitForReliablePublisher(PublisherImpl *publisher,
   return s;
 }
 
-absl::StatusOr<int>
-ClientImpl::WaitForReliablePublisher(PublisherImpl *publisher,
-                                     const toolbelt::FileDescriptor &fd,
-                                     std::chrono::nanoseconds timeout,
-                                     async::Context ctx) {
+absl::StatusOr<int> ClientImpl::WaitForReliablePublisher(
+    PublisherImpl *publisher, const toolbelt::FileDescriptor &fd,
+    std::chrono::nanoseconds timeout, async::Context ctx) {
   if (absl::Status status = CheckConnected(); !status.ok()) {
     return status;
   }
@@ -1183,11 +1330,9 @@ ClientImpl::ReadMessageInternal(SubscriberImpl *subscriber, ReadMode mode,
   bool checksum_error = false;
   if (prefix != nullptr) {
     if (prefix->HasChecksum()) {
-      auto data =
-          GetMessageChecksumData(prefix, subscriber->GetCurrentBufferAddress(),
-                                 new_slot->message_size,
-                                 subscriber->ChecksumSize(),
-                                 subscriber->MetadataSize());
+      auto data = GetMessageChecksumData(
+          prefix, subscriber->GetCurrentBufferAddress(), new_slot->message_size,
+          subscriber->ChecksumSize(), subscriber->MetadataSize());
       absl::Span<const std::byte> cksum =
           GetChecksumSpan(prefix, subscriber->ChecksumSize());
       checksum_error = !subscriber->ValidateChecksum(data, cksum);
@@ -1395,10 +1540,9 @@ absl::Status ClientImpl::ReloadSubscriber(SubscriberImpl *subscriber) {
     return status;
   }
   Request req;
-  auto *cmd = req.mutable_create_subscriber();
-  cmd->set_channel_name(subscriber->Name());
-  cmd->set_subscriber_id(subscriber->GetSubscriberId());
-  cmd->set_mux(subscriber->options_.mux);
+  FillCreateSubscriberRequest(req.mutable_create_subscriber(),
+                              subscriber->Name(), subscriber->options_,
+                              subscriber->GetSubscriberId());
 
   // Send request to server and wait for response.
   Response resp;
@@ -1854,9 +1998,9 @@ absl::Status ClientImpl::ResizeChannel(PublisherImpl *publisher,
 }
 
 void ClientImpl::FillCreatePublisherRequest(CreatePublisherRequest *cmd,
-                                             const std::string &channel_name,
-                                             const PublisherOptions &opts,
-                                             int publisher_id) {
+                                            const std::string &channel_name,
+                                            const PublisherOptions &opts,
+                                            int publisher_id) {
   cmd->set_channel_name(channel_name);
   cmd->set_slot_size(Aligned(opts.slot_size));
   cmd->set_num_slots(opts.num_slots);
@@ -1876,6 +2020,7 @@ void ClientImpl::FillCreatePublisherRequest(CreatePublisherRequest *cmd,
   cmd->set_use_split_buffers(opts.UseSplitBuffers());
   cmd->set_split_buffers_over_bridge(opts.SplitBuffersOverBridge());
   cmd->set_process_id(static_cast<uint64_t>(getpid()));
+  cmd->set_max_outstanding_slot_leases(opts.MaxOutstandingSlotLeases());
 }
 
 void ClientImpl::ApplyPublisherResponseFds(
@@ -1903,9 +2048,9 @@ void ClientImpl::ApplyPublisherResponseFds(
 }
 
 void ClientImpl::FillCreateSubscriberRequest(CreateSubscriberRequest *cmd,
-                                              const std::string &channel_name,
-                                              const SubscriberOptions &opts,
-                                              int subscriber_id) {
+                                             const std::string &channel_name,
+                                             const SubscriberOptions &opts,
+                                             int subscriber_id) {
   cmd->set_channel_name(channel_name);
   cmd->set_subscriber_id(subscriber_id);
   cmd->set_is_reliable(opts.IsReliable());
@@ -1913,6 +2058,7 @@ void ClientImpl::FillCreateSubscriberRequest(CreateSubscriberRequest *cmd,
   cmd->set_for_tunnel(opts.ForTunnel());
   cmd->set_type(opts.Type());
   cmd->set_max_active_messages(opts.MaxActiveMessages());
+  cmd->set_max_subscribers(opts.MaxSubscribers());
   cmd->set_mux(opts.Mux());
   cmd->set_vchan_id(opts.VchanId());
   cmd->set_process_id(static_cast<uint64_t>(getpid()));
@@ -1991,8 +2137,7 @@ absl::Status ClientImpl::Reconnect() {
 absl::Status ClientImpl::ReregisterPublisher(PublisherImpl *publisher) {
   Request req;
   FillCreatePublisherRequest(req.mutable_create_publisher(), publisher->Name(),
-                             publisher->options_,
-                             publisher->GetPublisherId());
+                             publisher->options_, publisher->GetPublisherId());
 
   Response resp;
   std::vector<toolbelt::FileDescriptor> fds;
@@ -2095,9 +2240,8 @@ absl::Status ClientImpl::SendRequestReceiveResponse(
   return s;
 }
 
-absl::Status
-ClientImpl::SendOneWayRequest(const Request &req,
-                              const std::vector<toolbelt::FileDescriptor> &fds) {
+absl::Status ClientImpl::SendOneWayRequest(
+    const Request &req, const std::vector<toolbelt::FileDescriptor> &fds) {
   size_t msg_len = req.ByteSizeLong();
   std::vector<char> send_msg(sizeof(int32_t) + msg_len);
   char *sendbuf = send_msg.data() + sizeof(int32_t);
@@ -2129,9 +2273,9 @@ ClientImpl::SendOneWayRequest(const Request &req,
   return absl::OkStatus();
 }
 
-absl::Status ClientImpl::RegisterClientBuffer(
-    const ClientBufferHandleMetadata &metadata,
-    const toolbelt::FileDescriptor *fd) {
+absl::Status
+ClientImpl::RegisterClientBuffer(const ClientBufferHandleMetadata &metadata,
+                                 const toolbelt::FileDescriptor *fd) {
   Request req;
   auto *register_buffer = req.mutable_register_client_buffer();
   ToProto(metadata, register_buffer->mutable_metadata());
@@ -2191,10 +2335,9 @@ ClientImpl::GetClientBuffers(const std::string &channel_name,
   return result;
 }
 
-absl::Status
-ClientImpl::UnregisterClientBuffer(const std::string &channel_name,
-                                   uint64_t session_id,
-                                   uint32_t buffer_index) {
+absl::Status ClientImpl::UnregisterClientBuffer(const std::string &channel_name,
+                                                uint64_t session_id,
+                                                uint32_t buffer_index) {
   Request req;
   auto *unregister = req.mutable_unregister_client_buffer();
   unregister->set_channel_name(channel_name);

--- a/client/client.h
+++ b/client/client.h
@@ -250,6 +250,19 @@ inline shared_ptr<T, Aliaser>::shared_ptr(const weak_ptr<T, Aliaser> &p)
 class Publisher;
 class Subscriber;
 
+// An explicitly leased publisher slot. The lease remains publisher-owned until
+// it is published or released. lease_id prevents stale slot-id reuse.
+struct PublisherBufferLease {
+  void *buffer = nullptr;
+  size_t buffer_size = 0;
+  int32_t slot_id = -1;
+  uint64_t lease_id = 0;
+
+  explicit operator bool() const {
+    return buffer != nullptr && slot_id >= 0 && lease_id != 0;
+  }
+};
+
 // This is an Subspace client.  It must be initialized by calling Init()
 // before it can be used.  The Init() function connects it to an Subspace
 // server that is listening on the same Unix Domain Socket.
@@ -404,6 +417,27 @@ private:
   // the publisher cannot access the message once it's been published.
   absl::StatusOr<const Message>
   PublishMessage(details::PublisherImpl *publisher, int64_t message_size);
+
+  absl::StatusOr<PublisherBufferLease>
+  AcquirePublisherBuffer(details::PublisherImpl *publisher);
+  absl::StatusOr<PublisherBufferLease>
+  ReclaimPublisherBuffer(details::PublisherImpl *publisher, int32_t slot_id);
+  absl::StatusOr<const Message>
+  PublishPublisherBuffer(details::PublisherImpl *publisher,
+                         const PublisherBufferLease &lease,
+                         int64_t message_size);
+  absl::StatusOr<const Message>
+  PublishPublisherBufferCopy(details::PublisherImpl *publisher,
+                             const PublisherBufferLease &lease,
+                             absl::Span<const std::byte> payload);
+  absl::StatusOr<const Message> PublishPublisherBufferInternal(
+      details::PublisherImpl *publisher, const PublisherBufferLease &lease,
+      int64_t message_size, const std::byte *payload);
+  absl::Status ReleasePublisherBuffer(details::PublisherImpl *publisher,
+                                      const PublisherBufferLease &lease);
+  absl::Span<std::byte>
+  GetPublisherBufferMetadata(details::PublisherImpl *publisher,
+                             const PublisherBufferLease &lease);
 
   // In thread-safe mode, if you don't want to publish the message, you must
   // cancel the publish.  This will release the lock.
@@ -604,17 +638,16 @@ private:
   int64_t GetCurrentOrdinal(details::SubscriberImpl *sub);
 
   absl::Status CheckConnected() const;
-  absl::Status
-  SendRequestReceiveResponse(const Request &req, Response &response,
-                             std::vector<toolbelt::FileDescriptor> &fds,
-                             const std::vector<toolbelt::FileDescriptor>
-                                 &send_fds = {});
+  absl::Status SendRequestReceiveResponse(
+      const Request &req, Response &response,
+      std::vector<toolbelt::FileDescriptor> &fds,
+      const std::vector<toolbelt::FileDescriptor> &send_fds = {});
   absl::Status
   SendOneWayRequest(const Request &req,
                     const std::vector<toolbelt::FileDescriptor> &fds = {});
-  absl::Status RegisterClientBuffer(
-      const ClientBufferHandleMetadata &metadata,
-      const toolbelt::FileDescriptor *fd = nullptr);
+  absl::Status
+  RegisterClientBuffer(const ClientBufferHandleMetadata &metadata,
+                       const toolbelt::FileDescriptor *fd = nullptr);
   absl::StatusOr<std::vector<RegisteredClientBuffer>>
   GetClientBuffers(const std::string &channel_name, uint64_t session_id,
                    uint32_t buffer_index);
@@ -851,6 +884,37 @@ public:
   // CancelPublish.
   absl::StatusOr<const Message> PublishMessage(int64_t message_size) {
     return client_->PublishMessage(impl_.get(), message_size);
+  }
+
+  // Lease multiple unpublished slots without holding the client's thread-safe
+  // mutex across the lease lifetime. The maximum is configured by
+  // PublisherOptions::SetMaxOutstandingSlotLeases().
+  absl::StatusOr<PublisherBufferLease> AcquireBufferLease() {
+    return client_->AcquirePublisherBuffer(impl_.get());
+  }
+
+  // Reclaim a specific slot reported by the retirement fd.
+  absl::StatusOr<PublisherBufferLease> ReclaimBufferLease(int32_t slot_id) {
+    return client_->ReclaimPublisherBuffer(impl_.get(), slot_id);
+  }
+
+  absl::StatusOr<const Message>
+  PublishBufferLease(const PublisherBufferLease &lease, int64_t message_size) {
+    return client_->PublishPublisherBuffer(impl_.get(), lease, message_size);
+  }
+
+  absl::StatusOr<const Message>
+  PublishBufferLeaseCopy(const PublisherBufferLease &lease,
+                         absl::Span<const std::byte> payload) {
+    return client_->PublishPublisherBufferCopy(impl_.get(), lease, payload);
+  }
+
+  absl::Status ReleaseBufferLease(const PublisherBufferLease &lease) {
+    return client_->ReleasePublisherBuffer(impl_.get(), lease);
+  }
+
+  absl::Span<std::byte> GetMetadata(const PublisherBufferLease &lease) {
+    return client_->GetPublisherBufferMetadata(impl_.get(), lease);
   }
 
   // Publish a message that already includes a prefix.  You have the option to

--- a/client/client.h
+++ b/client/client.h
@@ -263,6 +263,47 @@ struct PublisherBufferLease {
   }
 };
 
+// RAII owner for an explicitly leased publisher slot. Unless the lease is
+// published or explicitly released first, destruction releases it back to the
+// publisher. The Publisher must not be moved or destroyed while one of its
+// scoped leases is alive.
+class ScopedPublisherBufferLease {
+public:
+  ScopedPublisherBufferLease() = default;
+  ~ScopedPublisherBufferLease();
+
+  ScopedPublisherBufferLease(const ScopedPublisherBufferLease &) = delete;
+  ScopedPublisherBufferLease &
+  operator=(const ScopedPublisherBufferLease &) = delete;
+  ScopedPublisherBufferLease(ScopedPublisherBufferLease &&other) noexcept;
+  ScopedPublisherBufferLease &
+  operator=(ScopedPublisherBufferLease &&other) = delete;
+
+  explicit operator bool() const {
+    return publisher_ != nullptr && static_cast<bool>(lease_);
+  }
+  void *buffer() const { return lease_.buffer; }
+  size_t buffer_size() const { return lease_.buffer_size; }
+  int32_t slot_id() const { return lease_.slot_id; }
+  uint64_t lease_id() const { return lease_.lease_id; }
+  absl::Span<std::byte> GetMetadata();
+  absl::StatusOr<const Message> Publish(int64_t message_size);
+  absl::StatusOr<const Message> PublishCopy(absl::Span<const std::byte> payload);
+  absl::Status Release();
+
+private:
+  friend class Publisher;
+  ScopedPublisherBufferLease(Publisher *publisher, PublisherBufferLease lease)
+      : publisher_(publisher), lease_(lease) {}
+  void Invalidate() {
+    publisher_ = nullptr;
+    lease_ = {};
+  }
+
+  Publisher *publisher_ = nullptr;
+  PublisherBufferLease lease_;
+};
+
 // This is an Subspace client.  It must be initialized by calling Init()
 // before it can be used.  The Init() function connects it to an Subspace
 // server that is listening on the same Unix Domain Socket.
@@ -893,9 +934,26 @@ public:
     return client_->AcquirePublisherBuffer(impl_.get());
   }
 
+  absl::StatusOr<ScopedPublisherBufferLease> AcquireScopedBufferLease() & {
+    auto lease = AcquireBufferLease();
+    if (!lease.ok()) {
+      return lease.status();
+    }
+    return ScopedPublisherBufferLease(this, *lease);
+  }
+
   // Reclaim a specific slot reported by the retirement fd.
   absl::StatusOr<PublisherBufferLease> ReclaimBufferLease(int32_t slot_id) {
     return client_->ReclaimPublisherBuffer(impl_.get(), slot_id);
+  }
+
+  absl::StatusOr<ScopedPublisherBufferLease>
+  ReclaimScopedBufferLease(int32_t slot_id) & {
+    auto lease = ReclaimBufferLease(slot_id);
+    if (!lease.ok()) {
+      return lease.status();
+    }
+    return ScopedPublisherBufferLease(this, *lease);
   }
 
   absl::StatusOr<const Message>
@@ -1200,6 +1258,61 @@ private:
   std::function<absl::Status(Publisher *, int, int)> resize_callback_ = nullptr;
   std::vector<void *> address_cache_;
 };
+
+inline ScopedPublisherBufferLease::~ScopedPublisherBufferLease() {
+  Release().IgnoreError();
+}
+
+inline ScopedPublisherBufferLease::ScopedPublisherBufferLease(
+    ScopedPublisherBufferLease &&other) noexcept
+    : publisher_(other.publisher_), lease_(other.lease_) {
+  other.Invalidate();
+}
+
+inline absl::Span<std::byte> ScopedPublisherBufferLease::GetMetadata() {
+  if (!*this) {
+    return {};
+  }
+  return publisher_->GetMetadata(lease_);
+}
+
+inline absl::StatusOr<const Message>
+ScopedPublisherBufferLease::Publish(int64_t message_size) {
+  if (!*this) {
+    return absl::FailedPreconditionError(
+        "publisher buffer lease is not active");
+  }
+  auto result = publisher_->PublishBufferLease(lease_, message_size);
+  if (result.ok()) {
+    Invalidate();
+  }
+  return result;
+}
+
+inline absl::StatusOr<const Message>
+ScopedPublisherBufferLease::PublishCopy(
+    absl::Span<const std::byte> payload) {
+  if (!*this) {
+    return absl::FailedPreconditionError(
+        "publisher buffer lease is not active");
+  }
+  auto result = publisher_->PublishBufferLeaseCopy(lease_, payload);
+  if (result.ok()) {
+    Invalidate();
+  }
+  return result;
+}
+
+inline absl::Status ScopedPublisherBufferLease::Release() {
+  if (!*this) {
+    return absl::OkStatus();
+  }
+  absl::Status status = publisher_->ReleaseBufferLease(lease_);
+  if (status.ok()) {
+    Invalidate();
+  }
+  return status;
+}
 
 class Subscriber {
 public:

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -541,38 +541,61 @@ TEST_F(ClientTest, PublisherLeaseCapacityReservesSubscriberHeadroom) {
   Subscriber sub = EVAL_AND_ASSERT_OK(client.CreateSubscriber(
       "lease_capacity_exact", SubOpts().SetMaxActiveMessages(2)));
 
-  subspace::PublisherBufferLease lease1 =
-      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
-  subspace::PublisherBufferLease lease2 =
-      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
-  subspace::PublisherBufferLease lease3 =
-      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::ScopedPublisherBufferLease lease1 =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
+  subspace::ScopedPublisherBufferLease lease2 =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
+  subspace::ScopedPublisherBufferLease lease3 =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
   ASSERT_TRUE(lease1);
   ASSERT_TRUE(lease2);
   ASSERT_TRUE(lease3);
 
-  memcpy(lease1.buffer, "one", 3);
-  ASSERT_OK(pub.PublishBufferLease(lease1, 3));
+  memcpy(lease1.buffer(), "one", 3);
+  ASSERT_OK(lease1.Publish(3));
   Message message1 = EVAL_AND_ASSERT_OK(sub.ReadMessage());
   ASSERT_EQ(3, message1.length);
 
-  memcpy(lease2.buffer, "two", 3);
-  ASSERT_OK(pub.PublishBufferLease(lease2, 3));
+  memcpy(lease2.buffer(), "two", 3);
+  ASSERT_OK(lease2.Publish(3));
   Message message2 = EVAL_AND_ASSERT_OK(sub.ReadMessage());
   ASSERT_EQ(3, message2.length);
 
   // Two subscriber-held messages plus these three leases consume every usable
   // slot. Capacity admission guarantees both acquisitions still succeed.
-  subspace::PublisherBufferLease lease4 =
-      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
-  subspace::PublisherBufferLease lease5 =
-      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::ScopedPublisherBufferLease lease4 =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
+  subspace::ScopedPublisherBufferLease lease5 =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
   ASSERT_TRUE(lease4);
   ASSERT_TRUE(lease5);
+}
 
-  ASSERT_OK(pub.ReleaseBufferLease(lease3));
-  ASSERT_OK(pub.ReleaseBufferLease(lease4));
-  ASSERT_OK(pub.ReleaseBufferLease(lease5));
+TEST_F(ClientTest, ScopedPublisherLeaseReleasesOnDestruction) {
+  subspace::Client client;
+  InitClient(client);
+  Publisher pub = EVAL_AND_ASSERT_OK(client.CreatePublisher(
+      "scoped_publisher_lease", PubOpts(64, 2).SetMaxOutstandingSlotLeases(1)));
+
+  {
+    subspace::ScopedPublisherBufferLease lease =
+        EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
+    ASSERT_TRUE(lease);
+    EXPECT_EQ(lease.buffer_size(), 64);
+
+    auto unavailable = EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+    EXPECT_FALSE(unavailable);
+
+    subspace::ScopedPublisherBufferLease moved(std::move(lease));
+    EXPECT_FALSE(lease);
+    EXPECT_TRUE(moved);
+  }
+
+  subspace::ScopedPublisherBufferLease lease =
+      EVAL_AND_ASSERT_OK(pub.AcquireScopedBufferLease());
+  EXPECT_TRUE(lease);
+  ASSERT_OK(lease.Release());
+  EXPECT_FALSE(lease);
 }
 
 TEST_F(ClientTest, PublisherLeaseCapacitySumsAcrossVirtualPublishers) {

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -76,9 +76,7 @@ struct TestSplitBufferState {
   int free_count = 0;
 };
 
-uint64_t AlignPage(uint64_t size) {
-  return subspace::PageAlignedSize(size);
-}
+uint64_t AlignPage(uint64_t size) { return subspace::PageAlignedSize(size); }
 
 uint64_t ExpectedSplitBufferVirtualMemoryUsage(int num_slots,
                                                uint64_t slot_size,
@@ -91,9 +89,8 @@ uint64_t ExpectedSplitBufferVirtualMemoryUsage(int num_slots,
 
 subspace::PublisherOptions PubOpts(int32_t slot_size = 0,
                                    int32_t num_slots = 0) {
-  return subspace::PublisherOptions()
-      .SetSlotSize(slot_size)
-      .SetNumSlots(num_slots);
+  return subspace::PublisherOptions().SetSlotSize(slot_size).SetNumSlots(
+      num_slots);
 }
 
 subspace::SubscriberOptions SubOpts() { return subspace::SubscriberOptions(); }
@@ -120,19 +117,18 @@ absl::StatusOr<toolbelt::FileDescriptor> CreateTestMemfd(const char *name,
 }
 #endif
 
-subspace::SplitBufferCallbacks MakeTestSplitBufferCallbacks(
-    std::shared_ptr<TestSplitBufferState> state) {
+subspace::SplitBufferCallbacks
+MakeTestSplitBufferCallbacks(std::shared_ptr<TestSplitBufferState> state) {
   subspace::SplitBufferCallbacks callbacks;
-  callbacks.allocate =
-      [state](const subspace::SplitBufferMetadata &metadata)
+  callbacks.allocate = [state](const subspace::SplitBufferMetadata &metadata)
       -> absl::StatusOr<subspace::SplitBufferMapping> {
     auto memory = std::make_unique<char[]>(metadata.allocation_size);
     char *address = memory.get();
     uintptr_t handle = ++state->next_handle;
     state->allocations.emplace(
-        handle, TestSplitAllocation{std::move(memory),
-                                    static_cast<size_t>(
-                                        metadata.allocation_size)});
+        handle,
+        TestSplitAllocation{std::move(memory),
+                            static_cast<size_t>(metadata.allocation_size)});
     state->allocate_count++;
     subspace::SplitBufferMapping mapping;
     mapping.handle = handle;
@@ -141,8 +137,7 @@ subspace::SplitBufferCallbacks MakeTestSplitBufferCallbacks(
     mapping.private_data = address;
     return mapping;
   };
-  callbacks.map =
-      [state](const subspace::SplitBufferMetadata &metadata)
+  callbacks.map = [state](const subspace::SplitBufferMetadata &metadata)
       -> absl::StatusOr<subspace::SplitBufferMapping> {
     auto it = state->allocations.find(metadata.handle);
     if (it == state->allocations.end()) {
@@ -155,18 +150,18 @@ subspace::SplitBufferCallbacks MakeTestSplitBufferCallbacks(
     mapping.size = it->second.size;
     return mapping;
   };
-  callbacks.unmap = [state](const subspace::SplitBufferMetadata &,
-                            const subspace::SplitBufferMapping &mapping)
-      -> absl::Status {
+  callbacks.unmap =
+      [state](const subspace::SplitBufferMetadata &,
+              const subspace::SplitBufferMapping &mapping) -> absl::Status {
     if (mapping.address == nullptr || mapping.handle == 0) {
       return absl::InvalidArgumentError("invalid split buffer mapping");
     }
     state->unmap_count++;
     return absl::OkStatus();
   };
-  callbacks.free = [state](const subspace::SplitBufferMetadata &,
-                           const subspace::SplitBufferMapping &mapping)
-      -> absl::Status {
+  callbacks.free =
+      [state](const subspace::SplitBufferMetadata &,
+              const subspace::SplitBufferMapping &mapping) -> absl::Status {
     if (mapping.handle == 0) {
       return absl::InvalidArgumentError("invalid split buffer handle");
     }
@@ -272,8 +267,8 @@ TEST_F(ClientTest, AttachingPublisherPreservesResizedSlotSize) {
 #if SUBSPACE_SHMEM_MODE == SUBSPACE_SHMEM_MODE_MEMFD
 TEST(AndroidBufferRegistrationTest, FailedRegistrationRollsBackNumBuffers) {
   constexpr int kNumSlots = 2;
-  absl::StatusOr<toolbelt::FileDescriptor> scb_fd =
-      CreateTestMemfd("subspace_test_scb", sizeof(subspace::SystemControlBlock));
+  absl::StatusOr<toolbelt::FileDescriptor> scb_fd = CreateTestMemfd(
+      "subspace_test_scb", sizeof(subspace::SystemControlBlock));
   if (absl::IsUnimplemented(scb_fd.status())) {
     GTEST_SKIP() << "memfd_create is not available on this platform";
   }
@@ -294,8 +289,8 @@ TEST(AndroidBufferRegistrationTest, FailedRegistrationRollsBackNumBuffers) {
   options.SetUseSplitBuffers(false);
   subspace::details::PublisherImpl publisher(
       "android_registration_rollback", kNumSlots, /*channel_id=*/0,
-      /*publisher_id=*/0, /*vchan_id=*/-1, /*session_id=*/123, "",
-      options, [](subspace::Channel *) { return false; },
+      /*publisher_id=*/0, /*vchan_id=*/-1, /*session_id=*/123, "", options,
+      [](subspace::Channel *) { return false; },
       /*user_id=*/0, /*group_id=*/0);
   ASSERT_OK(publisher.Map(
       subspace::SharedMemoryFds(std::move(*ccb_fd), std::move(*bcb_fd)),
@@ -427,8 +422,7 @@ TEST_F(ClientTest, TooManyVirtualPublishers) {
   }
   // Publisher on the mux will fail
   absl::StatusOr<Publisher> mux_pub =
-      client.CreatePublisher("mainmux", 256, 10,
-                             PubOpts().SetType("foobar"));
+      client.CreatePublisher("mainmux", 256, 10, PubOpts().SetType("foobar"));
   ASSERT_FALSE(mux_pub.ok());
 
   // One more virtual publisher will fail.
@@ -452,8 +446,7 @@ TEST_F(ClientTest, CreateVirtualPublisherMuxMismatch) {
 
   // No mux.
   absl::StatusOr<Publisher> pub3 =
-      client.CreatePublisher("dave0", 256, 100,
-                             PubOpts().SetType("foobar"));
+      client.CreatePublisher("dave0", 256, 100, PubOpts().SetType("foobar"));
   ASSERT_FALSE(pub3.ok());
 
   // Creating a channel with same name as mux should fail.
@@ -530,6 +523,131 @@ TEST_F(ClientTest, TooManyPublishers) {
   EXPECT_EQ(9, info->num_publishers);
 }
 
+TEST_F(ClientTest, PublisherLeaseCapacityReservesSubscriberHeadroom) {
+  subspace::Client client;
+  InitClient(client);
+
+  auto small_pub = client.CreatePublisher(
+      "lease_capacity_small", PubOpts(64, 5).SetMaxOutstandingSlotLeases(3));
+  ASSERT_OK(small_pub);
+  auto rejected_sub = client.CreateSubscriber(
+      "lease_capacity_small", SubOpts().SetMaxActiveMessages(2));
+  ASSERT_FALSE(rejected_sub.ok());
+  EXPECT_THAT(rejected_sub.status().message(),
+              ::testing::HasSubstr("3 slot leases"));
+
+  Publisher pub = EVAL_AND_ASSERT_OK(client.CreatePublisher(
+      "lease_capacity_exact", PubOpts(64, 6).SetMaxOutstandingSlotLeases(3)));
+  Subscriber sub = EVAL_AND_ASSERT_OK(client.CreateSubscriber(
+      "lease_capacity_exact", SubOpts().SetMaxActiveMessages(2)));
+
+  subspace::PublisherBufferLease lease1 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::PublisherBufferLease lease2 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::PublisherBufferLease lease3 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  ASSERT_TRUE(lease1);
+  ASSERT_TRUE(lease2);
+  ASSERT_TRUE(lease3);
+
+  memcpy(lease1.buffer, "one", 3);
+  ASSERT_OK(pub.PublishBufferLease(lease1, 3));
+  Message message1 = EVAL_AND_ASSERT_OK(sub.ReadMessage());
+  ASSERT_EQ(3, message1.length);
+
+  memcpy(lease2.buffer, "two", 3);
+  ASSERT_OK(pub.PublishBufferLease(lease2, 3));
+  Message message2 = EVAL_AND_ASSERT_OK(sub.ReadMessage());
+  ASSERT_EQ(3, message2.length);
+
+  // Two subscriber-held messages plus these three leases consume every usable
+  // slot. Capacity admission guarantees both acquisitions still succeed.
+  subspace::PublisherBufferLease lease4 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::PublisherBufferLease lease5 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  ASSERT_TRUE(lease4);
+  ASSERT_TRUE(lease5);
+
+  ASSERT_OK(pub.ReleaseBufferLease(lease3));
+  ASSERT_OK(pub.ReleaseBufferLease(lease4));
+  ASSERT_OK(pub.ReleaseBufferLease(lease5));
+}
+
+TEST_F(ClientTest, PublisherLeaseCapacitySumsAcrossVirtualPublishers) {
+  subspace::Client client;
+  InitClient(client);
+
+  auto pub1 = client.CreatePublisher(
+      "lease_vchan_1",
+      PubOpts(64, 6).SetMux("lease_mux").SetMaxOutstandingSlotLeases(2));
+  ASSERT_OK(pub1);
+  auto pub2 = client.CreatePublisher(
+      "lease_vchan_2",
+      PubOpts(64, 6).SetMux("lease_mux").SetMaxOutstandingSlotLeases(3));
+  ASSERT_OK(pub2);
+
+  auto rejected_pub = client.CreatePublisher(
+      "lease_vchan_3",
+      PubOpts(64, 6).SetMux("lease_mux").SetMaxOutstandingSlotLeases(1));
+  ASSERT_FALSE(rejected_pub.ok());
+  EXPECT_THAT(rejected_pub.status().message(),
+              ::testing::HasSubstr("6 slot leases"));
+}
+
+TEST_F(ClientTest, PublisherLeaseMetadataLookupIsThreadSafe) {
+  subspace::Client client;
+  InitClient(client);
+  Publisher pub = EVAL_AND_ASSERT_OK(client.CreatePublisher(
+      "lease_metadata_thread_safe",
+      PubOpts(64, 4).SetMetadataSize(8).SetMaxOutstandingSlotLeases(2)));
+
+  subspace::PublisherBufferLease lease1 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  subspace::PublisherBufferLease lease2 =
+      EVAL_AND_ASSERT_OK(pub.AcquireBufferLease());
+  ASSERT_TRUE(lease1);
+  ASSERT_TRUE(lease2);
+
+  std::atomic<bool> start = false;
+  std::atomic<bool> failed = false;
+  std::thread metadata_reader([&]() {
+    while (!start.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
+    for (int i = 0; i < 2000; ++i) {
+      absl::Span<std::byte> metadata = pub.GetMetadata(lease1);
+      if (metadata.size() != 8) {
+        failed.store(true, std::memory_order_relaxed);
+        return;
+      }
+      metadata[0] = static_cast<std::byte>(i & 0xff);
+    }
+  });
+
+  start.store(true, std::memory_order_release);
+  for (int i = 0; i < 2000; ++i) {
+    absl::Status release = pub.ReleaseBufferLease(lease2);
+    if (!release.ok()) {
+      failed.store(true, std::memory_order_relaxed);
+      break;
+    }
+    absl::StatusOr<subspace::PublisherBufferLease> next =
+        pub.AcquireBufferLease();
+    if (!next.ok() || !*next) {
+      failed.store(true, std::memory_order_relaxed);
+      break;
+    }
+    lease2 = *next;
+  }
+
+  metadata_reader.join();
+  EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+  EXPECT_TRUE(pub.ReleaseBufferLease(lease1).ok());
+  EXPECT_TRUE(pub.ReleaseBufferLease(lease2).ok());
+}
+
 TEST_F(ClientTest, MaxPublishersOptionLimitsPublisherCount) {
   subspace::Client client;
   InitClient(client);
@@ -548,6 +666,35 @@ TEST_F(ClientTest, MaxPublishersOptionLimitsPublisherCount) {
   ASSERT_FALSE(pub3.ok());
   EXPECT_THAT(pub3.status().message(),
               ::testing::HasSubstr("maximum number of publishers"));
+}
+
+TEST_F(ClientTest, MaxSubscribersOptionLimitsSubscriberCount) {
+  subspace::Client client;
+  InitClient(client);
+  subspace::SubscriberOptions opts;
+  opts.SetMaxSubscribers(2);
+
+  absl::StatusOr<Subscriber> sub1 =
+      client.CreateSubscriber("max_subscribers", opts);
+  ASSERT_OK(sub1);
+  auto publisher =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("max_subscribers", 256, 10));
+  absl::StatusOr<Subscriber> sub2 =
+      client.CreateSubscriber("max_subscribers", opts);
+  ASSERT_OK(sub2);
+
+  void *buffer = EVAL_AND_ASSERT_OK(publisher.GetMessageBuffer());
+  memcpy(buffer, "limit", 5);
+  ASSERT_OK(publisher.PublishMessage(5));
+  Message received = EVAL_AND_ASSERT_OK(sub1->ReadMessage());
+  ASSERT_EQ(5, received.length);
+  ASSERT_EQ(0, memcmp(received.buffer, "limit", 5));
+
+  absl::StatusOr<Subscriber> sub3 =
+      client.CreateSubscriber("max_subscribers", opts);
+  ASSERT_FALSE(sub3.ok());
+  EXPECT_THAT(sub3.status().message(),
+              ::testing::HasSubstr("maximum number of subscribers"));
 }
 
 TEST_F(ClientTest, TooManySubscribers) {
@@ -573,9 +720,8 @@ TEST_F(ClientTest, TooManyVirtualSubscribers) {
   constexpr int kNumSlots = 10;
 
   // 1 publisher.
-  absl::StatusOr<Publisher> pub =
-      client.CreatePublisher("dave0", 256, kNumSlots,
-                             PubOpts().SetMux("foobar"));
+  absl::StatusOr<Publisher> pub = client.CreatePublisher(
+      "dave0", 256, kNumSlots, PubOpts().SetMux("foobar"));
   ASSERT_OK(pub);
 
   // 6 subscribers.
@@ -678,8 +824,7 @@ TEST_F(ClientTest, CreatePublisherThenSubscriber) {
 TEST_F(ClientTest, CreateVirtualPublisherThenSubscriber) {
   subspace::Client client;
   InitClient(client);
-  auto p = client.CreatePublisher("dave1", 256, 10,
-                                  PubOpts().SetMux("foobar"));
+  auto p = client.CreatePublisher("dave1", 256, 10, PubOpts().SetMux("foobar"));
   ASSERT_OK(p);
 
   auto s = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
@@ -692,16 +837,15 @@ TEST_F(ClientTest, CreateVirtualSubscriberThenPublisher) {
 
   auto s = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
   ASSERT_OK(s);
-  auto p = client.CreatePublisher("dave1", 256, 10,
-                                  PubOpts().SetMux("foobar"));
+  auto p = client.CreatePublisher("dave1", 256, 10, PubOpts().SetMux("foobar"));
   ASSERT_OK(p);
 }
 
 TEST_F(ClientTest, CreateVirtualPublisherThenSubscriberMuxMismatch) {
   subspace::Client client;
   InitClient(client);
-  auto p1 = client.CreatePublisher("dave1", 256, 10,
-                                   PubOpts().SetMux("foobar"));
+  auto p1 =
+      client.CreatePublisher("dave1", 256, 10, PubOpts().SetMux("foobar"));
   ASSERT_OK(p1);
 
   auto s1 = client.CreateSubscriber("dave1", SubOpts().SetMux("foobar"));
@@ -931,8 +1075,8 @@ TEST_F(ClientTest, SplitBuffersPublishWithHandlesAndSeparatePrefix) {
 
   uintptr_t *subscriber_handles = nullptr;
   size_t subscriber_handle_count = 0;
-  ASSERT_TRUE(
-      sub->GetSplitBufferHandles(&subscriber_handles, &subscriber_handle_count));
+  ASSERT_TRUE(sub->GetSplitBufferHandles(&subscriber_handles,
+                                         &subscriber_handle_count));
   ASSERT_EQ(4U, subscriber_handle_count);
   ASSERT_NE(nullptr, subscriber_handles);
   for (size_t i = 0; i < subscriber_handle_count; i++) {
@@ -943,11 +1087,11 @@ TEST_F(ClientTest, SplitBuffersPublishWithHandlesAndSeparatePrefix) {
       sub->Prefix(sub->GetSlot(pub_status->slot_id));
   ASSERT_NE(nullptr, sub_prefix);
   EXPECT_EQ(9, sub_prefix->message_size);
-  auto sub_metadata = subspace::GetMetadataSpan(
-      sub_prefix, sub->ChecksumSize(), sub->MetadataSize());
+  auto sub_metadata = subspace::GetMetadataSpan(sub_prefix, sub->ChecksumSize(),
+                                                sub->MetadataSize());
   ASSERT_EQ(8U, sub_metadata.size());
-  EXPECT_EQ(
-      0, std::memcmp(sub_metadata.data(), "metadata", sub_metadata.size()));
+  EXPECT_EQ(0,
+            std::memcmp(sub_metadata.data(), "metadata", sub_metadata.size()));
 }
 
 TEST_F(ClientTest, PlaceholderSubscriberLearnsSplitBuffersOnReload) {
@@ -1129,8 +1273,8 @@ TEST_F(ClientTest, PublishSingleMessageWithPrefixAndRead) {
   subspace::Client sub_client;
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
-  absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "dave6", PubOpts(256, 10).SetType("foobar"));
+  absl::StatusOr<Publisher> pub =
+      pub_client.CreatePublisher("dave6", PubOpts(256, 10).SetType("foobar"));
   ASSERT_OK(pub);
 
   ASSERT_EQ("foobar", pub->TypeView());
@@ -1212,8 +1356,7 @@ TEST_F(ClientTest, PublishSingleMessageAndReadNewest) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6",
-                                  SubOpts().SetMaxActiveMessages(2));
+      sub_client.CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   // Another message.
@@ -1243,8 +1386,8 @@ TEST_F(ClientTest, PublishSingleMessageAndReadWithActivation) {
   subspace::Client sub_client;
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
-  absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "dave6", PubOpts(256, 10).SetActivate(true));
+  absl::StatusOr<Publisher> pub =
+      pub_client.CreatePublisher("dave6", PubOpts(256, 10).SetActivate(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -1351,8 +1494,7 @@ TEST_F(ClientTest, VirtualPublishSingleMessageAndRead) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10,
-                                 PubOpts().SetMux("mainmux"));
+      pub_client.CreatePublisher("dave6", 256, 10, PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1391,8 +1533,7 @@ TEST_F(ClientTest, VirtualPublishMultiple) {
   for (int i = 0; i < 10; i++) {
     std::string name = "dave" + std::to_string(i);
     absl::StatusOr<Publisher> pub =
-        pub_client.CreatePublisher(name, 256, 100,
-                                   PubOpts().SetMux("mainmux"));
+        pub_client.CreatePublisher(name, 256, 100, PubOpts().SetMux("mainmux"));
     ASSERT_OK(pub);
     pubs.push_back(std::move(*pub));
   }
@@ -1463,8 +1604,7 @@ TEST_F(ClientTest, PublishAndResize) {
   ASSERT_OK(pub_status);
 
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6",
-                                  SubOpts().SetMaxActiveMessages(2));
+      sub_client.CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1500,8 +1640,7 @@ TEST_F(ClientTest, PublishVirtualAndResize) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10,
-                                 PubOpts().SetMux("mainmux"));
+      pub_client.CreatePublisher("dave6", 256, 10, PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1564,8 +1703,7 @@ TEST_F(ClientTest, PublishAndResize2) {
 
   // Now create subscriber and read both messages.
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6",
-                                  SubOpts().SetMaxActiveMessages(2));
+      sub_client.CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
 
   absl::StatusOr<Message> msg = sub->ReadMessage();
@@ -1668,8 +1806,7 @@ TEST_F(ClientTest, PublishAndResizeSubscriberFirst) {
 
   // First create subscriber.
   absl::StatusOr<Subscriber> sub =
-      sub_client.CreateSubscriber("dave6",
-                                  SubOpts().SetMaxActiveMessages(2));
+      sub_client.CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(2));
   ASSERT_OK(sub);
   ASSERT_EQ(0, sub->SlotSize()); // No buffers yet.
 
@@ -1715,8 +1852,7 @@ TEST_F(ClientTest, PublishVirtualAndResizeSubscriberFirst) {
   ASSERT_EQ(0, sub->SlotSize()); // No buffers yet.
 
   absl::StatusOr<Publisher> pub =
-      pub_client.CreatePublisher("dave6", 256, 10,
-                                 PubOpts().SetMux("mainmux"));
+      pub_client.CreatePublisher("dave6", 256, 10, PubOpts().SetMux("mainmux"));
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1755,8 +1891,7 @@ TEST_F(ClientTest, PublishAndResizeSubscriberConcurrently) {
   std::atomic<bool> publisher_finished{false};
 
   auto t1 = std::thread([&]() {
-    auto client1_pub = *client1.CreatePublisher(
-        channel_name, PubOpts(1, 4));
+    auto client1_pub = *client1.CreatePublisher(channel_name, PubOpts(1, 4));
     for (int i = 1; i < 24; i++) {
       std::size_t size = std::pow(2, i);
       auto buffer = client1_pub.GetMessageBuffer(size);
@@ -1795,8 +1930,7 @@ TEST_F(ClientTest, PublishConcurrentlyFromOneClientToOneSubscriber) {
   ASSERT_OK(sub_client.Init(Socket()));
   auto sub = *sub_client.CreateSubscriber(channel_name);
 
-  const int kNumPublishers =
-      absl::GetFlag(FLAGS_use_split_buffers) ? 16 : 100;
+  const int kNumPublishers = absl::GetFlag(FLAGS_use_split_buffers) ? 16 : 100;
   std::vector<Publisher> pubs;
   pubs.reserve(kNumPublishers);
   subspace::Client pub_client;
@@ -1853,42 +1987,42 @@ TEST_F(ClientTest, PublishConcurrentlyToOneSubscriber) {
 #ifdef __APPLE__
   constexpr int kNumPublishers = 16;
 #else
-  const int kNumPublishers =
-      absl::GetFlag(FLAGS_use_split_buffers) ? 16 : 100;
+  const int kNumPublishers = absl::GetFlag(FLAGS_use_split_buffers) ? 16 : 100;
 #endif
   pub_threads.reserve(kNumPublishers);
   std::atomic<int> published{0};
   for (int i = 0; i < kNumPublishers; ++i) {
-    pub_threads.emplace_back(std::thread(
-        [&channel_name, &published, kNumPublishers, i]() {
-      // We have a backlog of 10 hardcoded for the subscriber's listen socket.
-      // We will get a connection refused if we exceed this so use a retry loop
-      // with a delay if we get errors on connection.  Happens on MacOS.
-      subspace::Client pub_client;
-      bool connected = false;
-      for (int i = 0; i < 100; i++) {
-        if (pub_client.Init(Socket()).ok()) {
-          connected = true;
-          break;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
-      ASSERT_TRUE(connected);
-      absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-          channel_name, PubOpts(256, 2 * kNumPublishers + 16));
-      ASSERT_OK(pub) << pub.status();
-      std::array<char, 16> msg = {};
-      auto size = std::snprintf(msg.data(), msg.size(), "M%d", i);
-      auto buffer = pub->GetMessageBuffer(size);
-      ASSERT_OK(buffer) << buffer.status();
-      ASSERT_NE(nullptr, *buffer);
-      std::memcpy(*buffer, msg.data(), size);
-      ASSERT_OK(pub->PublishMessage(size));
-      published.fetch_add(1, std::memory_order_release);
-      while (published.load(std::memory_order_acquire) < kNumPublishers) {
-        std::this_thread::yield();
-      }
-    }));
+    pub_threads.emplace_back(
+        std::thread([&channel_name, &published, kNumPublishers, i]() {
+          // We have a backlog of 10 hardcoded for the subscriber's listen
+          // socket. We will get a connection refused if we exceed this so use a
+          // retry loop with a delay if we get errors on connection.  Happens on
+          // MacOS.
+          subspace::Client pub_client;
+          bool connected = false;
+          for (int i = 0; i < 100; i++) {
+            if (pub_client.Init(Socket()).ok()) {
+              connected = true;
+              break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+          }
+          ASSERT_TRUE(connected);
+          absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
+              channel_name, PubOpts(256, 2 * kNumPublishers + 16));
+          ASSERT_OK(pub) << pub.status();
+          std::array<char, 16> msg = {};
+          auto size = std::snprintf(msg.data(), msg.size(), "M%d", i);
+          auto buffer = pub->GetMessageBuffer(size);
+          ASSERT_OK(buffer) << buffer.status();
+          ASSERT_NE(nullptr, *buffer);
+          std::memcpy(*buffer, msg.data(), size);
+          ASSERT_OK(pub->PublishMessage(size));
+          published.fetch_add(1, std::memory_order_release);
+          while (published.load(std::memory_order_acquire) < kNumPublishers) {
+            std::this_thread::yield();
+          }
+        }));
   }
 
   for (auto &t : pub_threads) {
@@ -1949,7 +2083,8 @@ TEST_F(ClientTest, PublishSingleMessagePollAndReadAfterPlaceholderRead) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber("placeholder_read");
+  absl::StatusOr<Subscriber> sub =
+      sub_client.CreateSubscriber("placeholder_read");
   ASSERT_OK(sub);
 
   struct pollfd fd = sub->GetPollFd();
@@ -1959,7 +2094,8 @@ TEST_F(ClientTest, PublishSingleMessagePollAndReadAfterPlaceholderRead) {
   ASSERT_OK(msg);
   ASSERT_EQ(0, msg->length);
 
-  absl::StatusOr<Publisher> pub = pub_client.CreatePublisher("placeholder_read", 256, 10);
+  absl::StatusOr<Publisher> pub =
+      pub_client.CreatePublisher("placeholder_read", 256, 10);
   ASSERT_OK(pub);
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
   ASSERT_OK(buffer);
@@ -1987,8 +2123,10 @@ TEST_F(ClientTest, SlowReliableSubscriberDrainReachesEmptyRead) {
   ASSERT_OK(sub);
 
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "slow_reliable_drain",
-      subspace::PublisherOptions().SetReliable(true).SetSlotSize(64).SetNumSlots(4));
+      "slow_reliable_drain", subspace::PublisherOptions()
+                                 .SetReliable(true)
+                                 .SetSlotSize(64)
+                                 .SetNumSlots(4));
   ASSERT_OK(pub);
 
   std::atomic<bool> stop_publisher{false};
@@ -2026,7 +2164,8 @@ TEST_F(ClientTest, SlowReliableSubscriberDrainReachesEmptyRead) {
 
   EXPECT_LT(reads_before_empty, kMaxReadsBeforeEmpty)
       << "a slow reliable subscriber should finish draining the poll-triggered "
-         "batch instead of continuously chasing messages published during the drain";
+         "batch instead of continuously chasing messages published during the "
+         "drain";
 }
 
 // Reproduces the external-epoll pattern: fetch the poll fd ONCE before the
@@ -2076,8 +2215,7 @@ TEST_F(ClientTest, ExternalPollLoopGetPollFdOnceReadOnce) {
     absl::StatusOr<Message> msg = sub->ReadMessage();
     ASSERT_OK(msg);
     if (msg->length > 0) {
-      received.insert(
-          std::string(reinterpret_cast<const char *>(msg->buffer)));
+      received.insert(std::string(reinterpret_cast<const char *>(msg->buffer)));
     }
   }
   publisher.join();
@@ -2126,8 +2264,7 @@ TEST_F(ClientTest, ExternalPollLoopGetPollFdOnceDrainUntilEmpty) {
       if (msg->length == 0) {
         break;
       }
-      received.insert(
-          std::string(reinterpret_cast<const char *>(msg->buffer)));
+      received.insert(std::string(reinterpret_cast<const char *>(msg->buffer)));
     }
   }
   publisher.join();
@@ -2739,8 +2876,10 @@ TEST_F(ClientTest, PublishSingleMessageAndReadSharedPtr) {
   absl::StatusOr<const Message> pub_status = pub->PublishMessage(6);
   ASSERT_OK(pub_status);
 
-  absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "dave6", subspace::SubscriberOptions().SetMaxActiveMessages(3).SetKeepActiveMessage(false));
+  absl::StatusOr<Subscriber> sub =
+      sub_client.CreateSubscriber("dave6", subspace::SubscriberOptions()
+                                               .SetMaxActiveMessages(3)
+                                               .SetKeepActiveMessage(false));
   ASSERT_OK(sub);
 
   absl::StatusOr<subspace::shared_ptr<const char>> p =
@@ -2788,8 +2927,10 @@ TEST_F(ClientTest, Publish2Message2AndReadSharedPtrs) {
     ASSERT_OK(pub_status);
   }
 
-  absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "dave6", subspace::SubscriberOptions().SetMaxActiveMessages(2).SetKeepActiveMessage(false));
+  absl::StatusOr<Subscriber> sub =
+      sub_client.CreateSubscriber("dave6", subspace::SubscriberOptions()
+                                               .SetMaxActiveMessages(2)
+                                               .SetKeepActiveMessage(false));
   ASSERT_OK(sub);
 
   absl::StatusOr<subspace::shared_ptr<const char>> p =
@@ -3158,8 +3299,8 @@ TEST_F(ClientTest, RetirementTrigger1) {
 
   {
     // You can't create a virtual publisher with notify_retirement.
-    absl::StatusOr<Publisher> p2 =
-        pub_client->CreatePublisher("dave6v", PubOpts(256, 10).SetMux("/foobar").SetNotifyRetirement(true));
+    absl::StatusOr<Publisher> p2 = pub_client->CreatePublisher(
+        "dave6v", PubOpts(256, 10).SetMux("/foobar").SetNotifyRetirement(true));
     ASSERT_FALSE(p2.ok());
   }
   const toolbelt::FileDescriptor &retirement_fd = pub.GetRetirementFd();
@@ -3235,13 +3376,13 @@ TEST_F(ClientTest, RetirementTrigger2) {
 
   const toolbelt::FileDescriptor &retirement_fd = pub.GetRetirementFd();
 
-  absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
+  absl::StatusOr<Subscriber> s1 = sub_client->CreateSubscriber(
+      "dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
-  absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
+  absl::StatusOr<Subscriber> s2 = sub_client->CreateSubscriber(
+      "dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3425,13 +3566,13 @@ TEST_F(ClientTest, RetirementTrigger4) {
   // retires the slots.
   const toolbelt::FileDescriptor &retirement_fd = pub2.GetRetirementFd();
 
-  absl::StatusOr<Subscriber> s1 =
-      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
+  absl::StatusOr<Subscriber> s1 = sub_client->CreateSubscriber(
+      "dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s1);
   auto sub1 = std::move(*s1);
 
-  absl::StatusOr<Subscriber> s2 =
-      sub_client->CreateSubscriber("dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
+  absl::StatusOr<Subscriber> s2 = sub_client->CreateSubscriber(
+      "dave6", SubOpts().SetMaxActiveMessages(1).SetKeepActiveMessage(true));
   ASSERT_OK(s2);
   auto sub2 = std::move(*s2);
 
@@ -3520,7 +3661,8 @@ TEST_F(ClientTest, RetirementTrigger4) {
 
 TEST_F(ClientTest, ChannelDirectory) {
   constexpr char kClientName[] = "channel-directory-test";
-  auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket(), kClientName));
+  auto client =
+      EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket(), kClientName));
 
   absl::StatusOr<Publisher> p1 =
       client->CreatePublisher("chan1", PubOpts(256, 10));
@@ -3594,8 +3736,8 @@ TEST_F(ClientTest, ChannelDirectory) {
 TEST_F(ClientTest, MessageGetters) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
-  absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan1", PubOpts(256, 10).SetType("test-type"));
+  absl::StatusOr<Publisher> pub =
+      client->CreatePublisher("chan1", PubOpts(256, 10).SetType("test-type"));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan1");
@@ -3623,8 +3765,8 @@ TEST_F(ClientTest, MessageGetters) {
 TEST_F(ClientTest, ChecksumVerification) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
-  absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan1", PubOpts(256, 10).SetChecksum(true));
+  absl::StatusOr<Publisher> pub =
+      client->CreatePublisher("chan1", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   // Create a second publisher that doesn't calculate a checksum.
@@ -3744,17 +3886,16 @@ TEST_F(ClientTest, ChecksumVerification) {
 TEST_F(ClientTest, ChecksumCallback) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
-  absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cb", PubOpts(256, 10).SetChecksum(true));
+  absl::StatusOr<Publisher> pub =
+      client->CreatePublisher("chan_cb", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
       client->CreateSubscriber("chan_cb", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
-  auto fake_crc =
-      [](const std::array<absl::Span<const uint8_t>, 3> &data,
-         absl::Span<std::byte> checksum) {
+  auto fake_crc = [](const std::array<absl::Span<const uint8_t>, 3> &data,
+                     absl::Span<std::byte> checksum) {
     uint32_t sum = 0;
     for (const auto &span : data) {
       for (uint8_t byte : span) {
@@ -3808,9 +3949,8 @@ TEST_F(ClientTest, ChecksumCallbackPassErrors) {
       "chan_cb_pass", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub);
 
-  auto fake_crc =
-      [](const std::array<absl::Span<const uint8_t>, 3> &data,
-         absl::Span<std::byte> checksum) {
+  auto fake_crc = [](const std::array<absl::Span<const uint8_t>, 3> &data,
+                     absl::Span<std::byte> checksum) {
     uint32_t sum = 0;
     for (const auto &span : data) {
       for (uint8_t byte : span) {
@@ -3850,9 +3990,8 @@ TEST_F(ClientTest, ChecksumCallbackReset) {
       client->CreateSubscriber("chan_cb_reset", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
-  auto fake_crc =
-      [](const std::array<absl::Span<const uint8_t>, 3> &data,
-         absl::Span<std::byte> checksum) {
+  auto fake_crc = [](const std::array<absl::Span<const uint8_t>, 3> &data,
+                     absl::Span<std::byte> checksum) {
     uint32_t sum = 0;
     for (const auto &span : data) {
       for (uint8_t byte : span) {
@@ -3865,9 +4004,9 @@ TEST_F(ClientTest, ChecksumCallbackReset) {
   auto fake_crc_mismatch =
       [&fake_crc](const std::array<absl::Span<const uint8_t>, 3> &data,
                   absl::Span<std::byte> checksum) {
-    fake_crc(data, checksum);
-    checksum[0] ^= std::byte{0xFF};
-  };
+        fake_crc(data, checksum);
+        checksum[0] ^= std::byte{0xFF};
+      };
 
   pub->SetChecksumCallback(fake_crc);
   sub->SetChecksumCallback(fake_crc_mismatch);
@@ -3906,17 +4045,15 @@ TEST_F(ClientTest, ChecksumCallbackPublisherOnly) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cb_pub_only",
-      PubOpts(256, 10).SetChecksum(true));
+      "chan_cb_pub_only", PubOpts(256, 10).SetChecksum(true));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
       client->CreateSubscriber("chan_cb_pub_only", SubOpts().SetChecksum(true));
   ASSERT_OK(sub);
 
-  auto fake_crc =
-      [](const std::array<absl::Span<const uint8_t>, 3> &data,
-         absl::Span<std::byte> checksum) {
+  auto fake_crc = [](const std::array<absl::Span<const uint8_t>, 3> &data,
+                     absl::Span<std::byte> checksum) {
     uint32_t sum = 0;
     for (const auto &span : data) {
       for (uint8_t byte : span) {
@@ -3946,8 +4083,7 @@ TEST_F(ClientTest, Checksum20Byte) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_ck20",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20));
+      "chan_ck20", PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
@@ -3960,9 +4096,8 @@ TEST_F(ClientTest, Checksum20Byte) {
   ASSERT_EQ(20, sub->ChecksumSize());
 
   // 20-byte checksum: 5 CRC32 values computed with different seeds.
-  auto checksum_20 =
-      [](const std::array<absl::Span<const uint8_t>, 3> &data,
-         absl::Span<std::byte> checksum) {
+  auto checksum_20 = [](const std::array<absl::Span<const uint8_t>, 3> &data,
+                        absl::Span<std::byte> checksum) {
     ASSERT_GE(checksum.size(), 20u);
     uint32_t *out = reinterpret_cast<uint32_t *>(checksum.data());
     for (int k = 0; k < 5; k++) {
@@ -4011,8 +4146,8 @@ TEST_F(ClientTest, Checksum20Byte) {
 TEST_F(ClientTest, ChecksumSizeDefault) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
-  absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_def", PubOpts(256, 10));
+  absl::StatusOr<Publisher> pub =
+      client->CreatePublisher("chan_cs_def", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(4, pub->ChecksumSize());
@@ -4046,14 +4181,12 @@ TEST_F(ClientTest, PrefixSizeInconsistent) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub1 = client->CreatePublisher(
-      "chan_ps_incon",
-      PubOpts(256, 10).SetChecksumSize(20));
+      "chan_ps_incon", PubOpts(256, 10).SetChecksumSize(20));
   ASSERT_OK(pub1);
 
   // A second publisher with different sizes should fail.
   absl::StatusOr<Publisher> pub2 = client->CreatePublisher(
-      "chan_ps_incon",
-      PubOpts(256, 10).SetChecksumSize(32));
+      "chan_ps_incon", PubOpts(256, 10).SetChecksumSize(32));
   ASSERT_FALSE(pub2.ok());
 }
 
@@ -4067,8 +4200,11 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixIsShared) {
 
   // First publisher on vchan_a with checksum_size=20, metadata_size=50:
   //   48 + 20 + 50 = 118 → Aligned<64> = 128.
-  absl::StatusOr<Publisher> pub_a = client->CreatePublisher(
-      "vchan_a", PubOpts(256, 10).SetMux("shared_mux").SetChecksumSize(20).SetMetadataSize(50));
+  absl::StatusOr<Publisher> pub_a =
+      client->CreatePublisher("vchan_a", PubOpts(256, 10)
+                                             .SetMux("shared_mux")
+                                             .SetChecksumSize(20)
+                                             .SetMetadataSize(50));
   ASSERT_OK(pub_a);
   ASSERT_EQ(128, pub_a->PrefixSize());
   ASSERT_EQ(20, pub_a->ChecksumSize());
@@ -4085,8 +4221,11 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixIsShared) {
 
   // A second publisher on a different vchan on the same mux with matching
   // sizes must succeed and report the same prefix layout.
-  absl::StatusOr<Publisher> pub_b = client->CreatePublisher(
-      "vchan_b", PubOpts(256, 10).SetMux("shared_mux").SetChecksumSize(20).SetMetadataSize(50));
+  absl::StatusOr<Publisher> pub_b =
+      client->CreatePublisher("vchan_b", PubOpts(256, 10)
+                                             .SetMux("shared_mux")
+                                             .SetChecksumSize(20)
+                                             .SetMetadataSize(50));
   ASSERT_OK(pub_b);
   ASSERT_EQ(128, pub_b->PrefixSize());
 
@@ -4112,8 +4251,11 @@ TEST_F(ClientTest, VirtualChannelMuxPrefixSubscriberFirst) {
       client->CreateSubscriber("vchan_a", SubOpts().SetMux("sub_first_mux"));
   ASSERT_OK(sub_a);
 
-  absl::StatusOr<Publisher> pub_a = client->CreatePublisher(
-      "vchan_a", PubOpts(256, 10).SetMux("sub_first_mux").SetChecksumSize(20).SetMetadataSize(50));
+  absl::StatusOr<Publisher> pub_a =
+      client->CreatePublisher("vchan_a", PubOpts(256, 10)
+                                             .SetMux("sub_first_mux")
+                                             .SetChecksumSize(20)
+                                             .SetMetadataSize(50));
   ASSERT_OK(pub_a);
   ASSERT_EQ(128, pub_a->PrefixSize());
 
@@ -4134,8 +4276,7 @@ TEST_F(ClientTest, SubscriberGetsSizes) {
       PubOpts(256, 10).SetChecksumSize(20).SetMetadataSize(50));
   ASSERT_OK(pub);
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_sub_sizes");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_sub_sizes");
   ASSERT_OK(sub);
 
   ASSERT_EQ(pub->PrefixSize(), sub->PrefixSize());
@@ -4153,8 +4294,7 @@ TEST_F(ClientTest, MetadataSmall) {
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(8, pub->MetadataSize());
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_meta_s");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_meta_s");
   ASSERT_OK(sub);
   ASSERT_EQ(8, sub->MetadataSize());
 
@@ -4185,13 +4325,11 @@ TEST_F(ClientTest, MetadataExactFit) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_ex",
-      PubOpts(256, 10).SetMetadataSize(12));
+      "chan_meta_ex", PubOpts(256, 10).SetMetadataSize(12));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_meta_ex");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_meta_ex");
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4212,18 +4350,17 @@ TEST_F(ClientTest, MetadataExactFit) {
   ASSERT_EQ(0, memcmp("EXACTLY12!!!", sub_meta.data(), 12));
 }
 
-// metadata_size=13, checksum_size=4: 48+4+13=65 → prefix=128 (spills to 2nd chunk)
+// metadata_size=13, checksum_size=4: 48+4+13=65 → prefix=128 (spills to 2nd
+// chunk)
 TEST_F(ClientTest, MetadataSpillsToSecondChunk) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_sp",
-      PubOpts(256, 10).SetMetadataSize(13));
+      "chan_meta_sp", PubOpts(256, 10).SetMetadataSize(13));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_meta_sp");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_meta_sp");
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4256,8 +4393,7 @@ TEST_F(ClientTest, MetadataLargeWithLargeChecksum) {
   ASSERT_EQ(32, pub->ChecksumSize());
   ASSERT_EQ(200, pub->MetadataSize());
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_meta_lg");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_meta_lg");
   ASSERT_OK(sub);
   ASSERT_EQ(320, sub->PrefixSize());
   ASSERT_EQ(200, sub->MetadataSize());
@@ -4283,7 +4419,8 @@ TEST_F(ClientTest, MetadataLargeWithLargeChecksum) {
   auto sub_meta = sub->GetMetadata();
   ASSERT_EQ(200u, sub_meta.size());
   for (int i = 0; i < 200; i++) {
-    ASSERT_EQ(static_cast<std::byte>(i & 0xFF), sub_meta[i]) << "at index " << i;
+    ASSERT_EQ(static_cast<std::byte>(i & 0xFF), sub_meta[i])
+        << "at index " << i;
   }
 }
 
@@ -4291,8 +4428,7 @@ TEST_F(ClientTest, ChecksumSizeTooLarge) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_big_fail",
-      PubOpts(256, 10).SetChecksumSize(0x10000));
+      "chan_cs_big_fail", PubOpts(256, 10).SetChecksumSize(0x10000));
   ASSERT_FALSE(pub.ok());
 }
 
@@ -4300,8 +4436,7 @@ TEST_F(ClientTest, MetadataSizeTooLarge) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_ms_big_fail",
-      PubOpts(256, 10).SetMetadataSize(0x10000));
+      "chan_ms_big_fail", PubOpts(256, 10).SetMetadataSize(0x10000));
   ASSERT_FALSE(pub.ok());
 }
 
@@ -4309,8 +4444,7 @@ TEST_F(ClientTest, ChecksumSizeAtMax) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_max",
-      PubOpts(0x20000, 2).SetChecksumSize(0xFFFF));
+      "chan_cs_max", PubOpts(0x20000, 2).SetChecksumSize(0xFFFF));
   ASSERT_OK(pub);
   ASSERT_EQ(0xFFFF, pub->ChecksumSize());
 }
@@ -4319,8 +4453,7 @@ TEST_F(ClientTest, MetadataSizeAtMax) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_ms_max",
-      PubOpts(0x20000, 2).SetMetadataSize(0xFFFF));
+      "chan_ms_max", PubOpts(0x20000, 2).SetMetadataSize(0xFFFF));
   ASSERT_OK(pub);
   ASSERT_EQ(0xFFFF, pub->MetadataSize());
 }
@@ -4329,8 +4462,8 @@ TEST_F(ClientTest, MetadataSizeAtMax) {
 TEST_F(ClientTest, MetadataZero) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
-  absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_z", PubOpts(256, 10));
+  absl::StatusOr<Publisher> pub =
+      client->CreatePublisher("chan_meta_z", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_EQ(64, pub->PrefixSize());
   ASSERT_EQ(0, pub->MetadataSize());
@@ -4347,12 +4480,10 @@ TEST_F(ClientTest, MetadataMultipleMessages) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_meta_mm",
-      PubOpts(256, 10).SetMetadataSize(16));
+      "chan_meta_mm", PubOpts(256, 10).SetMetadataSize(16));
   ASSERT_OK(pub);
 
-  absl::StatusOr<Subscriber> sub =
-      client->CreateSubscriber("chan_meta_mm");
+  absl::StatusOr<Subscriber> sub = client->CreateSubscriber("chan_meta_mm");
   ASSERT_OK(sub);
 
   for (int i = 0; i < 5; i++) {
@@ -4388,8 +4519,7 @@ TEST_F(ClientTest, ChecksumWithMetadata) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_meta",
-      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
+      "chan_cs_meta", PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
   ASSERT_EQ(4, pub->ChecksumSize());
   ASSERT_EQ(16, pub->MetadataSize());
@@ -4421,7 +4551,8 @@ TEST_F(ClientTest, ChecksumWithMetadata) {
   ASSERT_EQ(0, memcmp("META_CHECKSUM!!\0", sub_meta.data(), 16));
 }
 
-// Checksum + metadata: corrupt the message payload after publish → checksum error.
+// Checksum + metadata: corrupt the message payload after publish → checksum
+// error.
 TEST_F(ClientTest, ChecksumWithMetadataCorruptPayload) {
   auto client = EVAL_AND_ASSERT_OK(subspace::Client::Create(Socket()));
 
@@ -4494,7 +4625,8 @@ TEST_F(ClientTest, ChecksumWithMetadataCorruptMetadataPassError) {
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber(
-      "chan_cs_meta_pe", SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
+      "chan_cs_meta_pe",
+      SubOpts().SetChecksum(true).SetPassChecksumErrors(true));
   ASSERT_OK(sub);
 
   absl::StatusOr<void *> buffer = pub->GetMessageBuffer();
@@ -4525,8 +4657,7 @@ TEST_F(ClientTest, ChecksumIgnoresPrefixPadding) {
   // checksum_size=4, metadata_size=16 → used=48+4+16=68, prefix=128.
   // Padding region is bytes [68..128) relative to prefix start.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
-      "chan_cs_pad",
-      PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
+      "chan_cs_pad", PubOpts(256, 10).SetChecksum(true).SetMetadataSize(16));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
 
@@ -4573,7 +4704,8 @@ TEST_F(ClientTest, ChecksumIgnoresPrefixPaddingLargeChecksum) {
   // Padding region is bytes [100..128).
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cs_pad_lg",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20).SetMetadataSize(32));
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(20).SetMetadataSize(
+          32));
   ASSERT_OK(pub);
   ASSERT_EQ(128, pub->PrefixSize());
   ASSERT_EQ(20, pub->ChecksumSize());
@@ -4631,29 +4763,36 @@ namespace {
 
 // FIPS 197 S-box.
 static const uint8_t kAesSbox[256] = {
-    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
-    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
-    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
-    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
-    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
-    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
-    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
-    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
-    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
-    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
-    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
-    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
-    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
-    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
-    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
-    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b,
+    0xfe, 0xd7, 0xab, 0x76, 0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0,
+    0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0, 0xb7, 0xfd, 0x93, 0x26,
+    0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2,
+    0xeb, 0x27, 0xb2, 0x75, 0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0,
+    0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84, 0x53, 0xd1, 0x00, 0xed,
+    0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f,
+    0x50, 0x3c, 0x9f, 0xa8, 0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5,
+    0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2, 0xcd, 0x0c, 0x13, 0xec,
+    0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14,
+    0xde, 0x5e, 0x0b, 0xdb, 0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c,
+    0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79, 0xe7, 0xc8, 0x37, 0x6d,
+    0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f,
+    0x4b, 0xbd, 0x8b, 0x8a, 0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e,
+    0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e, 0xe1, 0xf8, 0x98, 0x11,
+    0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f,
+    0xb0, 0x54, 0xbb, 0x16,
 };
 
-static const uint8_t kRcon[10] = {
-    0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x1b,0x36};
+static const uint8_t kRcon[10] = {0x01, 0x02, 0x04, 0x08, 0x10,
+                                  0x20, 0x40, 0x80, 0x1b, 0x36};
 
 inline void Xor128(uint8_t *dst, const uint8_t *src) {
-  for (int i = 0; i < 16; i++) dst[i] ^= src[i];
+  for (int i = 0; i < 16; i++)
+    dst[i] ^= src[i];
 }
 
 inline uint8_t Gmul2(uint8_t a) {
@@ -4665,12 +4804,10 @@ void Aes128KeyExpand(const uint8_t key[16], uint8_t rk[176]) {
   for (int i = 0; i < 10; i++) {
     const uint8_t *prev = rk + 16 * i;
     uint8_t *next = rk + 16 * (i + 1);
-    uint8_t t[4] = {
-        static_cast<uint8_t>(kAesSbox[prev[13]] ^ kRcon[i]),
-        kAesSbox[prev[14]],
-        kAesSbox[prev[15]],
-        kAesSbox[prev[12]]};
-    for (int j = 0; j < 4; j++) next[j] = prev[j] ^ t[j];
+    uint8_t t[4] = {static_cast<uint8_t>(kAesSbox[prev[13]] ^ kRcon[i]),
+                    kAesSbox[prev[14]], kAesSbox[prev[15]], kAesSbox[prev[12]]};
+    for (int j = 0; j < 4; j++)
+      next[j] = prev[j] ^ t[j];
     for (int w = 1; w < 4; w++)
       for (int j = 0; j < 4; j++)
         next[4 * w + j] = prev[4 * w + j] ^ next[4 * (w - 1) + j];
@@ -4691,20 +4828,26 @@ void MixColumns(uint8_t s[16]) {
 void Aes128Encrypt(const uint8_t rk[176], uint8_t block[16]) {
   Xor128(block, rk);
   for (int r = 1; r <= 10; r++) {
-    for (int i = 0; i < 16; i++) block[i] = kAesSbox[block[i]];
+    for (int i = 0; i < 16; i++)
+      block[i] = kAesSbox[block[i]];
     // ShiftRows (column-major state).
     // Row 1: left by 1.
     uint8_t t = block[1];
-    block[1] = block[5]; block[5] = block[9];
-    block[9] = block[13]; block[13] = t;
+    block[1] = block[5];
+    block[5] = block[9];
+    block[9] = block[13];
+    block[13] = t;
     // Row 2: left by 2.
     std::swap(block[2], block[10]);
     std::swap(block[6], block[14]);
     // Row 3: left by 3 (= right by 1).
     t = block[15];
-    block[15] = block[11]; block[11] = block[7];
-    block[7] = block[3]; block[3] = t;
-    if (r < 10) MixColumns(block);
+    block[15] = block[11];
+    block[11] = block[7];
+    block[7] = block[3];
+    block[3] = t;
+    if (r < 10)
+      MixColumns(block);
     Xor128(block, rk + 16 * r);
   }
 }
@@ -4727,12 +4870,15 @@ void Aes128Cmac(const uint8_t key[16],
   Aes128Encrypt(rk, L);
   uint8_t K1[16], K2[16];
   ShiftLeft128(L, K1);
-  if (L[0] & 0x80) K1[15] ^= 0x87;
+  if (L[0] & 0x80)
+    K1[15] ^= 0x87;
   ShiftLeft128(K1, K2);
-  if (K1[0] & 0x80) K2[15] ^= 0x87;
+  if (K1[0] & 0x80)
+    K2[15] ^= 0x87;
 
   size_t total = 0;
-  for (const auto &s : data) total += s.size();
+  for (const auto &s : data)
+    total += s.size();
 
   uint8_t X[16] = {};
   uint8_t blk[16];
@@ -4755,7 +4901,8 @@ void Aes128Cmac(const uint8_t key[16],
     Xor128(blk, K1);
   } else {
     blk[pos++] = 0x80;
-    while (pos < 16) blk[pos++] = 0x00;
+    while (pos < 16)
+      blk[pos++] = 0x00;
     Xor128(blk, K2);
   }
   Xor128(X, blk);
@@ -4764,14 +4911,13 @@ void Aes128Cmac(const uint8_t key[16],
 }
 
 // Fixed test key (RFC 4493 test vector key).
-static const uint8_t kCmacTestKey[16] = {
-    0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,
-    0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c};
+static const uint8_t kCmacTestKey[16] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+                                         0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88,
+                                         0x09, 0xcf, 0x4f, 0x3c};
 
 // ChecksumCallback wrapper that computes AES-128-CMAC.
-void CmacChecksumCallback(
-    const std::array<absl::Span<const uint8_t>, 3> &data,
-    absl::Span<std::byte> checksum) {
+void CmacChecksumCallback(const std::array<absl::Span<const uint8_t>, 3> &data,
+                          absl::Span<std::byte> checksum) {
   uint8_t mac[16];
   Aes128Cmac(kCmacTestKey, data, mac);
   memcpy(checksum.data(), mac, std::min<size_t>(checksum.size(), 16));
@@ -4783,15 +4929,13 @@ void CmacChecksumCallback(
 TEST(Aes128CmacTest, Rfc4493Vectors) {
   // Example 2: 16-byte message (one complete block).
   {
-    const uint8_t msg[16] = {
-        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
-        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a};
-    const uint8_t expected[16] = {
-        0x07,0x0a,0x16,0xb4,0x6b,0x4d,0x41,0x44,
-        0xf7,0x9b,0xdd,0x9d,0xd0,0x4a,0x28,0x7c};
+    const uint8_t msg[16] = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
+                             0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a};
+    const uint8_t expected[16] = {0x07, 0x0a, 0x16, 0xb4, 0x6b, 0x4d,
+                                  0x41, 0x44, 0xf7, 0x9b, 0xdd, 0x9d,
+                                  0xd0, 0x4a, 0x28, 0x7c};
     std::array<absl::Span<const uint8_t>, 3> data = {
-        absl::Span<const uint8_t>(msg, 16),
-        absl::Span<const uint8_t>(),
+        absl::Span<const uint8_t>(msg, 16), absl::Span<const uint8_t>(),
         absl::Span<const uint8_t>()};
     uint8_t mac[16];
     Aes128Cmac(kCmacTestKey, data, mac);
@@ -4799,18 +4943,16 @@ TEST(Aes128CmacTest, Rfc4493Vectors) {
   }
   // Example 3: 40-byte message (not a multiple of 16).
   {
-    const uint8_t msg[40] = {
-        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
-        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a,
-        0xae,0x2d,0x8a,0x57,0x1e,0x03,0xac,0x9c,
-        0x9e,0xb7,0x6f,0xac,0x45,0xaf,0x8e,0x51,
-        0x30,0xc8,0x1c,0x46,0xa3,0x5c,0xe4,0x11};
-    const uint8_t expected[16] = {
-        0xdf,0xa6,0x67,0x47,0xde,0x9a,0xe6,0x30,
-        0x30,0xca,0x32,0x61,0x14,0x97,0xc8,0x27};
+    const uint8_t msg[40] = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
+                             0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a,
+                             0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03, 0xac, 0x9c,
+                             0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51,
+                             0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11};
+    const uint8_t expected[16] = {0xdf, 0xa6, 0x67, 0x47, 0xde, 0x9a,
+                                  0xe6, 0x30, 0x30, 0xca, 0x32, 0x61,
+                                  0x14, 0x97, 0xc8, 0x27};
     std::array<absl::Span<const uint8_t>, 3> data = {
-        absl::Span<const uint8_t>(msg, 40),
-        absl::Span<const uint8_t>(),
+        absl::Span<const uint8_t>(msg, 40), absl::Span<const uint8_t>(),
         absl::Span<const uint8_t>()};
     uint8_t mac[16];
     Aes128Cmac(kCmacTestKey, data, mac);
@@ -4819,20 +4961,17 @@ TEST(Aes128CmacTest, Rfc4493Vectors) {
   // Example 4: 64-byte message (four complete blocks).
   {
     const uint8_t msg[64] = {
-        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
-        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a,
-        0xae,0x2d,0x8a,0x57,0x1e,0x03,0xac,0x9c,
-        0x9e,0xb7,0x6f,0xac,0x45,0xaf,0x8e,0x51,
-        0x30,0xc8,0x1c,0x46,0xa3,0x5c,0xe4,0x11,
-        0xe5,0xfb,0xc1,0x19,0x1a,0x0a,0x52,0xef,
-        0xf6,0x9f,0x24,0x45,0xdf,0x4f,0x9b,0x17,
-        0xad,0x2b,0x41,0x7b,0xe6,0x6c,0x37,0x10};
-    const uint8_t expected[16] = {
-        0x51,0xf0,0xbe,0xbf,0x7e,0x3b,0x9d,0x92,
-        0xfc,0x49,0x74,0x17,0x79,0x36,0x3c,0xfe};
+        0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e,
+        0x11, 0x73, 0x93, 0x17, 0x2a, 0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03,
+        0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51, 0x30,
+        0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1, 0x19,
+        0x1a, 0x0a, 0x52, 0xef, 0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b,
+        0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10};
+    const uint8_t expected[16] = {0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b,
+                                  0x9d, 0x92, 0xfc, 0x49, 0x74, 0x17,
+                                  0x79, 0x36, 0x3c, 0xfe};
     std::array<absl::Span<const uint8_t>, 3> data = {
-        absl::Span<const uint8_t>(msg, 64),
-        absl::Span<const uint8_t>(),
+        absl::Span<const uint8_t>(msg, 64), absl::Span<const uint8_t>(),
         absl::Span<const uint8_t>()};
     uint8_t mac[16];
     Aes128Cmac(kCmacTestKey, data, mac);
@@ -4840,15 +4979,14 @@ TEST(Aes128CmacTest, Rfc4493Vectors) {
   }
   // Same 40-byte message split across all three spans produces identical MAC.
   {
-    const uint8_t msg[40] = {
-        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
-        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a,
-        0xae,0x2d,0x8a,0x57,0x1e,0x03,0xac,0x9c,
-        0x9e,0xb7,0x6f,0xac,0x45,0xaf,0x8e,0x51,
-        0x30,0xc8,0x1c,0x46,0xa3,0x5c,0xe4,0x11};
-    const uint8_t expected[16] = {
-        0xdf,0xa6,0x67,0x47,0xde,0x9a,0xe6,0x30,
-        0x30,0xca,0x32,0x61,0x14,0x97,0xc8,0x27};
+    const uint8_t msg[40] = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
+                             0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a,
+                             0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03, 0xac, 0x9c,
+                             0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51,
+                             0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11};
+    const uint8_t expected[16] = {0xdf, 0xa6, 0x67, 0x47, 0xde, 0x9a,
+                                  0xe6, 0x30, 0x30, 0xca, 0x32, 0x61,
+                                  0x14, 0x97, 0xc8, 0x27};
     std::array<absl::Span<const uint8_t>, 3> data = {
         absl::Span<const uint8_t>(msg, 10),
         absl::Span<const uint8_t>(msg + 10, 17),
@@ -4866,7 +5004,8 @@ TEST_F(ClientTest, ChecksumAes128CmacWithMetadata) {
   // checksum_size=16 for the 128-bit CMAC output.
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(
+          24));
   ASSERT_OK(pub);
   ASSERT_EQ(16, pub->ChecksumSize());
   ASSERT_EQ(24, pub->MetadataSize());
@@ -4905,7 +5044,8 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptPayload) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_cp",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(
+          24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
@@ -4938,7 +5078,8 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptMetadata) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_cm",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(
+          24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub =
@@ -4971,7 +5112,8 @@ TEST_F(ClientTest, ChecksumAes128CmacCorruptMetadataPassError) {
 
   absl::StatusOr<Publisher> pub = client->CreatePublisher(
       "chan_cmac_pe",
-      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(24));
+      PubOpts(256, 10).SetChecksum(true).SetChecksumSize(16).SetMetadataSize(
+          24));
   ASSERT_OK(pub);
 
   absl::StatusOr<Subscriber> sub = client->CreateSubscriber(
@@ -5006,13 +5148,12 @@ TEST_F(ClientTest, TunnelPublisherSetsCrossMachineFlag) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "tunnel_test1",
-      PubOpts(256, 10).SetForTunnel(true));
+      "tunnel_test1", PubOpts(256, 10).SetForTunnel(true));
   ASSERT_OK(pub);
   ASSERT_TRUE(pub->ForTunnel());
 
-  absl::StatusOr<Subscriber> sub = sub_client.CreateSubscriber(
-      "tunnel_test1", SubOpts().SetForTunnel(true));
+  absl::StatusOr<Subscriber> sub =
+      sub_client.CreateSubscriber("tunnel_test1", SubOpts().SetForTunnel(true));
   ASSERT_OK(sub);
   ASSERT_TRUE(sub->ForTunnel());
 
@@ -5045,8 +5186,8 @@ TEST_F(ClientTest, NonTunnelPublisherDoesNotSetCrossMachineFlag) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  absl::StatusOr<Publisher> pub = pub_client.CreatePublisher(
-      "tunnel_test2", PubOpts(256, 10));
+  absl::StatusOr<Publisher> pub =
+      pub_client.CreatePublisher("tunnel_test2", PubOpts(256, 10));
   ASSERT_OK(pub);
   ASSERT_FALSE(pub->ForTunnel());
 
@@ -5115,8 +5256,8 @@ TEST_F(ClientTest, ChannelExistsFalse) {
 TEST_F(ClientTest, GetChannelStatsByName) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("stats_test", PubOpts(256, 4)));
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("stats_test", PubOpts(256, 4)));
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'x', 100);
   auto msg = pub.PublishMessage(100);
@@ -5133,10 +5274,10 @@ TEST_F(ClientTest, GetChannelStatsByName) {
 TEST_F(ClientTest, GetChannelStatsAll) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub1 = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("allstats1", PubOpts(64, 4)));
-  auto pub2 = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("allstats2", PubOpts(64, 4)));
+  auto pub1 =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("allstats1", PubOpts(64, 4)));
+  auto pub2 =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("allstats2", PubOpts(64, 4)));
 
   auto buf1 = EVAL_AND_ASSERT_OK(pub1.GetMessageBuffer());
   memset(buf1, 'a', 10);
@@ -5180,7 +5321,8 @@ TEST_F(ClientTest, GetChannelCountersByNameNotFound) {
   ASSERT_OK(client.Init(Socket()));
   auto counters = client.GetChannelCounters("nonexistent_channel_xyz");
   ASSERT_FALSE(counters.ok());
-  EXPECT_THAT(counters.status().message(), ::testing::HasSubstr("doesn't exist"));
+  EXPECT_THAT(counters.status().message(),
+              ::testing::HasSubstr("doesn't exist"));
 }
 
 TEST_F(ClientTest, GetChannelInfoAll) {
@@ -5209,8 +5351,7 @@ TEST_F(ClientTest, GetCurrentOrdinal) {
 
   auto pub = EVAL_AND_ASSERT_OK(
       pub_client.CreatePublisher("ordinal_test", PubOpts(64, 4)));
-  auto sub = EVAL_AND_ASSERT_OK(
-      sub_client.CreateSubscriber("ordinal_test"));
+  auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("ordinal_test"));
 
   // Before any reads, ordinal should be -1 (no current slot).
   ASSERT_EQ(-1, sub.GetCurrentOrdinal());
@@ -5231,8 +5372,8 @@ TEST_F(ClientTest, SetDebugDoesNotCrash) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   client.SetDebug(true);
-  auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("debug_test", PubOpts(64, 4)));
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("debug_test", PubOpts(64, 4)));
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'y', 5);
   ASSERT_OK(pub.PublishMessage(5));
@@ -5271,8 +5412,8 @@ TEST_F(ClientTest, UnreliablePublisherGetFileDescriptorInvalid) {
 TEST_F(ClientTest, PublishZeroSizeFails) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("zero_pub", PubOpts(64, 4)));
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("zero_pub", PubOpts(64, 4)));
   [[maybe_unused]] auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   auto msg = pub.PublishMessage(0);
   ASSERT_FALSE(msg.ok());
@@ -5314,19 +5455,19 @@ TEST_F(ClientTest, OnSendCallbackSuccess) {
 TEST_F(ClientTest, OnSendCallbackError) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("onsend_err", PubOpts(256, 4)));
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("onsend_err", PubOpts(256, 4)));
 
-  pub.SetOnSendCallback(
-      [](void *, int64_t) -> absl::StatusOr<int64_t> {
-        return absl::InternalError("send callback failed");
-      });
+  pub.SetOnSendCallback([](void *, int64_t) -> absl::StatusOr<int64_t> {
+    return absl::InternalError("send callback failed");
+  });
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'a', 10);
   auto msg = pub.PublishMessage(10);
   ASSERT_FALSE(msg.ok());
-  EXPECT_THAT(msg.status().message(), ::testing::HasSubstr("send callback failed"));
+  EXPECT_THAT(msg.status().message(),
+              ::testing::HasSubstr("send callback failed"));
   pub.ClearOnSendCallback();
 }
 
@@ -5338,7 +5479,8 @@ TEST_F(ClientTest, WaitForUnreliablePublisherFails) {
   ASSERT_FALSE(pub.IsReliable());
   absl::Status s = pub.Wait();
   ASSERT_FALSE(s.ok());
-  EXPECT_THAT(s.message(), ::testing::HasSubstr("Unreliable publishers can't wait"));
+  EXPECT_THAT(s.message(),
+              ::testing::HasSubstr("Unreliable publishers can't wait"));
 }
 
 TEST_F(ClientTest, WaitForReliablePublisherTimeout) {
@@ -5348,8 +5490,7 @@ TEST_F(ClientTest, WaitForReliablePublisherTimeout) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber(
-      "reliable_timeout",
-      subspace::SubscriberOptions().SetReliable(true)));
+      "reliable_timeout", subspace::SubscriberOptions().SetReliable(true)));
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
       "reliable_timeout",
       subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(2).SetReliable(
@@ -5373,8 +5514,8 @@ TEST_F(ClientTest, WaitForSubscriberTimeout) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   // Create pub first so channel exists, then subscriber.
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "sub_timeout", PubOpts(64, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("sub_timeout", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("sub_timeout"));
 
   // Read any initial trigger to drain the subscriber fd.
@@ -5396,8 +5537,7 @@ TEST_F(ClientTest, MaxActiveMessagesTooSmall) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
   auto sub = client.CreateSubscriber(
-      "max_active_test",
-      subspace::SubscriberOptions().SetMaxActiveMessages(0));
+      "max_active_test", subspace::SubscriberOptions().SetMaxActiveMessages(0));
   ASSERT_FALSE(sub.ok());
   EXPECT_THAT(sub.status().message(),
               ::testing::HasSubstr("MaxActiveMessages"));
@@ -5409,8 +5549,8 @@ TEST_F(ClientTest, OnReceiveCallbackSuccess) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "onrecv_test", PubOpts(256, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("onrecv_test", PubOpts(256, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("onrecv_test"));
 
   bool callback_called = false;
@@ -5437,14 +5577,13 @@ TEST_F(ClientTest, OnReceiveCallbackError) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "onrecv_err", PubOpts(256, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("onrecv_err", PubOpts(256, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("onrecv_err"));
 
-  sub.SetOnReceiveCallback(
-      [](void *, int64_t) -> absl::StatusOr<int64_t> {
-        return absl::InternalError("receive callback failed");
-      });
+  sub.SetOnReceiveCallback([](void *, int64_t) -> absl::StatusOr<int64_t> {
+    return absl::InternalError("receive callback failed");
+  });
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
   memset(buf, 'q', 10);
@@ -5472,8 +5611,8 @@ TEST_F(ClientTest, WaitForSubscriberWithExtraFd) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "twofd_test", PubOpts(64, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("twofd_test", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("twofd_test"));
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
@@ -5497,8 +5636,8 @@ TEST_F(ClientTest, WaitForSubscriberExtraFdFires) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "twofd_extra", PubOpts(64, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("twofd_extra", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("twofd_extra"));
 
   // Drain any initial trigger.
@@ -5527,8 +5666,7 @@ TEST_F(ClientTest, WaitForReliablePublisherWithExtraFd) {
   ASSERT_OK(sub_client.Init(Socket()));
 
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber(
-      "reliable_twofd",
-      subspace::SubscriberOptions().SetReliable(true)));
+      "reliable_twofd", subspace::SubscriberOptions().SetReliable(true)));
   auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
       "reliable_twofd",
       subspace::PublisherOptions().SetSlotSize(64).SetNumSlots(4).SetReliable(
@@ -5557,10 +5695,9 @@ TEST_F(ClientTest, DoubleRegisterDroppedMessageCallback) {
   ASSERT_OK(client.Init(Socket()));
   auto sub = EVAL_AND_ASSERT_OK(client.CreateSubscriber("double_dropped"));
 
-  ASSERT_OK(sub.RegisterDroppedMessageCallback(
-      [](Subscriber *, int64_t) {}));
-  absl::Status s = sub.RegisterDroppedMessageCallback(
-      [](Subscriber *, int64_t) {});
+  ASSERT_OK(sub.RegisterDroppedMessageCallback([](Subscriber *, int64_t) {}));
+  absl::Status s =
+      sub.RegisterDroppedMessageCallback([](Subscriber *, int64_t) {});
   ASSERT_FALSE(s.ok());
   EXPECT_THAT(s.message(), ::testing::HasSubstr("already been registered"));
   ASSERT_OK(sub.UnregisterDroppedMessageCallback());
@@ -5572,8 +5709,7 @@ TEST_F(ClientTest, UnregisterDroppedMessageCallbackNotRegistered) {
   auto sub = EVAL_AND_ASSERT_OK(client.CreateSubscriber("unreg_dropped"));
   absl::Status s = sub.UnregisterDroppedMessageCallback();
   ASSERT_FALSE(s.ok());
-  EXPECT_THAT(s.message(),
-              ::testing::HasSubstr("No dropped message callback"));
+  EXPECT_THAT(s.message(), ::testing::HasSubstr("No dropped message callback"));
 }
 
 TEST_F(ClientTest, DoubleRegisterMessageCallback) {
@@ -5581,10 +5717,8 @@ TEST_F(ClientTest, DoubleRegisterMessageCallback) {
   ASSERT_OK(client.Init(Socket()));
   auto sub = EVAL_AND_ASSERT_OK(client.CreateSubscriber("double_msg_cb"));
 
-  ASSERT_OK(sub.RegisterMessageCallback(
-      [](Subscriber *, Message) {}));
-  absl::Status s = sub.RegisterMessageCallback(
-      [](Subscriber *, Message) {});
+  ASSERT_OK(sub.RegisterMessageCallback([](Subscriber *, Message) {}));
+  absl::Status s = sub.RegisterMessageCallback([](Subscriber *, Message) {});
   ASSERT_FALSE(s.ok());
   EXPECT_THAT(s.message(), ::testing::HasSubstr("already been registered"));
   ASSERT_OK(sub.UnregisterMessageCallback());
@@ -5643,8 +5777,8 @@ TEST_F(ClientTest, MessageCopyAndMove) {
   ASSERT_OK(pub_client.Init(Socket()));
   ASSERT_OK(sub_client.Init(Socket()));
 
-  auto pub = EVAL_AND_ASSERT_OK(pub_client.CreatePublisher(
-      "msg_copy", PubOpts(64, 4)));
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("msg_copy", PubOpts(64, 4)));
   auto sub = EVAL_AND_ASSERT_OK(sub_client.CreateSubscriber("msg_copy"));
 
   auto buf = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
@@ -5780,11 +5914,11 @@ TEST_F(ClientTest, ResizeFixedSizePublisherFails) {
 TEST_F(ClientTest, ResizeCallbackReturnsError) {
   subspace::Client client;
   ASSERT_OK(client.Init(Socket()));
-  auto pub = EVAL_AND_ASSERT_OK(
-      client.CreatePublisher("resize_err", PubOpts(64, 4)));
+  auto pub =
+      EVAL_AND_ASSERT_OK(client.CreatePublisher("resize_err", PubOpts(64, 4)));
 
-  ASSERT_OK(pub.RegisterResizeCallback(
-      [](Publisher *, int, int) -> absl::Status {
+  ASSERT_OK(
+      pub.RegisterResizeCallback([](Publisher *, int, int) -> absl::Status {
         return absl::InternalError("resize denied");
       }));
 
@@ -5800,8 +5934,8 @@ TEST_F(ClientTest, ResizeCallbackReturnsError) {
 // ---------------------------------------------------------------------------
 
 TEST_F(ClientTest, FreeCreatePublisher) {
-  auto pub_or = subspace::CreatePublisher(
-      "free_pub", PubOpts(256, 10), Socket());
+  auto pub_or =
+      subspace::CreatePublisher("free_pub", PubOpts(256, 10), Socket());
   ASSERT_OK(pub_or);
   auto pub = std::move(*pub_or);
   ASSERT_EQ(256, pub.SlotSize());
@@ -5812,8 +5946,7 @@ TEST_F(ClientTest, FreeCreateSubscriber) {
   // Need a publisher first so the channel exists with concrete slots.
   subspace::Client client;
   InitClient(client);
-  auto pub =
-      EVAL_AND_ASSERT_OK(client.CreatePublisher("free_sub", 256, 10));
+  auto pub = EVAL_AND_ASSERT_OK(client.CreatePublisher("free_sub", 256, 10));
 
   auto sub_or = subspace::CreateSubscriber("free_sub", {}, Socket());
   ASSERT_OK(sub_or);
@@ -5831,8 +5964,8 @@ TEST_F(ClientTest, FreeCreateSubscriber) {
 }
 
 TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {
-  auto pub_or = subspace::CreatePublisher(
-      "free_rt", PubOpts(256, 10), Socket());
+  auto pub_or =
+      subspace::CreatePublisher("free_rt", PubOpts(256, 10), Socket());
   ASSERT_OK(pub_or);
   auto pub = std::move(*pub_or);
 
@@ -5852,15 +5985,14 @@ TEST_F(ClientTest, FreeCreatePublisherAndSubscriberRoundTrip) {
 }
 
 TEST_F(ClientTest, FreeCreatePublisherBadSocket) {
-  auto pub_or = subspace::CreatePublisher(
-      "bad_pub", PubOpts(256, 10),
-      "/tmp/no_such_subspace_socket");
+  auto pub_or = subspace::CreatePublisher("bad_pub", PubOpts(256, 10),
+                                          "/tmp/no_such_subspace_socket");
   ASSERT_FALSE(pub_or.ok());
 }
 
 TEST_F(ClientTest, FreeCreateSubscriberBadSocket) {
-  auto sub_or = subspace::CreateSubscriber(
-      "bad_sub", {}, "/tmp/no_such_subspace_socket");
+  auto sub_or =
+      subspace::CreateSubscriber("bad_sub", {}, "/tmp/no_such_subspace_socket");
   ASSERT_FALSE(sub_or.ok());
 }
 
@@ -5987,8 +6119,8 @@ public:
         /*wait_for_clients=*/true);
 
 #ifndef __APPLE__
-    auto status = server_->LoadPlugin("SPLIT_BUFFER_FREE_TEST",
-                                      "plugins/split_buffer_free_test_plugin.so");
+    auto status = server_->LoadPlugin(
+        "SPLIT_BUFFER_FREE_TEST", "plugins/split_buffer_free_test_plugin.so");
     if (!status.ok()) {
       fprintf(stderr, "Failed to load split-buffer test plugin: %s\n",
               status.ToString().c_str());
@@ -6078,9 +6210,9 @@ TEST_F(SplitBufferPluginTest, ServerCleanupUsesPluginEndToEnd) {
   std::memcpy(*buffer, "plugin-split", 12);
 
   uintptr_t publisher_handle = 0;
-  ASSERT_TRUE(
-      pub->GetSplitBufferHandleFromAddress(*buffer, &publisher_handle));
-  EXPECT_NE(state->allocations.end(), state->allocations.find(publisher_handle));
+  ASSERT_TRUE(pub->GetSplitBufferHandleFromAddress(*buffer, &publisher_handle));
+  EXPECT_NE(state->allocations.end(),
+            state->allocations.find(publisher_handle));
 
   absl::StatusOr<const Message> pub_status = pub->PublishMessage(12);
   ASSERT_OK(pub_status);

--- a/client/options.h
+++ b/client/options.h
@@ -125,6 +125,28 @@ struct PublisherOptions {
     return *this;
   }
 
+  // Maximum number of explicitly leased unpublished slots. Existing
+  // GetMessageBuffer()/PublishMessage() users retain their single-slot
+  // behavior; this limit applies to AcquireBufferLease().
+  PublisherOptions &SetMaxOutstandingSlotLeases(int32_t n) {
+    max_outstanding_slot_leases = n;
+    return *this;
+  }
+  int32_t MaxOutstandingSlotLeases() const {
+    return max_outstanding_slot_leases;
+  }
+
+  // When false, retirement notifications are emitted only after subscriber
+  // release (or immediately for a publication with no subscribers), never
+  // merely because an unreliable publisher forcibly reuses an old slot.
+  PublisherOptions &SetNotifyRetirementOnForcedReuse(bool v) {
+    notify_retirement_on_forced_reuse = v;
+    return *this;
+  }
+  bool NotifyRetirementOnForcedReuse() const {
+    return notify_retirement_on_forced_reuse;
+  }
+
   // If this is set to true all messages published will have a checksum
   // calculated and placed in the MessagePrefix metadata.  If subscribers want
   // to verify the checksum the must set the SubscriberOptions.Checksum to true.
@@ -232,6 +254,8 @@ struct PublisherOptions {
   std::string mux;
   int vchan_id = -1; // If -1, server will assign.
   bool notify_retirement = false;
+  int32_t max_outstanding_slot_leases = 1;
+  bool notify_retirement_on_forced_reuse = true;
   bool checksum = false;
   int32_t checksum_size = 4;
   int32_t metadata_size = 0;
@@ -275,6 +299,11 @@ struct SubscriberOptions {
   const std::string &Type() const { return type; }
   int MaxSharedPtrs() const { return max_active_messages - 1; }
   int MaxActiveMessages() const { return max_active_messages; }
+  SubscriberOptions &SetMaxSubscribers(int n) {
+    max_subscribers = n;
+    return *this;
+  }
+  int MaxSubscribers() const { return max_subscribers; }
   bool LogDroppedMessages() const { return log_dropped_messages; }
   void SetLogDroppedMessages(bool v) { log_dropped_messages = v; }
 
@@ -361,6 +390,7 @@ struct SubscriberOptions {
   bool for_tunnel = false;
   std::string type;
   int max_active_messages = 1;
+  int32_t max_subscribers = 0;
   bool log_dropped_messages = true;
   bool pass_activation = false; // If true, the subscriber will pass activation
                                 // messages to the user.

--- a/client/publisher.cc
+++ b/client/publisher.cc
@@ -185,6 +185,93 @@ void PublisherImpl::SetSlotToBiggestBuffer(MessageSlot *slot) {
   IncrementBufferRefs(slot->buffer_index);
 }
 
+uint64_t PublisherImpl::RegisterLease(MessageSlot *slot) {
+  if (slot == nullptr) {
+    return 0;
+  }
+  uint64_t lease_id = next_lease_id_++;
+  if (lease_id == 0) {
+    lease_id = next_lease_id_++;
+  }
+  leased_slots_[slot->id] = lease_id;
+  return lease_id;
+}
+
+MessageSlot *PublisherImpl::FindLease(int32_t slot_id,
+                                      uint64_t lease_id) const {
+  auto it = leased_slots_.find(slot_id);
+  if (it == leased_slots_.end() || it->second != lease_id) {
+    return nullptr;
+  }
+  MessageSlot *slot = GetSlot(slot_id);
+  if (slot == nullptr ||
+      slot->refs.load(std::memory_order_acquire) !=
+          (kPubOwned | uint64_t(publisher_id_))) {
+    return nullptr;
+  }
+  return slot;
+}
+
+void PublisherImpl::RemoveLease(int32_t slot_id) {
+  leased_slots_.erase(slot_id);
+}
+
+MessageSlot *PublisherImpl::ClaimRetiredSlot(int32_t slot_id) {
+  MessageSlot *slot = GetSlot(slot_id);
+  if (slot == nullptr || !RetiredSlots().IsSet(slot_id)) {
+    return nullptr;
+  }
+
+  uint64_t old_refs = slot->refs.load(std::memory_order_acquire);
+  if ((old_refs & (kPubOwned | kRefsMask)) != 0) {
+    return nullptr;
+  }
+  uint64_t expected = BuildRefsBitField(
+      slot->ordinal, (old_refs >> kVchanIdShift) & kVchanIdMask,
+      (old_refs >> kRetiredRefsShift) & kRetiredRefsMask);
+  if (!slot->refs.compare_exchange_strong(
+          expected, kPubOwned | uint64_t(publisher_id_),
+          std::memory_order_acquire, std::memory_order_relaxed)) {
+    return nullptr;
+  }
+  RetiredSlots().Clear(slot_id);
+  slot->ordinal = 0;
+  slot->timestamp = 0;
+  slot->vchan_id = vchan_id_;
+  SetSlotToBiggestBuffer(slot);
+  MessagePrefix *prefix = Prefix(slot);
+  prefix->flags = 0;
+  prefix->vchan_id = vchan_id_;
+  ccb_->subscribers.Traverse([this, slot](int sub_id) {
+    GetAvailableSlots(sub_id).Clear(slot->id);
+  });
+  return slot;
+}
+
+bool PublisherImpl::ReleaseLeasedSlot(MessageSlot *slot) {
+  if (slot == nullptr ||
+      slot->refs.load(std::memory_order_acquire) !=
+          (kPubOwned | uint64_t(publisher_id_))) {
+    return false;
+  }
+  slot->ordinal = 0;
+  slot->timestamp = 0;
+  slot->refs.store(0, std::memory_order_release);
+  ccb_->subscribers.Traverse([this, slot](int sub_id) {
+    GetAvailableSlots(sub_id).Clear(slot->id);
+  });
+  RetiredSlots().Set(slot->id);
+  return true;
+}
+
+void PublisherImpl::RetirePublishedSlotImmediately(MessageSlot *slot) {
+  if (slot == nullptr) {
+    return;
+  }
+  RetiredSlots().Set(slot->id);
+  TriggerRetirement(slot->id);
+}
+
 MessageSlot *PublisherImpl::FindFreeSlotUnreliable(int owner) {
   int retries = num_slots_ * 1000;
   MessageSlot *slot = nullptr;
@@ -338,7 +425,8 @@ MessageSlot *PublisherImpl::FindFreeSlotUnreliable(int owner) {
   // If we took a slot that wasn't retired we must trigger the retirement fd.
   // This happens when we recycle a slot that has not yet been seen by all
   // subscribers.
-  if (free_slot == -1 && retired_slot == -1) {
+  if (free_slot == -1 && retired_slot == -1 &&
+      NotifyRetirementOnForcedReuse()) {
     TriggerRetirement(slot->id);
   }
   return slot;
@@ -478,7 +566,8 @@ MessageSlot *PublisherImpl::FindFreeSlotReliable(int owner) {
   // If we took a slot that wasn't retired we must trigger the retirement fd.
   // This happens when we recycle a slot that has not yet been seen by all
   // subscribers.
-  if (free_slot == -1 && retired_slot == -1) {
+  if (free_slot == -1 && retired_slot == -1 &&
+      NotifyRetirementOnForcedReuse()) {
     TriggerRetirement(slot->id);
   }
   return slot;
@@ -486,7 +575,8 @@ MessageSlot *PublisherImpl::FindFreeSlotReliable(int owner) {
 
 Channel::PublishedMessage PublisherImpl::ActivateSlotAndGetAnother(
     MessageSlot *slot, bool reliable, bool is_activation, int owner,
-    bool omit_prefix, bool use_prefix_slot_id, bool for_tunnel) {
+    bool omit_prefix, bool use_prefix_slot_id, bool for_tunnel,
+    bool acquire_next) {
   void *buffer = GetBufferAddress(slot);
   MessagePrefix *prefix = Prefix(slot);
 
@@ -567,6 +657,10 @@ Channel::PublishedMessage PublisherImpl::ActivateSlotAndGetAnother(
       ccb_->max_message_size = slot->message_size;
     }
     ccb_->total_messages++;
+  }
+
+  if (!acquire_next) {
+    return {nullptr, prefix->ordinal, prefix->timestamp};
   }
 
   // A reliable publisher doesn't allocate a slot until it is asked for.

--- a/client/publisher.h
+++ b/client/publisher.h
@@ -7,7 +7,10 @@
 #include "client/client_channel.h"
 #include "client/message.h"
 
+#include <unordered_map>
+
 namespace subspace {
+class Publisher;
 namespace details {
 
 // This is a publisher.  It maps in the channel's memory and allows
@@ -72,11 +75,19 @@ public:
     return GetMetadataSpan(prefix, ChecksumSize(), MetadataSize());
   }
 
+  absl::Span<std::byte> GetMetadata(MessageSlot *slot) {
+    if (MetadataSize() == 0 || slot == nullptr) {
+      return {};
+    }
+    return GetMetadataSpan(Prefix(slot), ChecksumSize(), MetadataSize());
+  }
+
   std::string Mux() const { return options_.Mux(); }
   bool ForTunnel() const { return options_.ForTunnel(); }
 
 private:
   friend class ::subspace::ClientImpl;
+  friend class ::subspace::Publisher;
 
   bool IsPublisher() const override { return true; }
   bool IsBridge() const override { return options_.IsBridge(); }
@@ -91,6 +102,20 @@ private:
   std::string ResolvedName() const override {
     return IsVirtual() ? options_.mux : Name();
   }
+
+  MessageSlot *ClaimRetiredSlot(int32_t slot_id);
+  bool ReleaseLeasedSlot(MessageSlot *slot);
+  uint64_t RegisterLease(MessageSlot *slot);
+  MessageSlot *FindLease(int32_t slot_id, uint64_t lease_id) const;
+  void RemoveLease(int32_t slot_id);
+  size_t NumLeases() const { return leased_slots_.size(); }
+  int32_t MaxOutstandingSlotLeases() const {
+    return options_.MaxOutstandingSlotLeases();
+  }
+  bool NotifyRetirementOnForcedReuse() const {
+    return options_.NotifyRetirementOnForcedReuse();
+  }
+  void RetirePublishedSlotImmediately(MessageSlot *slot);
 
   // A publisher is done with its busy slot (it now contains a message).  The
   // slot is moved from the busy list to the end of the active list and other
@@ -111,7 +136,8 @@ private:
   Channel::PublishedMessage
   ActivateSlotAndGetAnother(MessageSlot *slot, bool reliable,
                             bool is_activation, int owner, bool omit_prefix,
-                            bool use_prefix_slot_id, bool for_tunnel = false);
+                            bool use_prefix_slot_id, bool for_tunnel = false,
+                            bool acquire_next = true);
 
   Channel::PublishedMessage ActivateSlotAndGetAnother(bool reliable,
                                                       bool is_activation,
@@ -154,6 +180,8 @@ private:
   std::function<absl::StatusOr<int64_t>(void *buffer, int64_t size)>
       on_send_callback_ = nullptr;
   ChecksumCallback checksum_callback_ = nullptr;
+  std::unordered_map<int32_t, uint64_t> leased_slots_;
+  uint64_t next_lease_id_ = 1;
 
 };
 

--- a/client/python/client.cc
+++ b/client/python/client.cc
@@ -4,13 +4,39 @@
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+#include <cstring>
+#include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <vector>
 
 namespace subspace {
 namespace python {
 
 namespace py = pybind11;
+
+class PythonPublisherBufferLease {
+public:
+  explicit PythonPublisherBufferLease(PublisherBufferLease lease)
+      : lease_(lease), staging_(lease.buffer_size) {}
+
+  explicit operator bool() const { return static_cast<bool>(lease_); }
+  PublisherBufferLease &Lease() { return lease_; }
+  const PublisherBufferLease &Lease() const { return lease_; }
+  std::vector<std::byte> &Staging() { return staging_; }
+  size_t BufferSize() const { return staging_.size(); }
+  int32_t SlotId() const { return lease_.slot_id; }
+  uint64_t LeaseId() const { return lease_.lease_id; }
+
+  void Invalidate() { lease_ = PublisherBufferLease{}; }
+
+private:
+  PublisherBufferLease lease_;
+  // Python memoryviews point into this stable staging allocation rather than
+  // shared memory. Existing views therefore remain harmless after the token is
+  // invalidated; publish copies the requested payload bytes into the lease.
+  std::vector<std::byte> staging_;
+};
 
 PYBIND11_MODULE(subspace, m) {
 
@@ -18,8 +44,9 @@ PYBIND11_MODULE(subspace, m) {
             "inter-process communication protocol.";
 
   // ReadMode enum.
-  py::enum_<ReadMode>(m, "ReadMode", "Mode for reading messages from a "
-                                     "subscriber.")
+  py::enum_<ReadMode>(m, "ReadMode",
+                      "Mode for reading messages from a "
+                      "subscriber.")
       .value("READ_NEXT", ReadMode::kReadNext,
              "Read the next available message.")
       .value("READ_NEWEST", ReadMode::kReadNewest,
@@ -113,6 +140,20 @@ PYBIND11_MODULE(subspace, m) {
            "Set whether the publisher notifies on message retirement.")
       .def("notify_retirement", &PublisherOptions::NotifyRetirement,
            "Get whether the publisher notifies on message retirement.")
+      .def("set_max_outstanding_slot_leases",
+           &PublisherOptions::SetMaxOutstandingSlotLeases,
+           "Set the maximum number of explicitly leased unpublished slots.")
+      .def("max_outstanding_slot_leases",
+           &PublisherOptions::MaxOutstandingSlotLeases,
+           "Get the maximum number of explicitly leased unpublished slots.")
+      .def("set_notify_retirement_on_forced_reuse",
+           &PublisherOptions::SetNotifyRetirementOnForcedReuse,
+           "Set whether unreliable forced slot reuse emits retirement "
+           "notifications.")
+      .def("notify_retirement_on_forced_reuse",
+           &PublisherOptions::NotifyRetirementOnForcedReuse,
+           "Get whether unreliable forced slot reuse emits retirement "
+           "notifications.")
       .def("set_checksum", &PublisherOptions::SetChecksum,
            "Set whether published messages include a checksum.")
       .def("checksum", &PublisherOptions::Checksum,
@@ -125,10 +166,11 @@ PYBIND11_MODULE(subspace, m) {
            "Set the metadata size in bytes.")
       .def("metadata_size", &PublisherOptions::MetadataSize,
            "Get the metadata size in bytes.")
-      .def("set_for_tunnel", &PublisherOptions::SetForTunnel,
-           "Set whether this publisher is for an external tunnel process. "
-           "Tunnel publishers mark messages with a cross-machine flag so "
-           "subscribers can distinguish locally vs remotely generated messages.")
+      .def(
+          "set_for_tunnel", &PublisherOptions::SetForTunnel,
+          "Set whether this publisher is for an external tunnel process. "
+          "Tunnel publishers mark messages with a cross-machine flag so "
+          "subscribers can distinguish locally vs remotely generated messages.")
       .def("for_tunnel", &PublisherOptions::ForTunnel,
            "Get whether this publisher is for an external tunnel process.");
 
@@ -151,6 +193,10 @@ PYBIND11_MODULE(subspace, m) {
            "Set the maximum number of active messages for the subscriber.")
       .def("max_active_messages", &SubscriberOptions::MaxActiveMessages,
            "Get the maximum number of active messages for the subscriber.")
+      .def("set_max_subscribers", &SubscriberOptions::SetMaxSubscribers,
+           "Set the server-enforced subscriber limit for the channel.")
+      .def("max_subscribers", &SubscriberOptions::MaxSubscribers,
+           "Get the server-enforced subscriber limit for the channel.")
       .def("set_log_dropped_messages",
            &SubscriberOptions::SetLogDroppedMessages,
            "Sets whether the subscriber logs dropped messages.")
@@ -217,19 +263,18 @@ PYBIND11_MODULE(subspace, m) {
                     "The virtual channel ID of the message. This is used to "
                     "identify the virtual channel in which the message was "
                     "sent.")
-      .def_property_readonly("buffer",
-                             [](const Message &self) {
-                               return py::bytes(
-                                   reinterpret_cast<const char *>(self.buffer),
-                                   self.length);
-                             },
-                             "The buffer containing the message data.")
+      .def_property_readonly(
+          "buffer",
+          [](const Message &self) {
+            return py::bytes(reinterpret_cast<const char *>(self.buffer),
+                             self.length);
+          },
+          "The buffer containing the message data.")
       .def("Reset", &Message::Reset,
            "Release the message slot. Called automatically by __exit__.")
       .def_readonly("is_activation", &Message::is_activation,
                     "Whether this is a channel activation message.")
-      .def_readonly("slot_id", &Message::slot_id,
-                    "The slot ID of the message.")
+      .def_readonly("slot_id", &Message::slot_id, "The slot ID of the message.")
       .def_readonly("checksum_error", &Message::checksum_error,
                     "Whether a checksum error was detected for this message.")
       .def("channel_type", &Message::ChannelType,
@@ -238,6 +283,40 @@ PYBIND11_MODULE(subspace, m) {
            "Get the number of message slots in this message's channel.")
       .def("slot_size", &Message::SlotSize,
            "Get the slot size in bytes for this message's channel.");
+
+  py::class_<PythonPublisherBufferLease>(
+      m, "PublisherBufferLease",
+      "An explicitly leased unpublished publisher slot.")
+      .def_property_readonly(
+          "buffer",
+          [](PythonPublisherBufferLease &self) -> py::memoryview {
+            if (!self) {
+              throw std::runtime_error(
+                  "Publisher buffer lease is invalid or no longer active");
+            }
+            std::vector<std::byte> &staging = self.Staging();
+            return py::memoryview::from_memory(
+                staging.data(), static_cast<Py_ssize_t>(staging.size()));
+          },
+          "Writable staging memoryview copied to the leased slot on publish.",
+          py::keep_alive<0, 1>())
+      .def_property_readonly("buffer_size",
+                             &PythonPublisherBufferLease::BufferSize,
+                             "Capacity of the leased payload buffer.")
+      .def_property_readonly("slot_id", &PythonPublisherBufferLease::SlotId,
+                             "Channel slot ID owned by this lease.")
+      .def_property_readonly("lease_id", &PythonPublisherBufferLease::LeaseId,
+                             "Generation token used to reject stale leases.")
+      .def("__bool__",
+           [](const PythonPublisherBufferLease &self) {
+             return static_cast<bool>(self);
+           })
+      .def_property_readonly(
+          "valid",
+          [](const PythonPublisherBufferLease &self) {
+            return static_cast<bool>(self);
+          },
+          "Whether this lease is still locally valid.");
 
   // -------------------------------------------------------------------------
   // Publisher
@@ -355,12 +434,81 @@ actually written.)doc",
                       "Cancel a pending zero-copy publish and release the "
                       "buffer lock.");
 
+  publisher_class.def(
+      "acquire_buffer_lease",
+      [](Publisher *self) -> std::optional<PythonPublisherBufferLease> {
+        absl::StatusOr<PublisherBufferLease> result =
+            self->AcquireBufferLease();
+        if (!result.ok()) {
+          throw std::runtime_error(result.status().ToString());
+        }
+        if (!*result) {
+          return std::nullopt;
+        }
+        return PythonPublisherBufferLease(*result);
+      },
+      R"doc(Acquire an unpublished publisher slot without holding the client
+lock. Returns None when no slot is currently available.)doc",
+      py::keep_alive<0, 1>());
+
+  publisher_class.def(
+      "reclaim_buffer_lease",
+      [](Publisher *self,
+         int32_t slot_id) -> std::optional<PythonPublisherBufferLease> {
+        absl::StatusOr<PublisherBufferLease> result =
+            self->ReclaimBufferLease(slot_id);
+        if (!result.ok()) {
+          throw std::runtime_error(result.status().ToString());
+        }
+        if (!*result) {
+          return std::nullopt;
+        }
+        return PythonPublisherBufferLease(*result);
+      },
+      R"doc(Reclaim a specific retired slot. Returns None if the slot is not
+currently reclaimable.)doc",
+      py::arg("slot_id"), py::keep_alive<0, 1>());
+
+  publisher_class.def(
+      "publish_buffer_lease",
+      [](Publisher *self, PythonPublisherBufferLease &lease,
+         int64_t message_size) -> Message {
+        absl::StatusOr<const Message> result =
+            message_size > 0 &&
+                    static_cast<size_t>(message_size) <= lease.Staging().size()
+                ? self->PublishBufferLeaseCopy(
+                      lease.Lease(), absl::Span<const std::byte>(
+                                         lease.Staging().data(),
+                                         static_cast<size_t>(message_size)))
+                : self->PublishBufferLease(lease.Lease(), message_size);
+        if (!result.ok()) {
+          throw std::runtime_error(result.status().ToString());
+        }
+        lease.Invalidate();
+        return *result;
+      },
+      R"doc(Publish data written into an explicit lease. A successful publish
+invalidates the Python lease object.)doc",
+      py::arg("lease"), py::arg("message_size"));
+
+  publisher_class.def(
+      "release_buffer_lease",
+      [](Publisher *self, PythonPublisherBufferLease &lease) {
+        absl::Status result = self->ReleaseBufferLease(lease.Lease());
+        if (!result.ok()) {
+          throw std::runtime_error(result.ToString());
+        }
+        lease.Invalidate();
+      },
+      R"doc(Discard an unpublished explicit lease. A successful release
+invalidates the Python lease object.)doc",
+      py::arg("lease"));
+
   // Wait variants with timeout and extra fd.
   publisher_class.def(
       "wait_with_timeout",
       [](Publisher *self, int64_t timeout_ns) {
-        absl::Status result =
-            self->Wait(std::chrono::nanoseconds(timeout_ns));
+        absl::Status result = self->Wait(std::chrono::nanoseconds(timeout_ns));
         if (!result.ok()) {
           throw std::runtime_error(result.ToString());
         }
@@ -394,16 +542,12 @@ interrupt the wait. Returns the fd that triggered the wake-up.)doc",
 
   publisher_class.def(
       "get_file_descriptor",
-      [](Publisher *self) -> int {
-        return self->GetFileDescriptor().Fd();
-      },
+      [](Publisher *self) -> int { return self->GetFileDescriptor().Fd(); },
       "Get the underlying trigger file descriptor.");
 
   publisher_class.def(
       "get_retirement_fd",
-      [](Publisher *self) -> int {
-        return self->GetRetirementFd().Fd();
-      },
+      [](Publisher *self) -> int { return self->GetRetirementFd().Fd(); },
       "Get the file descriptor notified when message slots are retired.");
 
   // Resize callback.
@@ -411,7 +555,8 @@ interrupt the wait. Returns the fd that triggered the wake-up.)doc",
       "register_resize_callback",
       [](Publisher *self, py::function callback) {
         absl::Status result = self->RegisterResizeCallback(
-            [callback](Publisher *, int old_size, int new_size) -> absl::Status {
+            [callback](Publisher *, int old_size,
+                       int new_size) -> absl::Status {
               py::gil_scoped_acquire acquire;
               py::object ret = callback(old_size, new_size);
               if (py::isinstance<py::bool_>(ret) && !ret.cast<bool>()) {
@@ -463,6 +608,20 @@ get_message_buffer() and publish_buffer() to read the current
 metadata contents.)doc");
 
   publisher_class.def(
+      "get_metadata",
+      [](Publisher *self,
+         const PythonPublisherBufferLease &lease) -> py::bytes {
+        absl::Span<std::byte> span = self->GetMetadata(lease.Lease());
+        if (span.empty() && self->MetadataSize() != 0) {
+          throw std::runtime_error("Invalid or stale publisher buffer lease");
+        }
+        return py::bytes(reinterpret_cast<const char *>(span.data()),
+                         span.size());
+      },
+      R"doc(Get a copy of the metadata area for an active explicit lease.)doc",
+      py::arg("lease"));
+
+  publisher_class.def(
       "set_metadata",
       [](Publisher *self, py::bytes data) {
         auto view = static_cast<std::string_view>(data);
@@ -478,6 +637,26 @@ metadata contents.)doc");
 between get_message_buffer() and publish_buffer().  The data
 must not exceed metadata_size() bytes.)doc",
       py::arg("data"));
+
+  publisher_class.def(
+      "set_metadata",
+      [](Publisher *self, const PythonPublisherBufferLease &lease,
+         py::bytes data) {
+        auto view = static_cast<std::string_view>(data);
+        absl::Span<std::byte> span = self->GetMetadata(lease.Lease());
+        if (span.empty() && self->MetadataSize() != 0) {
+          throw std::runtime_error("Invalid or stale publisher buffer lease");
+        }
+        if (view.size() > span.size()) {
+          throw std::runtime_error(
+              "Metadata too large: " + std::to_string(view.size()) +
+              " bytes vs " + std::to_string(span.size()) + " available");
+        }
+        std::memcpy(span.data(), view.data(), view.size());
+      },
+      R"doc(Write metadata into an active explicit lease. The data must not
+exceed metadata_size() bytes.)doc",
+      py::arg("lease"), py::arg("data"));
 
   publisher_class.def(
       "get_stats_counters",
@@ -631,8 +810,7 @@ checksum_error).  Use as a context manager to auto-release the slot:
   subscriber_class.def(
       "wait_with_timeout",
       [](Subscriber *self, int64_t timeout_ns) {
-        absl::Status result =
-            self->Wait(std::chrono::nanoseconds(timeout_ns));
+        absl::Status result = self->Wait(std::chrono::nanoseconds(timeout_ns));
         if (!result.ok()) {
           throw std::runtime_error(result.ToString());
         }
@@ -665,9 +843,7 @@ interrupt the wait. Returns the fd that triggered the wake-up.)doc",
 
   subscriber_class.def(
       "get_file_descriptor",
-      [](Subscriber *self) -> int {
-        return self->GetFileDescriptor().Fd();
-      },
+      [](Subscriber *self) -> int { return self->GetFileDescriptor().Fd(); },
       "Get the underlying trigger file descriptor.");
 
   // Batch message processing.
@@ -796,18 +972,18 @@ is listening on the same Unix Domain Socket.)doc");
   client_class.def(py::init<>());
 
   // Existing: init.
-  client_class.def("init",
-                   [](Client *self, const std::string &server_socket,
-                      const std::string &client_name) {
-                     absl::Status result =
-                         self->Init(server_socket, client_name);
-                     if (!result.ok()) {
-                       throw std::runtime_error(result.ToString());
-                     }
-                   },
-                   "Initialize the client by connecting to the server.",
-                   py::arg("server_socket") = std::string("/tmp/subspace"),
-                   py::arg("client_name") = std::string(""));
+  client_class.def(
+      "init",
+      [](Client *self, const std::string &server_socket,
+         const std::string &client_name) {
+        absl::Status result = self->Init(server_socket, client_name);
+        if (!result.ok()) {
+          throw std::runtime_error(result.ToString());
+        }
+      },
+      "Initialize the client by connecting to the server.",
+      py::arg("server_socket") = std::string("/tmp/subspace"),
+      py::arg("client_name") = std::string(""));
 
   // Existing: create_publisher overload 1 (slot_size, num_slots, flags).
   client_class.def(
@@ -902,8 +1078,7 @@ are any publishers on the channel.)doc",
       py::return_value_policy::move);
 
   // New client methods.
-  client_class.def("get_name", &Client::GetName,
-                   "Get the name of this client.",
+  client_class.def("get_name", &Client::GetName, "Get the name of this client.",
                    py::return_value_policy::copy);
 
   client_class.def("set_debug", &Client::SetDebug,
@@ -986,8 +1161,7 @@ are any publishers on the channel.)doc",
         }
         return *result;
       },
-      "Check whether a channel exists on the server.",
-      py::arg("channel_name"));
+      "Check whether a channel exists on the server.", py::arg("channel_name"));
 }
 
 } // namespace python

--- a/client/python/client_test.py
+++ b/client/python/client_test.py
@@ -2,6 +2,7 @@
 import client.python.subspace as subspace
 import server.python.subspace_server as subspace_server
 import os
+import select
 import struct
 import tempfile
 import unittest
@@ -273,6 +274,73 @@ class TestSubspaceClient(unittest.TestCase):
         pub = None
         sub = None
 
+    def test_explicit_publisher_buffer_leases(self):
+        client = self._make_client("leases")
+
+        pub_opts = subspace.PublisherOptions()
+        pub_opts.set_slot_size(128)
+        pub_opts.set_num_slots(6)
+        pub_opts.set_metadata_size(8)
+        pub_opts.set_max_outstanding_slot_leases(3)
+        pub_opts.set_notify_retirement(True)
+        pub_opts.set_notify_retirement_on_forced_reuse(False)
+        pub = client.create_publisher(channel_name="ch_leases",
+                                      options=pub_opts)
+
+        sub_opts = subspace.SubscriberOptions()
+        sub_opts.set_max_active_messages(2)
+        sub = client.create_subscriber(channel_name="ch_leases",
+                                       options=sub_opts)
+
+        leases = [pub.acquire_buffer_lease() for _ in range(3)]
+        self.assertTrue(all(lease is not None for lease in leases))
+        self.assertEqual(len({lease.slot_id for lease in leases}), 3)
+        self.assertTrue(all(lease.buffer_size == 128 for lease in leases))
+        self.assertIsNone(pub.acquire_buffer_lease())
+
+        lease = leases[1]
+        slot_id = lease.slot_id
+        lease_id = lease.lease_id
+        payload = b"lease-two"
+        stale_view = lease.buffer
+        stale_view[:len(payload)] = payload
+        pub.set_metadata(lease, b"lease-md")
+        self.assertEqual(pub.get_metadata(lease), b"lease-md")
+
+        published = pub.publish_buffer_lease(lease, len(payload))
+        self.assertEqual(published.slot_id, slot_id)
+        self.assertFalse(lease.valid)
+        # Exported views remain backed by private staging memory after publish;
+        # writing through one must not corrupt the now-visible shared slot.
+        stale_view[:len(payload)] = b"corrupt!!"
+        with self.assertRaises(RuntimeError):
+            pub.publish_buffer_lease(lease, len(payload))
+
+        sub.wait()
+        with sub.read_message_object() as received:
+            self.assertEqual(received.buffer, payload)
+            self.assertEqual(sub.get_metadata(), b"lease-md")
+
+        retirement_fd = pub.get_retirement_fd()
+        poller = select.poll()
+        poller.register(retirement_fd, select.POLLIN)
+        self.assertTrue(poller.poll(1000))
+        retired_slot, = struct.unpack("i", os.read(retirement_fd, 4))
+        self.assertEqual(retired_slot, slot_id)
+
+        reclaimed = pub.reclaim_buffer_lease(retired_slot)
+        self.assertIsNotNone(reclaimed)
+        self.assertEqual(reclaimed.slot_id, slot_id)
+        self.assertNotEqual(reclaimed.lease_id, lease_id)
+
+        pub.release_buffer_lease(leases[0])
+        pub.release_buffer_lease(leases[2])
+        pub.release_buffer_lease(reclaimed)
+        self.assertFalse(reclaimed.valid)
+
+        pub = None
+        sub = None
+
     # ------------------------------------------------------------------
     # PublisherOptions / SubscriberOptions
     # ------------------------------------------------------------------
@@ -285,6 +353,8 @@ class TestSubspaceClient(unittest.TestCase):
         opts.set_local(True)
         opts.set_fixed_size(True)
         opts.set_checksum(True)
+        opts.set_max_outstanding_slot_leases(3)
+        opts.set_notify_retirement_on_forced_reuse(False)
 
         self.assertEqual(opts.slot_size(), 1024)
         self.assertEqual(opts.num_slots(), 4)
@@ -293,6 +363,8 @@ class TestSubspaceClient(unittest.TestCase):
         self.assertTrue(opts.is_local())
         self.assertTrue(opts.is_fixed_size())
         self.assertTrue(opts.checksum())
+        self.assertEqual(opts.max_outstanding_slot_leases(), 3)
+        self.assertFalse(opts.notify_retirement_on_forced_reuse())
 
     def test_subscriber_options(self):
         opts = subspace.SubscriberOptions()
@@ -302,6 +374,7 @@ class TestSubspaceClient(unittest.TestCase):
         opts.set_checksum(True)
         opts.set_pass_checksum_errors(True)
         opts.set_keep_active_message(True)
+        opts.set_max_subscribers(2)
 
         self.assertTrue(opts.is_reliable())
         self.assertEqual(opts.type(), "sub_opts_type")
@@ -309,6 +382,41 @@ class TestSubspaceClient(unittest.TestCase):
         self.assertTrue(opts.checksum())
         self.assertTrue(opts.pass_checksum_errors())
         self.assertTrue(opts.keep_active_message())
+        self.assertEqual(opts.max_subscribers(), 2)
+
+    def test_max_subscribers_option(self):
+        client = self._make_client("max_subscribers")
+        pub = client.create_publisher(channel_name="ch_max_subscribers",
+                                      slot_size=64, num_slots=6)
+
+        opts = subspace.SubscriberOptions()
+        opts.set_max_subscribers(1)
+        sub = client.create_subscriber(channel_name="ch_max_subscribers",
+                                       options=opts)
+        with self.assertRaisesRegex(RuntimeError,
+                                    "maximum number of subscribers"):
+            client.create_subscriber(channel_name="ch_max_subscribers",
+                                     options=opts)
+
+        pub = None
+        sub = None
+
+    def test_lease_budget_is_in_channel_capacity(self):
+        client = self._make_client("lease_capacity")
+        pub_opts = subspace.PublisherOptions()
+        pub_opts.set_slot_size(64)
+        pub_opts.set_num_slots(5)
+        pub_opts.set_max_outstanding_slot_leases(3)
+        pub = client.create_publisher(channel_name="ch_lease_capacity",
+                                      options=pub_opts)
+
+        sub_opts = subspace.SubscriberOptions()
+        sub_opts.set_max_active_messages(2)
+        with self.assertRaisesRegex(RuntimeError, "3 slot leases"):
+            client.create_subscriber(channel_name="ch_lease_capacity",
+                                     options=sub_opts)
+
+        pub = None
 
     def test_create_publisher_with_options(self):
         client = self._make_client("opts_pub")

--- a/common/channel.cc
+++ b/common/channel.cc
@@ -353,7 +353,8 @@ uint64_t Channel::GetVirtualMemoryUsage() const {
 void Channel::CleanupSlots(int owner, bool reliable, bool is_pub,
                            int vchan_id) {
   if (is_pub) {
-    // Look for a slot with kPubOwned set and clear it.
+    // Clear every slot owned by this publisher. Explicit multi-slot leases can
+    // leave more than one slot publisher-owned when a process exits.
     for (int i = 0; i < NumSlots(); i++) {
       MessageSlot *slot = &ccb_->slots[i];
       uint64_t refs = slot->refs.load(std::memory_order_relaxed);
@@ -368,7 +369,6 @@ void Channel::CleanupSlots(int owner, bool reliable, bool is_pub,
         ccb_->subscribers.Traverse([this, slot](int sub_id) {
           GetAvailableSlots(sub_id).Clear(slot->id);
         });
-        return;
       }
     }
   } else {

--- a/common/split_buffer.cc
+++ b/common/split_buffer.cc
@@ -188,7 +188,15 @@ ReadSplitBufferMetadataFile(const std::string &shadow_file) {
 }
 
 std::string SplitBufferObjectName(const std::string &shadow_file) {
+#if defined(__QNXNTO__) || defined(__APPLE__)
+  // POSIX requires a leading slash for a portable global shm_open name.
+  // QNX otherwise resolves this relative to the process working directory,
+  // preventing subscribers launched from a different EM application
+  // directory from opening a publisher's split-buffer prefix.
+  return absl::StrFormat("/subspace_sb_%016x", StableHash64(shadow_file));
+#else
   return absl::StrFormat("subspace_sb_%016x", StableHash64(shadow_file));
+#endif
 }
 
 absl::StatusOr<toolbelt::FileDescriptor>

--- a/docs/Version2Features.md
+++ b/docs/Version2Features.md
@@ -70,7 +70,18 @@ If you set the `notify_retirement` option in `PublisherOptions`, the system will
 
 Say you have a message that contains a pointer to something in the GPU (a number).  The publisher will allocate the GPU memory, put a reference to it in the message and publish it.  The publisher needs to know when it can free up the GPU memory and reuse it, otherwise you would run of memory.  So the publisher process will set the `notify_retirement` option and call `GetRetirementFd` to get the file descriptor for the read-end of the pipe.
 
-Then, when all the subscribers have processed the message (or the message is dropped), the `slot ID` of the slot containing the message will be written to the pipe.  The publisher process can then read the slot ID from the pipe and correlate that number with the GPU pointer (it will need to keep that mapping).  It can then safely free up the GPU pointer.
+Then, when all the subscribers have processed the message, the `slot ID` of the
+slot containing the message will be written to the pipe. An unreliable
+publisher can also request notifications when it forcibly reuses an unread
+slot; this legacy behavior is controlled by
+`notify_retirement_on_forced_reuse`.
+
+The explicit publisher lease API can pass a retired slot ID to
+`ReclaimBufferLease()` and reacquire that exact slot with a new lease token.
+Applications using notifications for exact-slot reclamation or
+external-resource lifetime should disable forced-reuse notifications so every
+notification represents subscriber-completed retirement. See
+[Publisher Buffer Leases](publisher-buffer-leases.md).
 
 ## Multiplexed virtual channels
 There is a style of IPC usage that insists on only one publisher per channel.  If you are a proponent of this, you will probably be creating a bunch of channels, perhaps a set of them per process/node that all have one publisher and a few subscribers.  In an IPC system that uses TCP for transport this isn't a big deal since they will use the kernel's pre-allocated TCP buffers for their message storage, but in a shared memory IPC system, each channel will have a ring buffer of shared memory allocated for them.

--- a/docs/c-client.md
+++ b/docs/c-client.md
@@ -20,6 +20,7 @@ The main handle types are opaque wrappers:
 | `SubspaceSubscriber` | Subscriber attached to a channel. |
 | `SubspaceMessage` | A received message reference. |
 | `SubspaceMessageBuffer` | A writable publish buffer returned by a publisher. |
+| `SubspacePublisherBufferLease` | A specific unpublished publisher slot plus a stale-token guard. |
 
 Most functions return `bool`, an integer status, or a handle whose inner pointer
 is `NULL` on failure. When a call fails, use:
@@ -95,7 +96,9 @@ Important publisher options:
 | `type` | Opaque type string used to match publishers and subscribers. |
 | `activate` | Publish an activation message when the publisher is created. |
 | `mux`, `vchan_id` | Use a mux channel and optional virtual channel id. |
-| `notify_retirement` | Expose a retirement fd for reliable-slot retirement notifications. |
+| `notify_retirement` | Expose a retirement fd that reports retired slot IDs. |
+| `max_outstanding_slot_leases` | Maximum unpublished slots owned through the explicit lease API; default 1. |
+| `notify_retirement_on_forced_reuse` | Include unreliable forced-reuse notifications; default true. Set false for exact-slot reclamation. |
 | `checksum`, `checksum_size` | Enable checksums and reserve checksum bytes in the prefix. |
 | `metadata_size` | Reserve per-message user metadata bytes in the prefix. |
 | `prefer_retired_slots` | Prefer recently retired slots for unreliable publishers. |
@@ -139,6 +142,58 @@ Related publisher APIs:
 | `subspace_get_publisher_fd` | Return the publisher trigger fd. |
 | `subspace_get_publisher_retirement_fd` | Return the retirement notification fd. |
 
+## Explicit Publisher Buffer Leases
+
+The explicit lease API allows one publisher to own several unpublished slots
+without holding the thread-safe client's mutex across their lifetime:
+
+```c
+SubspacePublisherOptions opts =
+    subspace_publisher_options_default(4096, 16);
+opts.max_outstanding_slot_leases = 3;
+opts.notify_retirement = true;
+opts.notify_retirement_on_forced_reuse = false;
+
+SubspacePublisher pub =
+    subspace_create_publisher(client, "camera", opts);
+
+SubspacePublisherBufferLease lease =
+    subspace_acquire_publisher_buffer(pub);
+if (lease.buffer == NULL) {
+  if (subspace_has_error()) {
+    fprintf(stderr, "%s\n", subspace_get_last_error());
+  }
+  /* No error means no slot is currently available. */
+  return;
+}
+
+memcpy(lease.buffer, payload, payload_size);
+SubspaceMessage status =
+    subspace_publish_publisher_buffer(pub, lease, payload_size);
+```
+
+A lease contains the writable address, buffer capacity, slot ID, and a
+`lease_id` generation token. Publishing or releasing invalidates it; stale
+tokens are rejected. Discard an unpublished lease with
+`subspace_release_publisher_buffer`.
+
+With `notify_retirement` enabled, read `int32_t` slot IDs from
+`subspace_get_publisher_retirement_fd`. Reclaim an exact retired slot with:
+
+```c
+SubspacePublisherBufferLease reclaimed =
+    subspace_reclaim_publisher_buffer(pub, retired_slot_id);
+```
+
+The reclaimed lease has the same slot and payload address but a new lease ID.
+When forced-reuse notifications are enabled, a notified unreliable slot may
+already have been reused and therefore may not be reclaimable.
+
+Use either the explicit lease API or the implicit
+`subspace_get_message_buffer`/`subspace_publish_message` workflow for a given
+publisher, not both. See [Publisher Buffer Leases](publisher-buffer-leases.md)
+for the full lifecycle and capacity rules.
+
 ## Subscriber Options
 
 Start with `subspace_subscriber_options_default()`:
@@ -162,6 +217,7 @@ Important subscriber options:
 | `bridge`, `for_tunnel` | Mark bridge/tunnel subscribers. |
 | `type` | Required type string when type matching is used. |
 | `max_active_messages` | Maximum simultaneously held `SubspaceMessage` values. |
+| `max_subscribers` | Server-enforced subscriber limit; 0 means unlimited. The first subscriber establishes the value. |
 | `pass_activation` | Deliver activation messages to the caller. |
 | `log_dropped_messages` | Log detected drops to stderr. |
 | `read_write` | Map payload buffers writable for this subscriber. |
@@ -240,6 +296,10 @@ const void *received_metadata =
     subspace_get_subscriber_metadata(sub, &metadata_size);
 ```
 
+For an explicit publisher lease, use
+`subspace_get_publisher_buffer_metadata(pub, lease, &metadata_size)` before
+publishing the lease.
+
 Useful prefix accessors:
 
 | Function | Purpose |
@@ -265,6 +325,20 @@ subspace_register_subscriber_checksum_callback(sub, checksum_callback, NULL);
 The callback receives the same spans as the C++ API: prefix fields before the
 checksum, user metadata, and payload bytes. Publisher and subscriber callbacks
 must produce matching bytes.
+
+## Capacity and Admission
+
+For unreliable channels, the server reserves the configured maximums:
+
+```text
+sum(max_outstanding_slot_leases) + sum(max_active_messages)
+    <= num_slots - 1
+```
+
+This ensures that a publisher below its lease limit can acquire another slot
+even while subscribers hold their maximum active messages. The server rejects
+a publisher or subscriber whose configured budget would exceed capacity.
+Virtual channels sharing a mux are accounted together.
 
 ## Callbacks
 

--- a/docs/checksums-and-metadata.md
+++ b/docs/checksums-and-metadata.md
@@ -204,6 +204,19 @@ pub.PublishMessage(payload_size);
 `GetMetadata()` returns an `absl::Span<std::byte>` of `MetadataSize()` bytes.
 It returns an empty span if `MetadataSize()` is 0 or no slot is currently held.
 
+For an explicit publisher buffer lease, pass the valid lease token:
+
+```cpp
+auto lease = pub.AcquireBufferLease().value();
+auto meta = pub.GetMetadata(lease);
+// Fill metadata and lease.buffer, then publish the same lease.
+pub.PublishBufferLease(lease, payload_size);
+```
+
+The C equivalent is
+`subspace_get_publisher_buffer_metadata(pub, lease, &metadata_size)`. See
+[Publisher Buffer Leases](publisher-buffer-leases.md).
+
 ### Reading Metadata (Subscriber)
 
 Call `GetMetadata()` after `ReadMessage()`:

--- a/docs/client-architecture.md
+++ b/docs/client-architecture.md
@@ -25,6 +25,14 @@ Each channel uses three shared memory structures:
 3. **User writes data** directly into the buffer (zero-copy).
 4. **`PublishMessage(length)`** — writes a `MessagePrefix` (size, ordinal, timestamp, optional checksum and user metadata in the prefix area), marks the slot as available, and triggers subscriber file descriptors to wake them up.
 
+Publishers that need multiple in-flight producer buffers can use the explicit
+lease path instead. `AcquireBufferLease()` transfers ownership of a slot to a
+`PublisherBufferLease` without holding the thread-safe client mutex.
+`PublishBufferLease()` publishes it, while `ReleaseBufferLease()` discards it.
+`ReclaimBufferLease(slot_id)` reacquires the exact slot reported by a retirement
+fd. Lease IDs prevent stale tokens from operating on reused slots. See
+[Publisher Buffer Leases](publisher-buffer-leases.md).
+
 ## Subscribing Flow
 
 1. **Create subscriber** — similar RPC to the server, gets back FDs for shared memory and a trigger FD.
@@ -33,8 +41,21 @@ Each channel uses three shared memory structures:
 
 ## Reliable vs. Unreliable
 
-- **Unreliable** — publisher always has a slot, may overwrite old unread messages (subscribers detect dropped messages via ordinal gaps).
+- **Unreliable implicit publishing** — publisher reserves its next slot and may overwrite old unread messages (subscribers detect dropped messages via ordinal gaps).
+- **Unreliable explicit leases** — slots are acquired on demand. Acquisition can return an empty lease when all reusable slots are actively referenced or already leased.
 - **Reliable** — publisher waits for a free slot, guaranteeing no message loss.
+
+The server prevents configured clients from exhausting an unreliable channel:
+
+```text
+sum(publisher.max_outstanding_slot_leases)
+  + sum(subscriber.max_active_messages)
+  <= num_slots - 1
+```
+
+Capacity is aggregated across virtual channels sharing a mux. The server also
+enforces `max_subscribers`, a channel-level subscriber limit established by the
+first subscriber.
 
 ## Key Class Hierarchy
 
@@ -68,7 +89,8 @@ with C-style naming. Messages must be explicitly freed with
 
 The C wrapper also exposes channel introspection, stats/counters, timeout and
 fd-based waits, bulk reads, user metadata, checksum callbacks, split-buffer
-callbacks and handle lookup, transform callbacks, and slot/prefix diagnostics.
+callbacks and handle lookup, explicit publisher leases, transform callbacks,
+and slot/prefix diagnostics.
 See [C Client API](c-client.md).
 
 ## Other Notable Features
@@ -77,6 +99,8 @@ See [C Client API](c-client.md).
 - **Coroutine support** — the client can yield when waiting for slots/messages (uses the `co` library).
 - **Checksums** — optional message integrity verification using CRC32 by default, with support for arbitrary-sized checksums via callbacks.  The `checksum_size` and `metadata_size` publisher options control the prefix layout; user metadata can be attached to each message through `GetMetadata()`.  See [Checksums and User Metadata](checksums-and-metadata.md) for details.
 - **Split buffers** — optional separate payload allocations for custom memory pools or handle-based mapping APIs. See [Split Buffers](split-buffers.md).
+- **Publisher buffer leases** — own multiple unpublished slots, reclaim exact retired slots, and avoid holding the client mutex across an asynchronous producer pipeline. See [Publisher Buffer Leases](publisher-buffer-leases.md).
+- **Subscriber limits** — `max_subscribers` gives channels a server-enforced subscriber cap.
 - **Bridging** — forwards channels between servers over TCP for cross-machine communication.
 - **Tunnel support** — the `for_tunnel` publisher/subscriber option marks messages with the `kMessageCrossMachine` flag in the `MessagePrefix`, allowing external tunnel processes to distinguish locally and remotely generated messages.
 

--- a/docs/client_design.md
+++ b/docs/client_design.md
@@ -176,7 +176,7 @@ Following the slot array (with 64-byte alignment):
 `Client::CreatePublisher(channel_name, slot_size, num_slots, options)`:
 
 1. Sends a `CreatePublisher` RPC to the server.
-2. The server creates the channel (if new) with the specified slot size and slot count, validates options (type matching, checksum/metadata size limits), and returns file descriptors for CCB, BCB, and buffer shared memory.
+2. The server creates the channel (if new) with the specified slot size and slot count, validates options (type matching, checksum/metadata size limits, and `max_outstanding_slot_leases`), and returns file descriptors for CCB, BCB, and buffer shared memory.
 3. The client maps all shared memory regions.
 4. For **unreliable** publishers: a free slot is immediately claimed via `FindFreeSlotUnreliable`. If `options.activate` is set, an activation message is published.
 5. For **reliable** publishers: an activation message is published via `ActivateReliableChannel`, **unless** the publisher is a bridge or tunnel publisher (they skip activation because the original local publisher has already activated the channel).
@@ -196,7 +196,7 @@ void* buf = publisher.GetMessageBuffer(max_size);
 
 - If `max_size` exceeds the current slot size, the channel is resized (see Section 8).
 - For reliable publishers, returns `nullptr` when no slot is available.
-- For unreliable publishers, always returns a buffer (may recycle a slot with unread messages).
+- For unreliable publishers using this implicit path, always returns a buffer (may recycle a slot with unread messages).
 
 **Phase 2: Publish**
 
@@ -228,9 +228,56 @@ Internally, `ActivateSlotAndGetAnother`:
 
 ### 4.5 Retirement Notifications
 
-If `notify_retirement` is set, the publisher receives a pipe file descriptor. When a slot is fully retired (all subscribers have released it), the slot ID is written to this pipe. The publisher can poll `GetRetirementFd()` to learn which slots have been retired.
+If `notify_retirement` is set, the publisher receives a pipe file descriptor.
+When a slot is fully retired (all subscribers have released it), the slot ID is
+written to this pipe. A leased publication with no subscribers retires
+immediately. The publisher can poll `GetRetirementFd()` to learn which slots
+have been retired.
 
-### 4.6 On-Send Callback
+For an unreliable publisher, `notify_retirement_on_forced_reuse` controls
+whether overwriting an unread slot also emits a notification. The default is
+true for compatibility. Set it false when notifications drive external-resource
+lifetime or `ReclaimBufferLease()`, because a forced-reuse notification may
+refer to a slot that the publisher has already reused.
+
+### 4.6 Explicit Buffer Leases
+
+`AcquireBufferLease()` moves the publisher's current slot into an explicit
+`PublisherBufferLease`, or claims another slot when there is no current slot.
+The returned token contains the payload address, buffer size, slot ID, and a
+monotonic lease ID. The lease ID prevents a stale token from operating on the
+same slot after reuse.
+
+A publisher can own up to `max_outstanding_slot_leases` unpublished slots. The
+lease remains publisher-owned until one of these terminal operations:
+
+- `PublishBufferLease(lease, size)` activates the slot without implicitly
+  acquiring a replacement.
+- `ReleaseBufferLease(lease)` returns the unpublished slot to the retired pool.
+
+`ReclaimBufferLease(slot_id)` claims a specific retired slot reported through
+the retirement fd and assigns a new lease ID. `GetMetadata(lease)` returns the
+writable metadata span for a valid leased slot.
+
+Unlike `GetMessageBuffer()`, leases do not hold the thread-safe client's mutex
+across the producer's write interval. An empty successful lease means no slot
+is currently available. The application should wait for retirement and retry.
+The implicit and explicit workflows should not be mixed on one publisher.
+
+For unreliable channel admission, the server requires:
+
+```text
+sum(publisher.max_outstanding_slot_leases)
+  + sum(subscriber.max_active_messages)
+  <= num_slots - 1
+```
+
+This reserves enough capacity for every configured lease and active-message
+maximum, including users on virtual channels sharing a mux.
+
+See [Publisher Buffer Leases](publisher-buffer-leases.md) for examples.
+
+### 4.7 On-Send Callback
 
 `Publisher::SetOnSendCallback(callback)` registers a callback invoked just before publish. The callback receives the buffer pointer and message size, and returns the (possibly modified) message size. Returning an error aborts the publish.
 
@@ -243,9 +290,12 @@ If `notify_retirement` is set, the publisher receives a pipe file descriptor. Wh
 `Client::CreateSubscriber(channel_name, options)`:
 
 1. Sends a `CreateSubscriber` RPC to the server.
-2. If no publisher exists for the channel, a **placeholder** subscriber is created with `num_slots = 0`. The placeholder is automatically reloaded when a publisher appears (detected via SCB counter changes).
-3. Otherwise, the client maps CCB, BCB, and buffer shared memory. The subscriber registers itself in the CCB's subscriber bitset and initializes its `AvailableSlots` bitset.
-4. Trigger file descriptors are set up for poll-based notification.
+2. The server validates `max_subscribers`. The first subscriber establishes the
+   channel-level value; `0` means unlimited. Later subscribers must request the
+   same value and are rejected once a nonzero limit is reached.
+3. If no publisher exists for the channel, a **placeholder** subscriber is created with `num_slots = 0`. The placeholder is automatically reloaded when a publisher appears (detected via SCB counter changes).
+4. Otherwise, the client maps CCB, BCB, and buffer shared memory. The subscriber registers itself in the CCB's subscriber bitset and initializes its `AvailableSlots` bitset.
+5. Trigger file descriptors are set up for poll-based notification.
 
 ### 5.2 Reading Messages
 

--- a/docs/publisher-buffer-leases.md
+++ b/docs/publisher-buffer-leases.md
@@ -49,27 +49,36 @@ if (!pub_or.ok()) {
 }
 subspace::Publisher pub = *std::move(pub_or);
 
-auto lease_or = pub.AcquireBufferLease();
+auto lease_or = pub.AcquireScopedBufferLease();
 if (!lease_or.ok()) {
   return lease_or.status();
 }
-subspace::PublisherBufferLease lease = *lease_or;
+subspace::ScopedPublisherBufferLease lease = *std::move(lease_or);
 if (!lease) {
   // No slot is currently available. Retry after a retirement notification.
   return absl::UnavailableError("no publisher slot available");
 }
 
-std::memcpy(lease.buffer, payload, payload_size);
-absl::Span<std::byte> metadata = pub.GetMetadata(lease);
+std::memcpy(lease.buffer(), payload, payload_size);
+absl::Span<std::byte> metadata = lease.GetMetadata();
 // Fill metadata when configured.
 
-auto message_or = pub.PublishBufferLease(lease, payload_size);
+auto message_or = lease.Publish(payload_size);
 if (!message_or.ok()) {
   return message_or.status();
 }
 ```
 
-`PublisherBufferLease` contains:
+`ScopedPublisherBufferLease` automatically releases an active unpublished
+lease when it leaves scope. Successful `Publish()`, `PublishCopy()`, or
+`Release()` invalidates the scoped lease, so no additional cleanup is needed.
+It is movable but not copyable. The originating `Publisher` must not be moved
+or destroyed while one of its scoped leases is alive.
+
+Use `AcquireScopedBufferLease()` for any available slot and
+`ReclaimScopedBufferLease(slot_id)` for an exact retired slot. The low-level
+`AcquireBufferLease()` and `ReclaimBufferLease()` methods instead return a
+manually managed `PublisherBufferLease`, which contains:
 
 | Field | Meaning |
 | --- | --- |
@@ -84,6 +93,9 @@ query metadata with an old lease. To discard an unpublished buffer, call:
 ```cpp
 absl::Status status = pub.ReleaseBufferLease(lease);
 ```
+
+Prefer the scoped interface unless ownership must cross an API boundary that
+cannot carry the RAII object.
 
 ## Python Example
 
@@ -165,10 +177,11 @@ int32_t slot_id;
 ssize_t count =
     read(pub.GetRetirementFd().Fd(), &slot_id, sizeof(slot_id));
 if (count == sizeof(slot_id)) {
-  auto reclaimed_or = pub.ReclaimBufferLease(slot_id);
+  auto reclaimed_or = pub.ReclaimScopedBufferLease(slot_id);
   if (reclaimed_or.ok() && *reclaimed_or) {
-    subspace::PublisherBufferLease reclaimed = *reclaimed_or;
-    // reclaimed.slot_id is slot_id and reclaimed.lease_id is a new token.
+    subspace::ScopedPublisherBufferLease reclaimed =
+        *std::move(reclaimed_or);
+    // reclaimed.slot_id() is slot_id and reclaimed.lease_id() is a new token.
   }
 }
 ```

--- a/docs/publisher-buffer-leases.md
+++ b/docs/publisher-buffer-leases.md
@@ -1,0 +1,244 @@
+# Publisher Buffer Leases
+
+Publisher buffer leases let a C++, C, Python, or Rust publisher own several
+unpublished channel slots at once. They are useful for asynchronous producers,
+external memory pipelines, and applications that need to reclaim the exact slot
+reported by retirement notifications.
+
+The lease API is currently exposed by the C++, C, Python, and Rust clients. The
+Java client continues to use the implicit single-buffer publish API.
+
+## Implicit Buffers Versus Explicit Leases
+
+The existing publish workflow remains unchanged:
+
+1. `GetMessageBuffer()` obtains the publisher's implicit current slot.
+2. The application writes the payload and optional metadata.
+3. `PublishMessage()` publishes it. An unreliable publisher immediately
+   reserves its next current slot.
+
+The explicit workflow is:
+
+1. `AcquireBufferLease()` obtains a `PublisherBufferLease`.
+2. The application writes through `lease.buffer` and, optionally,
+   `GetMetadata(lease)`.
+3. It calls either `PublishBufferLease()` or `ReleaseBufferLease()`.
+
+Explicit leases do not hold the thread-safe client's mutex for the lifetime of
+the buffer. A publisher may own up to `max_outstanding_slot_leases` unpublished
+leases at once. The default is `1`.
+
+Choose one publish workflow for a publisher. After the explicit lease path
+takes the implicit current slot, the legacy unreliable `GetMessageBuffer()`
+path no longer has its usual preallocated current slot.
+
+## C++ Example
+
+```cpp
+subspace::PublisherOptions options;
+options.SetSlotSize(4096)
+    .SetNumSlots(16)
+    .SetMetadataSize(16)
+    .SetMaxOutstandingSlotLeases(3)
+    .SetNotifyRetirement(true)
+    .SetNotifyRetirementOnForcedReuse(false);
+
+auto pub_or = client.CreatePublisher("camera", options);
+if (!pub_or.ok()) {
+  return pub_or.status();
+}
+subspace::Publisher pub = *std::move(pub_or);
+
+auto lease_or = pub.AcquireBufferLease();
+if (!lease_or.ok()) {
+  return lease_or.status();
+}
+subspace::PublisherBufferLease lease = *lease_or;
+if (!lease) {
+  // No slot is currently available. Retry after a retirement notification.
+  return absl::UnavailableError("no publisher slot available");
+}
+
+std::memcpy(lease.buffer, payload, payload_size);
+absl::Span<std::byte> metadata = pub.GetMetadata(lease);
+// Fill metadata when configured.
+
+auto message_or = pub.PublishBufferLease(lease, payload_size);
+if (!message_or.ok()) {
+  return message_or.status();
+}
+```
+
+`PublisherBufferLease` contains:
+
+| Field | Meaning |
+| --- | --- |
+| `buffer` | Writable payload address. |
+| `buffer_size` | Capacity of that payload buffer. |
+| `slot_id` | Channel slot owned by the lease. |
+| `lease_id` | Generation token that rejects stale operations after reuse. |
+
+Publishing or releasing invalidates the token. Do not publish, release, or
+query metadata with an old lease. To discard an unpublished buffer, call:
+
+```cpp
+absl::Status status = pub.ReleaseBufferLease(lease);
+```
+
+## Python Example
+
+Python lease buffers are writable staging `memoryview` objects. On publish, the
+requested payload bytes are copied into the validated leased slot. This keeps
+an already-exported view safe after publish or release: later writes affect
+only its private staging allocation, not a published or reused shared-memory
+slot. Acquiring or reclaiming returns `None` when the requested slot is
+temporarily unavailable:
+
+```python
+options = subspace.PublisherOptions()
+options.set_slot_size(4096)
+options.set_num_slots(16)
+options.set_metadata_size(16)
+options.set_max_outstanding_slot_leases(3)
+options.set_notify_retirement(True)
+options.set_notify_retirement_on_forced_reuse(False)
+
+pub = client.create_publisher("camera", options=options)
+lease = pub.acquire_buffer_lease()
+if lease is not None:
+    lease.buffer[:len(payload)] = payload
+    pub.set_metadata(lease, metadata)
+    message = pub.publish_buffer_lease(lease, len(payload))
+```
+
+`publish_buffer_lease()` and `release_buffer_lease()` invalidate the Python
+lease object after success. `lease.valid` becomes false and subsequent access
+is rejected. After reading a retired `int32_t` slot ID from
+`pub.get_retirement_fd()`, call `pub.reclaim_buffer_lease(slot_id)` to acquire
+the same slot with a new `lease_id`.
+
+## Rust Example
+
+Rust exposes the payload as a raw shared-memory pointer and provides an unsafe
+slice helper:
+
+```rust
+let options = PublisherOptions::new()
+    .set_slot_size(4096)
+    .set_num_slots(16)
+    .set_metadata_size(16)
+    .set_max_outstanding_slot_leases(3)
+    .set_notify_retirement(true)
+    .set_notify_retirement_on_forced_reuse(false);
+let publisher = client.create_publisher("camera", &options)?;
+
+if let Some(mut lease) = publisher.acquire_buffer_lease()? {
+    unsafe {
+        lease.as_mut_slice()[..payload.len()].copy_from_slice(payload);
+    }
+    publisher.set_lease_metadata(&lease, metadata)?;
+    publisher.publish_buffer_lease(&lease, payload.len() as i64)?;
+}
+```
+
+`acquire_buffer_lease()` and `reclaim_buffer_lease()` return `Ok(None)` for
+temporary unavailability. `publish_buffer_lease()` and
+`release_buffer_lease()` logically invalidate the token; stale copies are
+rejected with `SubspaceError::FailedPrecondition`.
+
+An empty lease is a temporary availability result, not an error. For example,
+an unreliable publisher cannot take a slot that is actively referenced by a
+subscriber, and a reliable publisher does not acquire a slot while it has no
+subscribers.
+
+## Retirement and Exact-Slot Reclamation
+
+With `notify_retirement` enabled, `GetRetirementFd()` returns a pipe read end.
+Each notification is an `int32_t` slot ID. A slot normally retires when every
+subscriber has released it. A leased publication with no subscribers retires
+immediately.
+
+After reading a retired slot ID, reclaim that exact slot:
+
+```cpp
+int32_t slot_id;
+ssize_t count =
+    read(pub.GetRetirementFd().Fd(), &slot_id, sizeof(slot_id));
+if (count == sizeof(slot_id)) {
+  auto reclaimed_or = pub.ReclaimBufferLease(slot_id);
+  if (reclaimed_or.ok() && *reclaimed_or) {
+    subspace::PublisherBufferLease reclaimed = *reclaimed_or;
+    // reclaimed.slot_id is slot_id and reclaimed.lease_id is a new token.
+  }
+}
+```
+
+For unreliable publishers,
+`notify_retirement_on_forced_reuse` controls notifications generated when the
+publisher overwrites an unread message:
+
+- `true` (default) preserves legacy retirement notifications for forced reuse.
+  Such a notification is informational; the slot may already have been reused,
+  so exact reclamation can return an empty lease.
+- `false` reports only subscriber-completed retirement, plus immediate
+  retirement when there are no subscribers. Use this mode when notifications
+  drive exact-slot reclamation or external-resource lifetime.
+
+Virtual publishers do not support retirement notifications.
+
+## Channel Capacity
+
+For unreliable channels, the server reserves capacity from configured maxima,
+not current usage:
+
+```text
+slots_needed =
+    sum(publisher.max_outstanding_slot_leases)
+  + sum(subscriber.max_active_messages)
+
+slots_needed <= num_slots - 1
+```
+
+This guarantees that a publisher below its configured lease limit can acquire
+another lease even when subscribers hold their maximum active messages. The
+same accounting is aggregated across virtual channels sharing a multiplexer.
+A publisher or subscriber registration is rejected if its configured budget
+would exceed the channel capacity.
+
+The default lease limit of `1` preserves the previous capacity behavior.
+
+## Subscriber Limits
+
+`SubscriberOptions::SetMaxSubscribers(n)`, Python
+`SubscriberOptions.set_max_subscribers(n)`, Rust
+`SubscriberOptions::set_max_subscribers(n)`, and the C
+`SubspaceSubscriberOptions.max_subscribers` field set a server-enforced
+subscriber count limit. `0` means no explicit limit. The first subscriber to a
+channel establishes the value; later subscribers must request the same value.
+For virtual channels, the limit applies to the shared multiplexer.
+
+## C API
+
+Configure the C publisher before creation:
+
+```c
+SubspacePublisherOptions options =
+    subspace_publisher_options_default(4096, 16);
+options.max_outstanding_slot_leases = 3;
+options.notify_retirement = true;
+options.notify_retirement_on_forced_reuse = false;
+```
+
+The matching lifecycle functions are:
+
+| Function | Purpose |
+| --- | --- |
+| `subspace_acquire_publisher_buffer` | Acquire any available unpublished slot. |
+| `subspace_reclaim_publisher_buffer` | Acquire a specific retired slot ID. |
+| `subspace_get_publisher_buffer_metadata` | Return writable metadata for a valid lease. |
+| `subspace_publish_publisher_buffer` | Publish a leased slot and invalidate the lease. |
+| `subspace_release_publisher_buffer` | Discard a leased slot and invalidate the lease. |
+| `subspace_get_publisher_retirement_fd` | Return the fd that emits retired `int32_t` slot IDs. |
+
+An unavailable acquisition has `buffer == NULL` without setting the
+thread-local error. A real failure also sets `subspace_get_last_error()`.

--- a/docs/rust-client.md
+++ b/docs/rust-client.md
@@ -49,6 +49,42 @@ let msg = publisher.publish_message(payload.len() as i64).unwrap();
 slots. In that case, call `publisher.wait(timeout_ms)` to block until a slot
 becomes available.
 
+### Explicit Publisher Buffer Leases
+
+Explicit leases allow one publisher to own several unpublished slots without
+holding its publish lock across the buffers' lifetime:
+
+```rust
+let opts = PublisherOptions::new()
+    .set_slot_size(4096)
+    .set_num_slots(16)
+    .set_metadata_size(8)
+    .set_max_outstanding_slot_leases(3)
+    .set_notify_retirement(true)
+    .set_notify_retirement_on_forced_reuse(false);
+let publisher = client.create_publisher("camera", &opts).unwrap();
+
+let mut lease = publisher.acquire_buffer_lease().unwrap().unwrap();
+let payload = b"frame data";
+unsafe {
+    lease.as_mut_slice()[..payload.len()].copy_from_slice(payload);
+}
+publisher.set_lease_metadata(&lease, b"frame001").unwrap();
+publisher
+    .publish_buffer_lease(&lease, payload.len() as i64)
+    .unwrap();
+```
+
+`acquire_buffer_lease()` and `reclaim_buffer_lease(slot_id)` return `Ok(None)`
+when no suitable slot is currently available. Publishing or releasing a lease
+makes its token stale; later operations with the same `lease_id` fail.
+`release_buffer_lease()` discards an unpublished lease.
+
+Retirement notifications are native-endian `i32` slot IDs read from
+`get_retirement_fd()`. Reclaiming a retired ID returns the same slot with a new
+lease token. Do not mix the implicit `get_message_buffer()` workflow with
+explicit leases on the same publisher.
+
 ### Subscribing to Messages
 
 ```rust
@@ -100,6 +136,8 @@ loop {
 | `mux` | "" | Multiplexer name for virtual channels. |
 | `vchan_id` | -1 | Virtual channel ID within a multiplexer. |
 | `notify_retirement` | false | Enable retirement notifications via a pipe FD. |
+| `max_outstanding_slot_leases` | 1 | Maximum unpublished slots owned through explicit leases. |
+| `notify_retirement_on_forced_reuse` | true | Emit retirement notifications when an unreliable publisher forcibly reuses an unread slot. |
 | `checksum` | false | Compute CRC32 checksums on published messages. |
 | `checksum_size` | 4 | Bytes reserved for checksums (default: 4 for CRC32). |
 | `metadata_size` | 0 | Bytes reserved in each message prefix for user metadata. |
@@ -126,6 +164,7 @@ let opts = PublisherOptions::new()
 | `for_tunnel` | false | Subscriber is used by an external tunnel process. |
 | `channel_type` | "" | Must match the publisher's type string. |
 | `max_active_messages` | 1 | Max messages a subscriber can hold simultaneously. |
+| `max_subscribers` | 0 | Server-enforced channel subscriber limit; 0 means unlimited. |
 | `log_dropped_messages` | true | Log warnings when messages are dropped. |
 | `pass_activation` | false | Deliver channel activation messages to the subscriber. |
 | `read_write` | false | Map shared memory as read-write (default is read-only). |
@@ -155,6 +194,10 @@ and can register a dropped-message callback.
 **Reliable channels** (`reliable = true`): the publisher waits for a free slot,
 guaranteeing no message loss. `get_message_buffer` returns `Ok(None)` when all
 slots are in use; call `publisher.wait()` to block until one is freed.
+
+The implicit workflow keeps its normal preallocated slot. Explicit lease
+acquisition can instead return `Ok(None)` while all reusable slots are
+subscriber-held or already leased.
 
 ## Waiting and Polling
 

--- a/docs/server-architecture.md
+++ b/docs/server-architecture.md
@@ -98,19 +98,47 @@ Each channel requires three shared memory regions, created via `shm_open()` (POS
 
 ### Adding a Publisher
 
-1. Allocate a user ID from the channel's `user_ids_` bitset.
-2. Create a `PublisherUser` with reliability/local/bridge/tunnel flags.
-3. Initialize a trigger FD for reliable publishers.
-4. Update SCB counters.
-5. Return the publisher ID and file descriptors (CCB, BCB, trigger, poll, retirement FDs).
+1. Normalize `max_outstanding_slot_leases` (`0` from an older client means
+   `1`) and validate it against the channel slot count.
+2. For a new unreliable publisher, check capacity using its entire lease
+   budget. A reclaimed publisher is already included in the channel's usage.
+3. Allocate a user ID from the channel's `user_ids_` bitset.
+4. Create a `PublisherUser` with reliability/local/bridge/tunnel flags and its
+   maximum lease count.
+5. Initialize trigger and optional retirement FDs.
+6. Update SCB counters and replicate the publisher metadata to each shadow.
+7. Return the publisher ID and file descriptors (CCB, BCB, trigger, poll,
+   retirement FDs).
 
 ### Adding a Subscriber
 
-1. Allocate a user ID similarly.
-2. Check capacity for unreliable channels: `slots_needed = num_pubs + num_subs + max_active_messages + 1`.
-3. Create a `SubscriberUser` with a trigger FD.
+1. Validate or establish the channel's `max_subscribers` setting. The first
+   subscriber fixes the value; `0` means no explicit limit. Reject a new
+   subscriber when the nonzero limit is already reached.
+2. Check capacity for unreliable subscribers using their complete
+   `max_active_messages` budget.
+3. Allocate a user ID and create a `SubscriberUser` with a trigger FD.
 4. Register the subscriber in the CCB.
-5. Return file descriptors (CCB, BCB, trigger, all subscriber trigger FDs, retirement FDs).
+5. Return file descriptors (CCB, BCB, trigger, all subscriber trigger FDs,
+   retirement FDs).
+
+### Capacity Accounting
+
+The server admits an unreliable publisher or subscriber only when:
+
+```text
+slots_needed =
+    sum(publisher.max_outstanding_slot_leases)
+  + sum(subscriber.max_active_messages)
+
+slots_needed <= num_slots - 1
+```
+
+The calculation uses configured maxima so a publisher below its lease limit can
+always acquire another slot even when every subscriber holds its maximum active
+messages. `ChannelMultiplexer` includes users from every virtual channel that
+shares its storage. The default one lease per publisher reproduces the previous
+single-current-slot accounting.
 
 ## Bridge and Discovery System
 
@@ -206,8 +234,9 @@ Server
 - **Single-threaded with coroutines** — avoids locking and race conditions; cooperative multitasking via the `co` library. All blocking operations (accept, receive, send) yield to the scheduler.
 - **File descriptor passing** — shared memory FDs are sent to clients via Unix socket SCM_RIGHTS messages, so clients map the same memory regions.
 - **Discovery-based bridging** — UDP for lightweight discovery, TCP for reliable data transfer. Supports IPv4 and virtual addresses (VSOCK).
-- **Capacity management** — unreliable channels check capacity before adding subscribers to prevent buffer exhaustion.
+- **Capacity management** — unreliable channels reserve publisher lease budgets and subscriber active-message budgets before admitting users.
 - **Retirement tracking** — for reliable channels, tracks message lifetimes across bridges to prevent premature slot reuse.
+- **Subscriber limits** — the server enforces a consistent channel-level `max_subscribers` value, including across virtual channels sharing a mux.
 - **Tunnel tracking** — publishers and subscribers can be flagged as tunnel endpoints (`for_tunnel`). The server tracks tunnel user counts separately and reports them via `GetChannelInfo` (`num_tunnel_pubs`, `num_tunnel_subs`), allowing monitoring tools to distinguish between local, bridged, and tunneled users.
 - **Plugin system** — loadable modules with callbacks (OnReady, OnNewChannel, OnNewPublisher, etc.) for extensibility.
 

--- a/docs/shadow-process.md
+++ b/docs/shadow-process.md
@@ -89,8 +89,8 @@ All messages are wrapped in a `ShadowEvent` protobuf oneof. File descriptors acc
 | Event | Direction | FDs | Purpose |
 |---|---|---|---|
 | `ShadowStateDump` | Shadow -> Server | `[scb_fd]` if session_id != 0 | Header sent on new connection; contains the shadow's session ID and channel count |
-| `ShadowCreateChannel` | Both | `[ccb_fd, bcb_fd]` | Channel metadata + shared memory FDs |
-| `ShadowAddPublisher` | Both | `[poll_fd, trigger_fd, ...]` | Publisher metadata + notification FDs |
+| `ShadowCreateChannel` | Both | `[ccb_fd, bcb_fd]` | Channel metadata, subscriber limit, and shared memory FDs |
+| `ShadowAddPublisher` | Both | `[poll_fd, trigger_fd, ...]` | Publisher metadata, lease budget, and notification FDs |
 | `ShadowAddSubscriber` | Both | `[trigger_fd, poll_fd]` | Subscriber metadata + notification FDs |
 | `ShadowStateDone` | Shadow -> Server | none | End-of-dump marker |
 | `ShadowInit` | Server -> Shadow | `[scb_fd]` | New session; clears shadow state |
@@ -151,7 +151,7 @@ If the shadow has no prior state (first startup), it sends `session_id=0` with n
 - **Reserves the channel ID** in the server's ID bitmap (so new channels don't collide).
 - **Constructs a `ServerChannel`** with the recovered metadata (name, slot size, num_slots, type, etc.).
 - **Maps existing shared memory** via `ServerChannel::MapExisting()` — this maps the recovered CCB and BCB file descriptors into the server's address space without reinitializing them, preserving all message data.
-- **Reconstructs publishers and subscribers** with `handler=nullptr` (orphaned users — they have no client connection yet). Their trigger FDs and retirement pipes are restored from the recovered file descriptors.
+- **Reconstructs publishers and subscribers** with `handler=nullptr` (orphaned users — they have no client connection yet). Their trigger FDs and retirement pipes are restored from the recovered file descriptors. Publisher `max_outstanding_slot_leases` values and channel `max_subscribers` limits are restored so admission behavior is unchanged after recovery.
 - **Inserts the channel** into the server's channel map.
 
 ### 4. Server re-replicates to both shadows
@@ -167,8 +167,8 @@ The server proceeds with its normal startup (spawning coroutines, accepting clie
 | Survives | Does not survive |
 |---|---|
 | Shared memory regions (SCB, CCB, BCB) | Client TCP/socket connections |
-| Channel metadata (name, slot config, type) | In-flight RPC state |
-| Publisher/subscriber registration (IDs, flags) | Coroutine state |
+| Channel metadata (name, slot config, type, subscriber limit) | In-flight RPC state |
+| Publisher/subscriber registration (IDs, flags, publisher lease budgets) | Coroutine state |
 | Message data already written to shared memory | Publisher/subscriber client handlers |
 | Event notification FDs (trigger, poll, retirement) | |
 

--- a/docs/split-buffers.md
+++ b/docs/split-buffers.md
@@ -79,6 +79,24 @@ auto opts = subspace::PublisherOptions()
 auto pub = client.CreatePublisher("camera", opts);
 ```
 
+Split-buffer publishers can use explicit buffer leases to keep several payload
+slots in an external producer pipeline and to reclaim the exact payload slot
+reported by retirement:
+
+```cpp
+auto opts = subspace::PublisherOptions()
+    .SetSlotSize(4096)
+    .SetNumSlots(16)
+    .SetUseSplitBuffers(true)
+    .SetMaxOutstandingSlotLeases(3)
+    .SetNotifyRetirement(true)
+    .SetNotifyRetirementOnForcedReuse(false);
+```
+
+The lease's `buffer` points at the split payload allocation; metadata remains in
+the corresponding prefix slot. See
+[Publisher Buffer Leases](publisher-buffer-leases.md).
+
 To request split payload buffers for the remote mirror publisher created over a
 bridge, set `SetSplitBuffersOverBridge(true)`:
 

--- a/proto/subspace.proto
+++ b/proto/subspace.proto
@@ -42,6 +42,7 @@ message CreatePublisherRequest {
   int32 max_publishers = 17;   // 0 means no explicit publisher limit.
   bool split_buffers_over_bridge = 18; // Remote bridge publisher uses split buffers.
   uint64 process_id = 19;      // Client process id for introspection.
+  int32 max_outstanding_slot_leases = 20; // Unpublished slots reserved by this publisher.
 }
 
 message CreatePublisherResponse {
@@ -74,6 +75,7 @@ message CreateSubscriberRequest {
   string mux = 8;
   int32 vchan_id = 9;
   uint64 process_id = 10; // Client process id for introspection.
+  int32 max_subscribers = 11; // 0 means no explicit subscriber limit.
 }
 
 message CreateSubscriberResponse {
@@ -488,6 +490,8 @@ message ShadowCreateChannel {
   bool has_max_publishers = 15;
   int32 max_publishers = 16;
   bool split_buffers_over_bridge = 17;
+  bool has_max_subscribers = 18;
+  int32 max_subscribers = 19;
   // FDs sent via SCM_RIGHTS: [ccb_fd, bcb_fd]
 }
 
@@ -505,6 +509,7 @@ message ShadowAddPublisher {
   bool is_fixed_size = 6;
   bool notify_retirement = 7;
   bool for_tunnel = 8;
+  int32 max_outstanding_slot_leases = 9;
   // FDs sent via SCM_RIGHTS: [poll_fd, trigger_fd]
   // If notify_retirement: also [retirement_read_fd, retirement_write_fd]
 }
@@ -559,4 +564,6 @@ message ShadowUpdateChannelOptions {
   bool has_max_publishers = 4;
   int32 max_publishers = 5;
   bool split_buffers_over_bridge = 6;
+  bool has_max_subscribers = 7;
+  int32 max_subscribers = 8;
 }

--- a/rust_client/src/channel.rs
+++ b/rust_client/src/channel.rs
@@ -829,7 +829,6 @@ impl Channel {
                     ccb.subscribers.traverse(|sub_id| {
                         self.get_available_slots(sub_id).clear(slot.id as usize);
                     });
-                    return;
                 }
             }
         } else {

--- a/rust_client/src/client.rs
+++ b/rust_client/src/client.rs
@@ -59,6 +59,48 @@ impl Drop for PublishLock {
     }
 }
 
+struct PublishUnlockGuard<'a> {
+    lock: &'a PublishLock,
+    armed: bool,
+}
+
+impl<'a> PublishUnlockGuard<'a> {
+    fn new(lock: &'a PublishLock) -> Self {
+        Self { lock, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PublishUnlockGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.lock.unlock();
+        }
+    }
+}
+
+#[cfg(test)]
+mod publish_lock_tests {
+    use super::{PublishLock, PublishUnlockGuard};
+
+    #[test]
+    fn unlock_guard_releases_lock_during_unwind() {
+        let lock = PublishLock::new();
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            lock.lock();
+            let _guard = PublishUnlockGuard::new(&lock);
+            panic!("exercise unwind-safe publisher unlocking");
+        }));
+        assert!(panic.is_err());
+
+        lock.lock();
+        lock.unlock();
+    }
+}
+
 // ── Info / Stats types ──────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -97,11 +139,42 @@ struct ClientInner {
 
 // ── Publisher wrapper ───────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy)]
+pub struct PublisherBufferLease {
+    pub buffer: *mut u8,
+    pub buffer_size: usize,
+    pub slot_id: i32,
+    pub lease_id: u64,
+}
+
+impl PublisherBufferLease {
+    pub fn is_valid(&self) -> bool {
+        !self.buffer.is_null() && self.slot_id >= 0 && self.lease_id != 0
+    }
+
+    /// Returns the writable payload area for this lease.
+    ///
+    /// # Safety
+    ///
+    /// The publisher must remain alive, the lease must still be active, and
+    /// no other reference may access this payload buffer for the returned
+    /// slice's lifetime.
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.buffer, self.buffer_size) }
+    }
+}
+
 #[derive(Clone)]
 pub struct Publisher {
     inner: Arc<Mutex<ClientInner>>,
     pub(crate) imp: Arc<Mutex<PublisherImpl>>,
     publish_lock: Arc<PublishLock>,
+    _lifetime: Arc<PublisherLifetime>,
+}
+
+struct PublisherLifetime {
+    inner: Arc<Mutex<ClientInner>>,
+    imp: Arc<Mutex<PublisherImpl>>,
 }
 
 impl Publisher {
@@ -137,6 +210,7 @@ impl Publisher {
     /// obtaining the same buffer concurrently.
     pub fn get_message_buffer(&self, max_size: i32) -> Result<Option<(*mut u8, usize)>> {
         self.publish_lock.lock();
+        let mut unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
 
         let result = (|| -> Result<Option<(*mut u8, usize)>> {
             let mut client = self.inner.lock().unwrap();
@@ -181,7 +255,7 @@ impl Publisher {
                     return Ok(None);
                 }
                 let owner = pub_impl.publisher_id;
-                let slot = pub_impl.find_free_slot_reliable(owner);
+                let slot = pub_impl.find_free_slot_reliable(owner, true);
                 if slot.is_none() {
                     return Ok(None);
                 }
@@ -198,9 +272,8 @@ impl Publisher {
             Ok(Some((buffer, span_size)))
         })();
 
-        match &result {
-            Ok(Some(_)) => {}
-            _ => self.publish_lock.unlock(),
+        if matches!(&result, Ok(Some(_))) {
+            unlock_guard.disarm();
         }
 
         result
@@ -209,6 +282,7 @@ impl Publisher {
     /// Publish the message that was written into the buffer.
     /// Releases the publish lock acquired by `get_message_buffer`.
     pub fn publish_message(&self, message_size: i64) -> Result<Message> {
+        let _unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
         let result = (|| -> Result<Message> {
             let mut client = self.inner.lock().unwrap();
             let mut pub_impl = self.imp.lock().unwrap();
@@ -240,8 +314,9 @@ impl Publisher {
             let reliable = pub_impl.options.reliable;
             let vchan_id = pub_impl.channel.vchan_id;
 
-            let published = pub_impl
-                .activate_slot_and_get_another(slot_idx, reliable, false, owner, false, false);
+            let published = pub_impl.activate_slot_and_get_another(
+                slot_idx, reliable, false, owner, false, false, true,
+            );
 
             pub_impl.channel.slot = published.new_slot;
             pub_impl.trigger_subscribers();
@@ -266,7 +341,6 @@ impl Publisher {
             })
         })();
 
-        self.publish_lock.unlock();
         result
     }
 
@@ -274,6 +348,195 @@ impl Publisher {
     /// Call this after `get_message_buffer` if you decide not to publish.
     pub fn cancel_publish(&self) {
         self.publish_lock.unlock();
+    }
+
+    /// Acquire an unpublished slot without holding the publish lock for the
+    /// lifetime of the returned lease.
+    pub fn acquire_buffer_lease(&self) -> Result<Option<PublisherBufferLease>> {
+        self.publish_lock.lock();
+        let _unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
+        let result = (|| -> Result<Option<PublisherBufferLease>> {
+            let mut client = self.inner.lock().unwrap();
+            let mut pub_impl = self.imp.lock().unwrap();
+
+            if pub_impl.num_leases() >= pub_impl.options.max_outstanding_slot_leases as usize {
+                return Ok(None);
+            }
+            reload_subscribers_if_necessary(&mut client, &mut pub_impl)?;
+
+            let slot_idx = if let Some(slot_idx) = pub_impl.channel.slot.take() {
+                slot_idx
+            } else {
+                if pub_impl.options.reliable
+                    && pub_impl.channel.num_subscribers(pub_impl.channel.vchan_id) == 0
+                {
+                    return Ok(None);
+                }
+                let owner = pub_impl.publisher_id;
+                let slot = if pub_impl.options.reliable {
+                    pub_impl.find_free_slot_reliable(owner, false)
+                } else {
+                    pub_impl.find_free_slot_unreliable(owner, false)
+                };
+                match slot {
+                    Some(slot_idx) => slot_idx,
+                    None => return Ok(None),
+                }
+            };
+
+            let lease_id = pub_impl.register_lease(slot_idx);
+            Ok(Some(PublisherBufferLease {
+                buffer: pub_impl.channel.get_buffer_address(slot_idx),
+                buffer_size: pub_impl.channel.slot_size_for_slot(slot_idx) as usize,
+                slot_id: pub_impl.channel.slot_ref(slot_idx).id,
+                lease_id,
+            }))
+        })();
+        result
+    }
+
+    /// Reclaim a specific retired slot. Returns `None` while the slot is not
+    /// reclaimable or the publisher is already at its lease limit.
+    pub fn reclaim_buffer_lease(&self, slot_id: i32) -> Result<Option<PublisherBufferLease>> {
+        self.publish_lock.lock();
+        let _unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
+        let result = (|| -> Result<Option<PublisherBufferLease>> {
+            let mut client = self.inner.lock().unwrap();
+            let mut pub_impl = self.imp.lock().unwrap();
+
+            if pub_impl.num_leases() >= pub_impl.options.max_outstanding_slot_leases as usize {
+                return Ok(None);
+            }
+            reload_subscribers_if_necessary(&mut client, &mut pub_impl)?;
+            let slot_idx = match pub_impl.claim_retired_slot(slot_id) {
+                Some(slot_idx) => slot_idx,
+                None => return Ok(None),
+            };
+            let lease_id = pub_impl.register_lease(slot_idx);
+            Ok(Some(PublisherBufferLease {
+                buffer: pub_impl.channel.get_buffer_address(slot_idx),
+                buffer_size: pub_impl.channel.slot_size_for_slot(slot_idx) as usize,
+                slot_id: pub_impl.channel.slot_ref(slot_idx).id,
+                lease_id,
+            }))
+        })();
+        result
+    }
+
+    /// Publish data written into an explicit lease. The token becomes stale
+    /// after a successful publish.
+    pub fn publish_buffer_lease(
+        &self,
+        lease: &PublisherBufferLease,
+        message_size: i64,
+    ) -> Result<Message> {
+        self.publish_lock.lock();
+        let _unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
+        let result = (|| -> Result<Message> {
+            if message_size <= 0 {
+                return Err(SubspaceError::InvalidArgument(
+                    "Message size must be greater than 0".into(),
+                ));
+            }
+
+            let mut client = self.inner.lock().unwrap();
+            let mut pub_impl = self.imp.lock().unwrap();
+            let slot_idx = pub_impl
+                .find_lease(lease.slot_id, lease.lease_id)
+                .ok_or_else(|| {
+                    SubspaceError::FailedPrecondition("Invalid or stale publisher lease".into())
+                })?;
+            if message_size > pub_impl.channel.slot_size_for_slot(slot_idx) as i64 {
+                return Err(SubspaceError::InvalidArgument(
+                    "Message size exceeds leased slot size".into(),
+                ));
+            }
+            reload_subscribers_if_necessary(&mut client, &mut pub_impl)?;
+
+            let mut message_size = message_size;
+            if let Some(ref cb) = pub_impl.on_send_callback {
+                let buffer = pub_impl.channel.get_buffer_address(slot_idx);
+                message_size = cb(buffer, message_size)?;
+            }
+            pub_impl.channel.slot_mut(slot_idx).message_size = message_size as u64;
+
+            let owner = pub_impl.publisher_id;
+            let reliable = pub_impl.options.reliable;
+            let vchan_id = pub_impl.channel.vchan_id;
+            let published = pub_impl.activate_slot_and_get_another(
+                slot_idx, reliable, false, owner, false, false, false,
+            );
+            pub_impl.remove_lease(lease.slot_id);
+            pub_impl.trigger_subscribers();
+            if pub_impl.channel.num_subscribers(vchan_id) == 0 {
+                pub_impl.retire_published_slot_immediately(slot_idx);
+            }
+
+            Ok(Message {
+                length: message_size as usize,
+                buffer: std::ptr::null(),
+                ordinal: published.ordinal,
+                timestamp: published.timestamp,
+                vchan_id,
+                is_activation: false,
+                slot_id: lease.slot_id,
+                checksum_error: false,
+                active_message: None,
+            })
+        })();
+        result
+    }
+
+    /// Discard an unpublished explicit lease. The token becomes stale after a
+    /// successful release.
+    pub fn release_buffer_lease(&self, lease: &PublisherBufferLease) -> Result<()> {
+        self.publish_lock.lock();
+        let _unlock_guard = PublishUnlockGuard::new(&self.publish_lock);
+        let result = (|| -> Result<()> {
+            let mut pub_impl = self.imp.lock().unwrap();
+            let slot_idx = pub_impl
+                .find_lease(lease.slot_id, lease.lease_id)
+                .ok_or_else(|| {
+                    SubspaceError::FailedPrecondition("Invalid or stale publisher lease".into())
+                })?;
+            if !pub_impl.release_leased_slot(slot_idx) {
+                return Err(SubspaceError::Internal(
+                    "Failed to release publisher lease".into(),
+                ));
+            }
+            pub_impl.remove_lease(lease.slot_id);
+            Ok(())
+        })();
+        result
+    }
+
+    pub fn get_lease_metadata(&self, lease: &PublisherBufferLease) -> Result<Vec<u8>> {
+        let mut pub_impl = self.imp.lock().unwrap();
+        let slot_idx = pub_impl
+            .find_lease(lease.slot_id, lease.lease_id)
+            .ok_or_else(|| {
+                SubspaceError::FailedPrecondition("Invalid or stale publisher lease".into())
+            })?;
+        Ok(pub_impl.get_metadata_for_slot(slot_idx).to_vec())
+    }
+
+    pub fn set_lease_metadata(&self, lease: &PublisherBufferLease, data: &[u8]) -> Result<()> {
+        let mut pub_impl = self.imp.lock().unwrap();
+        let slot_idx = pub_impl
+            .find_lease(lease.slot_id, lease.lease_id)
+            .ok_or_else(|| {
+                SubspaceError::FailedPrecondition("Invalid or stale publisher lease".into())
+            })?;
+        let metadata = pub_impl.get_metadata_for_slot(slot_idx);
+        if data.len() > metadata.len() {
+            return Err(SubspaceError::InvalidArgument(format!(
+                "Metadata too large: {} bytes vs {} available",
+                data.len(),
+                metadata.len()
+            )));
+        }
+        metadata[..data.len()].copy_from_slice(data);
+        Ok(())
     }
 
     /// Wait until a reliable publisher can try sending again.
@@ -421,7 +684,7 @@ impl Publisher {
     }
 }
 
-impl Drop for Publisher {
+impl Drop for PublisherLifetime {
     fn drop(&mut self) {
         let client = self.inner.lock().unwrap();
         let mut pub_impl = self.imp.lock().unwrap();
@@ -847,6 +1110,13 @@ impl Client {
     ) -> Result<Publisher> {
         let mut client = self.inner.lock().unwrap();
 
+        if opts.max_outstanding_slot_leases < 1 || opts.max_outstanding_slot_leases > opts.num_slots
+        {
+            return Err(SubspaceError::InvalidArgument(
+                "MaxOutstandingSlotLeases must be between 1 and NumSlots".into(),
+            ));
+        }
+
         let slot_size = aligned64(opts.slot_size as i64);
 
         let req = proto::Request {
@@ -871,6 +1141,7 @@ impl Client {
                     max_publishers: 0,
                     publisher_id: -1,
                     process_id: std::process::id() as u64,
+                    max_outstanding_slot_leases: opts.max_outstanding_slot_leases,
                 },
             )),
         };
@@ -943,7 +1214,7 @@ impl Client {
         if !opts.reliable {
             let owner = pub_impl.publisher_id;
 
-            let slot = pub_impl.find_free_slot_unreliable(owner);
+            let slot = pub_impl.find_free_slot_unreliable(owner, true);
             if slot.is_none() {
                 return Err(SubspaceError::Internal(
                     "No slot available for publisher".into(),
@@ -968,10 +1239,15 @@ impl Client {
         pub_impl.trigger_subscribers();
 
         let pub_arc = Arc::new(Mutex::new(pub_impl));
+        let publisher_lifetime = Arc::new(PublisherLifetime {
+            inner: self.inner.clone(),
+            imp: pub_arc.clone(),
+        });
         Ok(Publisher {
             inner: self.inner.clone(),
             imp: pub_arc,
             publish_lock: Arc::new(PublishLock::new()),
+            _lifetime: publisher_lifetime,
         })
     }
 
@@ -1001,6 +1277,7 @@ impl Client {
                     mux: opts.mux.clone(),
                     vchan_id: opts.vchan_id,
                     process_id: std::process::id() as u64,
+                    max_subscribers: opts.max_subscribers,
                 },
             )),
         };
@@ -1636,7 +1913,7 @@ fn reload_reliable_publishers_if_necessary(
 
 fn activate_reliable_channel(publisher: &mut PublisherImpl) -> Result<()> {
     let owner = publisher.publisher_id;
-    let slot = publisher.find_free_slot_reliable(owner);
+    let slot = publisher.find_free_slot_reliable(owner, true);
     if slot.is_none() {
         return Err(SubspaceError::Internal(format!(
             "Channel {} has no free slots",
@@ -1655,7 +1932,7 @@ fn activate_reliable_channel(publisher: &mut PublisherImpl) -> Result<()> {
     publisher.channel.slot_mut(si).message_size = 1;
 
     let owner = publisher.publisher_id;
-    publisher.activate_slot_and_get_another(si, true, true, owner, false, false);
+    publisher.activate_slot_and_get_another(si, true, true, owner, false, false, true);
     publisher.channel.slot = None;
     publisher.trigger_subscribers();
 
@@ -1678,7 +1955,8 @@ fn activate_channel(publisher: &mut PublisherImpl) -> Result<()> {
     publisher.channel.slot_mut(si).message_size = 1;
 
     let owner = publisher.publisher_id;
-    let published = publisher.activate_slot_and_get_another(si, false, true, owner, false, false);
+    let published =
+        publisher.activate_slot_and_get_another(si, false, true, owner, false, false, true);
     publisher.channel.slot = published.new_slot;
     publisher.trigger_subscribers();
 

--- a/rust_client/src/error.rs
+++ b/rust_client/src/error.rs
@@ -13,6 +13,9 @@ pub enum SubspaceError {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
 
+    #[error("failed precondition: {0}")]
+    FailedPrecondition(String),
+
     #[error("not connected: {0}")]
     NotConnected(String),
 

--- a/rust_client/src/lib.rs
+++ b/rust_client/src/lib.rs
@@ -21,7 +21,7 @@ pub mod proto {
 }
 
 pub use channel::ChannelCounters;
-pub use client::{ChannelInfo, ChannelStats, Client, Publisher, Subscriber};
+pub use client::{ChannelInfo, ChannelStats, Client, Publisher, PublisherBufferLease, Subscriber};
 pub use error::SubspaceError;
 pub use message::Message;
 pub use options::{PublisherOptions, SubscriberOptions};

--- a/rust_client/src/options.rs
+++ b/rust_client/src/options.rs
@@ -23,6 +23,8 @@ pub struct PublisherOptions {
     pub mux: String,
     pub vchan_id: i32,
     pub notify_retirement: bool,
+    pub max_outstanding_slot_leases: i32,
+    pub notify_retirement_on_forced_reuse: bool,
     pub checksum: bool,
     pub checksum_size: i32,
     pub metadata_size: i32,
@@ -46,6 +48,8 @@ impl Default for PublisherOptions {
             mux: String::new(),
             vchan_id: -1,
             notify_retirement: false,
+            max_outstanding_slot_leases: 1,
+            notify_retirement_on_forced_reuse: true,
             checksum: false,
             checksum_size: 4,
             metadata_size: 0,
@@ -121,6 +125,16 @@ impl PublisherOptions {
         self
     }
 
+    pub fn set_max_outstanding_slot_leases(mut self, n: i32) -> Self {
+        self.max_outstanding_slot_leases = n;
+        self
+    }
+
+    pub fn set_notify_retirement_on_forced_reuse(mut self, v: bool) -> Self {
+        self.notify_retirement_on_forced_reuse = v;
+        self
+    }
+
     pub fn set_checksum(mut self, v: bool) -> Self {
         self.checksum = v;
         self
@@ -187,6 +201,7 @@ pub struct SubscriberOptions {
     pub for_tunnel: bool,
     pub channel_type: String,
     pub max_active_messages: i32,
+    pub max_subscribers: i32,
     pub log_dropped_messages: bool,
     pub pass_activation: bool,
     pub read_write: bool,
@@ -206,6 +221,7 @@ impl Default for SubscriberOptions {
             for_tunnel: false,
             channel_type: String::new(),
             max_active_messages: 1,
+            max_subscribers: 0,
             log_dropped_messages: true,
             pass_activation: false,
             read_write: false,
@@ -241,6 +257,11 @@ impl SubscriberOptions {
 
     pub fn set_max_active_messages(mut self, n: i32) -> Self {
         self.max_active_messages = n;
+        self
+    }
+
+    pub fn set_max_subscribers(mut self, n: i32) -> Self {
+        self.max_subscribers = n;
         self
     }
 

--- a/rust_client/src/publisher.rs
+++ b/rust_client/src/publisher.rs
@@ -18,6 +18,7 @@ use crate::syscall_shim::{
 use nix::fcntl::OFlag;
 use nix::sys::mman::ProtFlags;
 use nix::sys::stat::Mode;
+use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::Ordering;
 
@@ -40,6 +41,8 @@ pub struct PublisherImpl {
     pub trigger_fd: RawFd,
     pub retirement_fd: RawFd,
     pub retirement_trigger_fds: Vec<RawFd>,
+    leased_slots: HashMap<i32, u64>,
+    next_lease_id: u64,
 
     pub(crate) on_send_callback: Option<OnSendCallback>,
     pub(crate) resize_callback: Option<ResizeCallback>,
@@ -73,6 +76,8 @@ impl PublisherImpl {
             trigger_fd: -1,
             retirement_fd: -1,
             retirement_trigger_fds: Vec::new(),
+            leased_slots: HashMap::new(),
+            next_lease_id: 1,
             on_send_callback: None,
             resize_callback: None,
             checksum_callback: None,
@@ -122,7 +127,137 @@ impl PublisherImpl {
         }
     }
 
-    pub fn find_free_slot_unreliable(&mut self, owner: i32) -> Option<usize> {
+    pub fn get_metadata_for_slot(&mut self, slot_idx: usize) -> &mut [u8] {
+        if self.channel.metadata_size == 0 {
+            return &mut [];
+        }
+        let prefix = self.channel.get_prefix(slot_idx);
+        if prefix.is_null() {
+            return &mut [];
+        }
+        unsafe {
+            checksum::get_metadata_slice(
+                prefix,
+                self.channel.checksum_size,
+                self.channel.metadata_size,
+            )
+        }
+    }
+
+    pub fn num_leases(&self) -> usize {
+        self.leased_slots.len()
+    }
+
+    pub fn register_lease(&mut self, slot_idx: usize) -> u64 {
+        let mut lease_id = self.next_lease_id;
+        self.next_lease_id = self.next_lease_id.wrapping_add(1);
+        if lease_id == 0 {
+            lease_id = self.next_lease_id;
+            self.next_lease_id = self.next_lease_id.wrapping_add(1);
+        }
+        self.leased_slots
+            .insert(self.channel.slot_ref(slot_idx).id, lease_id);
+        lease_id
+    }
+
+    pub fn find_lease(&self, slot_id: i32, lease_id: u64) -> Option<usize> {
+        if self.leased_slots.get(&slot_id) != Some(&lease_id)
+            || slot_id < 0
+            || slot_id >= self.channel.num_slots
+        {
+            return None;
+        }
+        let slot_idx = slot_id as usize;
+        let refs = self.channel.slot_ref(slot_idx).refs.load(Ordering::Acquire);
+        (refs == (PUB_OWNED | self.publisher_id as u64)).then_some(slot_idx)
+    }
+
+    pub fn remove_lease(&mut self, slot_id: i32) {
+        self.leased_slots.remove(&slot_id);
+    }
+
+    pub fn claim_retired_slot(&mut self, slot_id: i32) -> Option<usize> {
+        if slot_id < 0
+            || slot_id >= self.channel.num_slots
+            || !self.channel.retired_slots().is_set(slot_id as usize)
+        {
+            return None;
+        }
+
+        let slot_idx = slot_id as usize;
+        let slot_ptr = self.channel.slot_ptr(slot_idx);
+        unsafe {
+            let old_refs = (*slot_ptr).refs.load(Ordering::Acquire);
+            if (old_refs & (PUB_OWNED | REFS_MASK)) != 0 {
+                return None;
+            }
+            let expected = build_refs_bit_field(
+                (*slot_ptr).ordinal,
+                ((old_refs >> VCHAN_ID_SHIFT) & VCHAN_ID_MASK) as i32,
+                ((old_refs >> RETIRED_REFS_SHIFT) & RETIRED_REFS_MASK) as i32,
+            );
+            if (*slot_ptr)
+                .refs
+                .compare_exchange(
+                    expected,
+                    PUB_OWNED | self.publisher_id as u64,
+                    Ordering::Acquire,
+                    Ordering::Relaxed,
+                )
+                .is_err()
+            {
+                return None;
+            }
+        }
+
+        self.channel.retired_slots().clear(slot_idx);
+        let vchan_id = self.channel.vchan_id;
+        let slot = self.channel.slot_mut(slot_idx);
+        slot.ordinal = 0;
+        slot.timestamp = 0;
+        slot.vchan_id = vchan_id as i16;
+        self.channel.set_slot_to_biggest_buffer(slot_idx);
+
+        let prefix = self.channel.get_prefix(slot_idx);
+        if !prefix.is_null() {
+            unsafe {
+                (*prefix).flags = 0;
+                (*prefix).vchan_id = vchan_id;
+            }
+        }
+        self.channel.ccb().subscribers.traverse(|sub_id| {
+            self.channel.get_available_slots(sub_id).clear(slot_idx);
+        });
+        Some(slot_idx)
+    }
+
+    pub fn release_leased_slot(&mut self, slot_idx: usize) -> bool {
+        if self.channel.slot_ref(slot_idx).refs.load(Ordering::Acquire)
+            != (PUB_OWNED | self.publisher_id as u64)
+        {
+            return false;
+        }
+        let slot = self.channel.slot_mut(slot_idx);
+        slot.ordinal = 0;
+        slot.timestamp = 0;
+        slot.refs.store(0, Ordering::Release);
+        self.channel.ccb().subscribers.traverse(|sub_id| {
+            self.channel.get_available_slots(sub_id).clear(slot_idx);
+        });
+        self.channel.retired_slots().set(slot_idx);
+        true
+    }
+
+    pub fn retire_published_slot_immediately(&self, slot_idx: usize) {
+        self.channel.retired_slots().set(slot_idx);
+        self.trigger_retirement(slot_idx);
+    }
+
+    pub fn find_free_slot_unreliable(
+        &mut self,
+        owner: i32,
+        set_current_slot: bool,
+    ) -> Option<usize> {
         let max_retries = self.channel.num_slots as usize * 1000;
         let mut retries = max_retries;
         let mut slot_idx: Option<usize> = None;
@@ -253,15 +388,17 @@ impl PublisherImpl {
             self.channel.get_available_slots(sub_id).clear(si);
         });
 
-        if free_slot == -1 && retired_slot == -1 {
+        if free_slot == -1 && retired_slot == -1 && self.options.notify_retirement_on_forced_reuse {
             self.trigger_retirement(si);
         }
 
-        self.channel.slot = Some(si);
+        if set_current_slot {
+            self.channel.slot = Some(si);
+        }
         Some(si)
     }
 
-    pub fn find_free_slot_reliable(&mut self, owner: i32) -> Option<usize> {
+    pub fn find_free_slot_reliable(&mut self, owner: i32, set_current_slot: bool) -> Option<usize> {
         let mut slot_idx: Option<usize>;
         self.channel.embargoed_slots.clear_all();
         let mut retired_slot: i32;
@@ -408,11 +545,13 @@ impl PublisherImpl {
             self.channel.get_available_slots(sub_id).clear(si);
         });
 
-        if free_slot == -1 && retired_slot == -1 {
+        if free_slot == -1 && retired_slot == -1 && self.options.notify_retirement_on_forced_reuse {
             self.trigger_retirement(si);
         }
 
-        self.channel.slot = Some(si);
+        if set_current_slot {
+            self.channel.slot = Some(si);
+        }
         Some(si)
     }
 
@@ -424,6 +563,7 @@ impl PublisherImpl {
         owner: i32,
         omit_prefix: bool,
         use_prefix_slot_id: bool,
+        acquire_next: bool,
     ) -> PublishedMessage {
         let slot = self.channel.slot_mut(slot_idx);
         let vchan_id = self.channel.vchan_id;
@@ -486,32 +626,6 @@ impl PublisherImpl {
             }
         }
 
-        let slot = self.channel.slot_ref(slot_idx);
-        if !is_activation {
-            self.channel
-                .ccb()
-                .total_messages
-                .fetch_add(1, Ordering::Relaxed);
-            self.channel
-                .ccb()
-                .total_bytes
-                .fetch_add(slot.message_size, Ordering::Relaxed);
-
-            let msg_size = slot.message_size as u32;
-            let mut old_max = self.channel.ccb().max_message_size.load(Ordering::Relaxed);
-            while msg_size > old_max {
-                match self.channel.ccb().max_message_size.compare_exchange_weak(
-                    old_max,
-                    msg_size,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => break,
-                    Err(v) => old_max = v,
-                }
-            }
-        }
-
         // Release the slot: store refs with ordinal, no PUB_OWNED.
         let slot = self.channel.slot_ref(slot_idx);
         slot.refs.store(
@@ -531,21 +645,54 @@ impl PublisherImpl {
             self.channel.get_available_slots(sub_id).set(slot_idx);
         });
 
-        if reliable {
-            return PublishedMessage {
-                new_slot: None,
-                ordinal: unsafe { (*prefix).ordinal },
-                timestamp: unsafe { (*prefix).timestamp },
-            };
-        }
+        if !is_activation {
+            self.channel
+                .ccb()
+                .total_bytes
+                .fetch_add(slot.message_size, Ordering::Relaxed);
 
-        let new_slot = self.find_free_slot_unreliable(owner);
+            let msg_size = slot.message_size as u32;
+            let mut old_max = self.channel.ccb().max_message_size.load(Ordering::Relaxed);
+            while msg_size > old_max {
+                match self.channel.ccb().max_message_size.compare_exchange_weak(
+                    old_max,
+                    msg_size,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(v) => old_max = v,
+                }
+            }
+            self.channel
+                .ccb()
+                .total_messages
+                .fetch_add(1, Ordering::SeqCst);
+        }
 
         let (ordinal, timestamp) = if !prefix.is_null() {
             unsafe { ((*prefix).ordinal, (*prefix).timestamp) }
         } else {
             (0, 0)
         };
+
+        if !acquire_next {
+            return PublishedMessage {
+                new_slot: None,
+                ordinal,
+                timestamp,
+            };
+        }
+
+        if reliable {
+            return PublishedMessage {
+                new_slot: None,
+                ordinal,
+                timestamp,
+            };
+        }
+
+        let new_slot = self.find_free_slot_unreliable(owner, true);
 
         PublishedMessage {
             new_slot,

--- a/rust_client/tests/client_test.rs
+++ b/rust_client/tests/client_test.rs
@@ -65,6 +65,8 @@ fn publisher_options_defaults() {
     assert!(opts.mux.is_empty());
     assert!(!opts.use_split_buffers);
     assert!(!opts.split_buffers_over_bridge);
+    assert_eq!(opts.max_outstanding_slot_leases, 1);
+    assert!(opts.notify_retirement_on_forced_reuse);
 }
 
 #[test]
@@ -76,6 +78,8 @@ fn publisher_options_builder_chain() {
         .set_local(true)
         .set_fixed_size(true)
         .set_checksum(true)
+        .set_max_outstanding_slot_leases(3)
+        .set_notify_retirement_on_forced_reuse(false)
         .set_use_split_buffers(true)
         .set_split_buffers_over_bridge(true)
         .set_type("sensor".into())
@@ -89,6 +93,8 @@ fn publisher_options_builder_chain() {
     assert!(opts.local);
     assert!(opts.fixed_size);
     assert!(opts.checksum);
+    assert_eq!(opts.max_outstanding_slot_leases, 3);
+    assert!(!opts.notify_retirement_on_forced_reuse);
     assert!(opts.use_split_buffers);
     assert!(opts.split_buffers_over_bridge);
     assert!(opts.activate);
@@ -110,6 +116,7 @@ fn subscriber_options_defaults() {
     assert!(!opts.pass_checksum_errors);
     assert!(!opts.keep_active_message);
     assert_eq!(opts.vchan_id, -1);
+    assert_eq!(opts.max_subscribers, 0);
 }
 
 #[test]
@@ -117,6 +124,7 @@ fn subscriber_options_builder_chain() {
     let opts = SubscriberOptions::new()
         .set_reliable(true)
         .set_max_active_messages(8)
+        .set_max_subscribers(3)
         .set_log_dropped_messages(false)
         .set_pass_activation(true)
         .set_checksum(true)
@@ -127,6 +135,7 @@ fn subscriber_options_builder_chain() {
 
     assert!(opts.reliable);
     assert_eq!(opts.max_active_messages, 8);
+    assert_eq!(opts.max_subscribers, 3);
     assert!(!opts.log_dropped_messages);
     assert!(opts.pass_activation);
     assert!(opts.checksum);
@@ -2027,6 +2036,184 @@ fn read_retired_slot(fd: i32) -> i32 {
     slot_id
 }
 
+// ── Explicit publisher buffer lease tests ───────────────────────────────────
+
+#[test]
+fn integration_explicit_publisher_buffer_leases() {
+    let pub_client = new_client("test_lease_p");
+    let sub_client = new_client("test_lease_s");
+
+    let pub_opts = PublisherOptions::new()
+        .set_slot_size(128)
+        .set_num_slots(6)
+        .set_metadata_size(8)
+        .set_max_outstanding_slot_leases(3)
+        .set_notify_retirement(true)
+        .set_notify_retirement_on_forced_reuse(false);
+    let publisher = pub_client
+        .create_publisher("rust_explicit_leases", &pub_opts)
+        .unwrap();
+    let subscriber = sub_client
+        .create_subscriber(
+            "rust_explicit_leases",
+            &SubscriberOptions::new().set_max_active_messages(2),
+        )
+        .unwrap();
+
+    let publisher_clone = publisher.clone();
+    drop(publisher_clone);
+    assert_eq!(publisher.get_counters().num_pubs, 1);
+
+    let mut leases = Vec::new();
+    for _ in 0..3 {
+        leases.push(publisher.acquire_buffer_lease().unwrap().unwrap());
+    }
+    assert_eq!(
+        leases
+            .iter()
+            .map(|lease| lease.slot_id)
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        3
+    );
+    assert!(leases.iter().all(|lease| lease.buffer_size == 128));
+    assert!(publisher.acquire_buffer_lease().unwrap().is_none());
+
+    let lease = leases[1];
+    let payload = b"lease-two";
+    unsafe {
+        std::ptr::copy_nonoverlapping(payload.as_ptr(), lease.buffer, payload.len());
+    }
+    publisher.set_lease_metadata(&lease, b"lease-md").unwrap();
+    assert_eq!(publisher.get_lease_metadata(&lease).unwrap(), b"lease-md");
+
+    let published = publisher
+        .publish_buffer_lease(&lease, payload.len() as i64)
+        .unwrap();
+    assert_eq!(published.slot_id, lease.slot_id);
+    assert!(matches!(
+        publisher.publish_buffer_lease(&lease, payload.len() as i64),
+        Err(SubspaceError::FailedPrecondition(_))
+    ));
+
+    let received = subscriber.read_message(ReadMode::ReadNext).unwrap();
+    assert_eq!(unsafe { received.as_slice() }, payload);
+    assert_eq!(subscriber.get_metadata(), b"lease-md");
+    drop(received);
+
+    let retirement_fd = publisher.get_retirement_fd();
+    assert!(retirement_fd_readable(retirement_fd, 1000));
+    let retired_slot = read_retired_slot(retirement_fd);
+    assert_eq!(retired_slot, lease.slot_id);
+
+    let reclaimed = publisher
+        .reclaim_buffer_lease(retired_slot)
+        .unwrap()
+        .unwrap();
+    assert_eq!(reclaimed.slot_id, lease.slot_id);
+    assert_ne!(reclaimed.lease_id, lease.lease_id);
+
+    publisher.release_buffer_lease(&leases[0]).unwrap();
+    publisher.release_buffer_lease(&leases[2]).unwrap();
+    publisher.release_buffer_lease(&reclaimed).unwrap();
+    assert!(matches!(
+        publisher.release_buffer_lease(&reclaimed),
+        Err(SubspaceError::FailedPrecondition(_))
+    ));
+}
+
+#[test]
+fn integration_lease_without_subscribers_retires_immediately() {
+    let client = new_client("test_lease_no_sub");
+    let publisher = client
+        .create_publisher(
+            "rust_lease_no_sub",
+            &PublisherOptions::new()
+                .set_slot_size(128)
+                .set_num_slots(4)
+                .set_max_outstanding_slot_leases(2)
+                .set_notify_retirement(true)
+                .set_notify_retirement_on_forced_reuse(false),
+        )
+        .unwrap();
+
+    let lease = publisher.acquire_buffer_lease().unwrap().unwrap();
+    let original_buffer = lease.buffer;
+    unsafe {
+        std::ptr::copy_nonoverlapping(b"solo".as_ptr(), lease.buffer, 4);
+    }
+    publisher.publish_buffer_lease(&lease, 4).unwrap();
+
+    let retirement_fd = publisher.get_retirement_fd();
+    assert!(retirement_fd_readable(retirement_fd, 1000));
+    let retired_slot = read_retired_slot(retirement_fd);
+    assert_eq!(retired_slot, lease.slot_id);
+
+    let reclaimed = publisher
+        .reclaim_buffer_lease(retired_slot)
+        .unwrap()
+        .unwrap();
+    assert_eq!(reclaimed.buffer, original_buffer);
+    assert_ne!(reclaimed.lease_id, lease.lease_id);
+    publisher.release_buffer_lease(&reclaimed).unwrap();
+}
+
+#[test]
+fn integration_lease_budget_is_in_channel_capacity() {
+    let client = new_client("test_lease_capacity");
+    let publisher = client
+        .create_publisher(
+            "rust_lease_capacity",
+            &PublisherOptions::new()
+                .set_slot_size(64)
+                .set_num_slots(5)
+                .set_max_outstanding_slot_leases(3),
+        )
+        .unwrap();
+
+    let error = match client.create_subscriber(
+        "rust_lease_capacity",
+        &SubscriberOptions::new().set_max_active_messages(2),
+    ) {
+        Ok(_) => panic!("subscriber creation unexpectedly fit channel capacity"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("3 slot leases"));
+    drop(publisher);
+}
+
+#[test]
+fn integration_max_subscribers_limits_count_and_still_delivers() {
+    let client = new_client("test_max_subscribers");
+    let publisher = client
+        .create_publisher(
+            "rust_max_subscribers",
+            &PublisherOptions::new().set_slot_size(64).set_num_slots(6),
+        )
+        .unwrap();
+    let sub_opts = SubscriberOptions::new().set_max_subscribers(1);
+    let subscriber = client
+        .create_subscriber("rust_max_subscribers", &sub_opts)
+        .unwrap();
+    let error = match client.create_subscriber("rust_max_subscribers", &sub_opts) {
+        Ok(_) => panic!("subscriber creation unexpectedly exceeded channel limit"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("maximum number of subscribers"));
+
+    let payload = b"limit-ok";
+    let (buffer, _) = publisher
+        .get_message_buffer(payload.len() as i32)
+        .unwrap()
+        .unwrap();
+    unsafe {
+        std::ptr::copy_nonoverlapping(payload.as_ptr(), buffer, payload.len());
+    }
+    publisher.publish_message(payload.len() as i64).unwrap();
+    let received = subscriber.read_message(ReadMode::ReadNext).unwrap();
+    assert_eq!(unsafe { received.as_slice() }, payload);
+}
+
 // ── Retirement trigger tests ─────────────────────────────────────────────────
 
 /// One publisher with retirement notification and two subscribers.
@@ -2168,6 +2355,57 @@ fn integration_retirement_trigger_publisher_side() {
     let r1 = read_retired_slot(retirement_fd);
     assert_eq!(r0, 1);
     assert_eq!(r1, 2);
+
+    assert!(!retirement_fd_readable(retirement_fd, 0));
+}
+
+#[test]
+fn integration_forced_reuse_retirement_can_be_suppressed() {
+    let pub_client = new_client("test_ret_no_forced_p");
+    let sub_client = new_client("test_ret_no_forced_s");
+
+    let publisher = pub_client
+        .create_publisher(
+            "rust_ret_no_forced",
+            &PublisherOptions::new()
+                .set_slot_size(256)
+                .set_num_slots(10)
+                .set_notify_retirement(true)
+                .set_notify_retirement_on_forced_reuse(false),
+        )
+        .unwrap();
+    let retirement_fd = publisher.get_retirement_fd();
+    let subscriber = sub_client
+        .create_subscriber(
+            "rust_ret_no_forced",
+            &SubscriberOptions::new().set_log_dropped_messages(false),
+        )
+        .unwrap();
+    let _slow_subscriber = sub_client
+        .create_subscriber(
+            "rust_ret_no_forced",
+            &SubscriberOptions::new().set_log_dropped_messages(false),
+        )
+        .unwrap();
+
+    for _ in 0..7 {
+        let (buffer, _) = publisher.get_message_buffer(256).unwrap().unwrap();
+        unsafe {
+            std::ptr::copy_nonoverlapping(b"foobar".as_ptr(), buffer, 6);
+        }
+        publisher.publish_message(6).unwrap();
+    }
+    for _ in 0..2 {
+        let message = subscriber.read_message(ReadMode::ReadNext).unwrap();
+        assert_eq!(message.length, 6);
+    }
+    for _ in 0..3 {
+        let (buffer, _) = publisher.get_message_buffer(256).unwrap().unwrap();
+        unsafe {
+            std::ptr::copy_nonoverlapping(b"foobar".as_ptr(), buffer, 6);
+        }
+        publisher.publish_message(6).unwrap();
+    }
 
     assert!(!retirement_fd_readable(retirement_fd, 0));
 }

--- a/server/client_handler.cc
+++ b/server/client_handler.cc
@@ -350,6 +350,20 @@ void ClientHandler::HandleCreatePublisher(
     const subspace::CreatePublisherRequest &req,
     subspace::CreatePublisherResponse *response,
     std::vector<toolbelt::FileDescriptor> &fds) {
+  int max_outstanding_slot_leases = req.max_outstanding_slot_leases();
+  // Zero is the protobuf default used by clients predating explicit leases.
+  if (max_outstanding_slot_leases == 0) {
+    max_outstanding_slot_leases = 1;
+  }
+  if (max_outstanding_slot_leases < 1 ||
+      max_outstanding_slot_leases > req.num_slots()) {
+    response->set_error(absl::StrFormat(
+        "Invalid max_outstanding_slot_leases %d for channel %s: value must be "
+        "between 1 and num_slots (%d)",
+        max_outstanding_slot_leases, req.channel_name(), req.num_slots()));
+    return;
+  }
+
   ServerChannel *channel = server_->FindChannel(req.channel_name());
   if (channel == nullptr) {
     server_->logger_.Log(toolbelt::LogLevel::kDebug,
@@ -443,17 +457,6 @@ void ClientHandler::HandleCreatePublisher(
   }
   if (channel->Type().empty()) {
     channel->SetType(req.type());
-  }
-
-  // Check capacity of channel for unreliable channels.
-  if (!req.is_reliable()) {
-    absl::Status cap_ok = channel->HasSufficientCapacity(0);
-    if (!cap_ok.ok()) {
-      response->set_error(absl::StrFormat(
-          "Insufficient capacity to add a new publisher to channel %s: %s",
-          req.channel_name(), cap_ok.ToString()));
-      return;
-    }
   }
 
   int num_pubs, num_subs, num_bridge_pubs, num_bridge_subs;
@@ -565,6 +568,19 @@ void ClientHandler::HandleCreatePublisher(
   }
 
   if (!reclaimed) {
+    // Reclaimed publishers are already included in capacity usage. Any request
+    // that creates a new publisher, including a failed reclaim, must reserve
+    // its configured lease budget.
+    if (!req.is_reliable()) {
+      absl::Status cap_ok =
+          channel->HasSufficientCapacity(0, max_outstanding_slot_leases);
+      if (!cap_ok.ok()) {
+        response->set_error(absl::StrFormat(
+            "Insufficient capacity to add a new publisher to channel %s: %s",
+            req.channel_name(), cap_ok.ToString()));
+        return;
+      }
+    }
     server_->logger_.Log(toolbelt::LogLevel::kDebug,
                          "Client %s creating publisher on channel %s: VM: %s",
                          client_name_.c_str(), req.channel_name().c_str(),
@@ -572,7 +588,8 @@ void ClientHandler::HandleCreatePublisher(
     // Create the publisher.
     absl::StatusOr<PublisherUser *> publisher = channel->AddPublisher(
         this, req.is_reliable(), req.is_local(), req.is_bridge(),
-        req.for_tunnel(), req.is_fixed_size(), req.process_id());
+        req.for_tunnel(), req.is_fixed_size(), max_outstanding_slot_leases,
+        req.process_id());
     if (!publisher.ok()) {
       response->set_error(publisher.status().ToString());
       return;
@@ -763,6 +780,35 @@ void ClientHandler::HandleCreateSubscriber(
       return;
     }
   }
+  ServerChannel *limit_channel =
+      channel->IsVirtual() ? static_cast<VirtualChannel *>(channel)->GetMux()
+                           : channel;
+  if (absl::Status status = limit_channel->ValidateOrSetMaxSubscribers(
+          req.max_subscribers(), /*set_if_missing=*/true, "subscriber");
+      !status.ok()) {
+    response->set_error(status.ToString());
+    return;
+  }
+  server_->ForEachShadow([&](const std::unique_ptr<ShadowReplicator> &shadow) {
+    shadow->SendUpdateChannelOptions(limit_channel);
+  });
+  if (req.subscriber_id() < 0 && limit_channel->MaxSubscribers() > 0) {
+    int limit_num_pubs = 0;
+    int limit_num_subs = 0;
+    int limit_num_bridge_pubs = 0;
+    int limit_num_bridge_subs = 0;
+    int limit_num_tunnel_pubs = 0;
+    int limit_num_tunnel_subs = 0;
+    limit_channel->CountUsers(
+        limit_num_pubs, limit_num_subs, limit_num_bridge_pubs,
+        limit_num_bridge_subs, limit_num_tunnel_pubs, limit_num_tunnel_subs);
+    if (limit_num_subs >= limit_channel->MaxSubscribers()) {
+      response->set_error(absl::StrFormat(
+          "Channel %s already has the maximum number of subscribers (%d)",
+          req.channel_name(), limit_channel->MaxSubscribers()));
+      return;
+    }
+  }
   SubscriberUser *sub;
   bool reclaimed = false;
   if (req.subscriber_id() != -1) {
@@ -785,7 +831,7 @@ void ClientHandler::HandleCreateSubscriber(
   } else {
     if (!req.is_reliable()) {
       absl::Status cap_ok =
-          channel->HasSufficientCapacity(req.max_active_messages() - 1);
+          channel->HasSufficientCapacity(req.max_active_messages(), 0);
       if (!cap_ok.ok()) {
         response->set_error(absl::StrFormat(
             "Insufficient capacity to add a new subscriber to channel %s: %s",

--- a/server/server.cc
+++ b/server/server.cc
@@ -1349,6 +1349,14 @@ absl::Status Server::RecoverFromShadow(RecoveredState &state) {
         return s;
       }
     }
+    if (rch.has_max_subscribers) {
+      if (absl::Status s = channel->ValidateOrSetMaxSubscribers(
+              rch.max_subscribers, /*set_if_missing=*/true,
+              "shadow recovery");
+          !s.ok()) {
+        return s;
+      }
+    }
 
     if (absl::Status s = channel->MapExisting(scb_fd_, std::move(rch.ccb_fd),
                                               std::move(rch.bcb_fd));
@@ -1363,7 +1371,8 @@ absl::Status Server::RecoverFromShadow(RecoveredState &state) {
     for (auto &rpub : rch.publishers) {
       auto pub = std::make_unique<PublisherUser>(
           nullptr, rpub.id, rpub.is_reliable, rpub.is_local, rpub.is_bridge,
-          rpub.for_tunnel, rpub.is_fixed_size);
+          rpub.for_tunnel, rpub.is_fixed_size,
+          rpub.max_outstanding_slot_leases);
 
       toolbelt::TriggerFd tfd(rpub.poll_fd, rpub.trigger_fd);
       pub->SetTriggerFd(std::move(tfd));

--- a/server/server_channel.cc
+++ b/server/server_channel.cc
@@ -178,6 +178,30 @@ absl::Status ServerChannel::ValidateOrSetMaxPublishers(
   return absl::OkStatus();
 }
 
+absl::Status ServerChannel::ValidateOrSetMaxSubscribers(
+    int32_t max_subscribers, bool set_if_missing, const char *user_type) {
+  if (max_subscribers < 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Invalid max_subscribers %d for %s on channel %s: value must be "
+        "non-negative",
+        max_subscribers, user_type, Name()));
+  }
+  if (!max_subscribers_set_) {
+    if (set_if_missing || max_subscribers > 0) {
+      max_subscribers_ = max_subscribers;
+      max_subscribers_set_ = true;
+    }
+    return absl::OkStatus();
+  }
+  if (max_subscribers_ != max_subscribers) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Inconsistent max_subscribers for %s on channel %s: already %d, not "
+        "%d",
+        user_type, Name(), max_subscribers_, max_subscribers));
+  }
+  return absl::OkStatus();
+}
+
 void ServerChannel::RemoveBuffer(uint64_t session_id, Server *server) {
   if (ccb_ == nullptr) {
     return;
@@ -431,14 +455,16 @@ absl::StatusOr<int> ServerChannel::AllocateUserId(const char *type) {
 absl::StatusOr<PublisherUser *>
 ServerChannel::AddPublisher(ClientHandler *handler, bool is_reliable,
                             bool is_local, bool is_bridge, bool for_tunnel,
-                            bool is_fixed_size, uint64_t process_id) {
+                            bool is_fixed_size,
+                            int max_outstanding_slot_leases,
+                            uint64_t process_id) {
   absl::StatusOr<int> user_id = AllocateUserId("publisher");
   if (!user_id.ok()) {
     return user_id.status();
   }
   std::unique_ptr<PublisherUser> pub = std::make_unique<PublisherUser>(
       handler, *user_id, is_reliable, is_local, is_bridge, for_tunnel,
-      is_fixed_size);
+      is_fixed_size, max_outstanding_slot_leases);
   pub->SetProcessId(process_id);
   absl::Status status = pub->Init();
   if (!status.ok()) {
@@ -588,6 +614,25 @@ void ServerChannel::CountUsers(int &num_pubs, int &num_subs,
   }
 }
 
+void ServerChannel::CountCapacityUsage(
+    int &max_active_messages, int &max_outstanding_slot_leases) const {
+  max_active_messages = 0;
+  max_outstanding_slot_leases = 0;
+  for (const auto &[id, user] : users_) {
+    if (user == nullptr) {
+      continue;
+    }
+    if (user->IsPublisher()) {
+      max_outstanding_slot_leases +=
+          static_cast<const PublisherUser *>(user.get())
+              ->MaxOutstandingSlotLeases();
+    } else {
+      max_active_messages +=
+          static_cast<const SubscriberUser *>(user.get())->MaxActiveMessages();
+    }
+  }
+}
+
 // Channel is public if there are any public publishers.
 bool ServerChannel::IsLocal() const {
   for (auto &[id, user] : users_) {
@@ -674,9 +719,10 @@ bool ServerChannel::IsBridgeSubscriber() const {
 }
 
 ServerChannel::CapacityInfo ServerChannel::HasSufficientCapacityInternal(
-    int new_max_active_messages) const {
+    int new_max_active_messages,
+    int new_max_outstanding_slot_leases) const {
   if (NumSlots() == 0) {
-    return CapacityInfo{true, 0, 0, 0, 0};
+    return CapacityInfo{true, 0, 0, 0, 0, 0};
   }
   // Count number of publishers and subscribers.
   int num_pubs, num_subs, num_bridge_pubs, num_bridge_subs;
@@ -684,25 +730,23 @@ ServerChannel::CapacityInfo ServerChannel::HasSufficientCapacityInternal(
   CountUsers(num_pubs, num_subs, num_bridge_pubs, num_bridge_subs,
              num_tunnel_pubs, num_tunnel_subs);
 
-  // Add in the total active message maximums.
-  int max_active_messages = new_max_active_messages;
-  for (auto &[id, user] : users_) {
-    if (user == nullptr) {
-      continue;
-    }
-    if (user->IsSubscriber()) {
-      SubscriberUser *sub = static_cast<SubscriberUser *>(user.get());
-      max_active_messages += sub->MaxActiveMessages() - 1;
-    }
-  }
-  int slots_needed = num_pubs + num_subs + max_active_messages + 1;
+  int max_active_messages;
+  int max_outstanding_slot_leases;
+  CountCapacityUsage(max_active_messages, max_outstanding_slot_leases);
+  max_active_messages += new_max_active_messages;
+  max_outstanding_slot_leases += new_max_outstanding_slot_leases;
+  int slots_needed = max_active_messages + max_outstanding_slot_leases;
   return CapacityInfo{slots_needed <= NumSlots() - 1, num_pubs, num_subs,
-                      max_active_messages, slots_needed};
+                      max_active_messages, max_outstanding_slot_leases,
+                      slots_needed};
 }
 
 absl::Status
-ServerChannel::HasSufficientCapacity(int new_max_active_messages) const {
-  auto info = HasSufficientCapacityInternal(new_max_active_messages);
+ServerChannel::HasSufficientCapacity(
+    int new_max_active_messages,
+    int new_max_outstanding_slot_leases) const {
+  auto info = HasSufficientCapacityInternal(
+      new_max_active_messages, new_max_outstanding_slot_leases);
   if (info.capacity_ok) {
     return absl::OkStatus();
   }
@@ -711,10 +755,12 @@ ServerChannel::HasSufficientCapacity(int new_max_active_messages) const {
 
 absl::Status ServerChannel::CapacityError(const CapacityInfo &info) const {
   return absl::InternalError(absl::StrFormat(
-      "there are %d slots with %d publisher%s and %d "
-      "subscriber%s with %d additional active message%s; you "
+      "there are %d slots with %d publisher%s reserving %d slot lease%s and "
+      "%d subscriber%s reserving %d active message%s; you "
       "need at least %d slots",
-      NumSlots(), info.num_pubs, (info.num_pubs == 1 ? "" : "s"), info.num_subs,
+      NumSlots(), info.num_pubs, (info.num_pubs == 1 ? "" : "s"),
+      info.max_outstanding_slot_leases,
+      (info.max_outstanding_slot_leases == 1 ? "" : "s"), info.num_subs,
       (info.num_subs == 1 ? "" : "s"), info.max_active_messages,
       (info.max_active_messages == 1 ? "" : "s"), info.slots_needed + 1));
 }
@@ -912,5 +958,19 @@ void ChannelMultiplexer::CountUsers(int &num_pubs, int &num_subs,
   num_bridge_subs += total_bridge_subs;
   num_tunnel_pubs += total_tunnel_pubs;
   num_tunnel_subs += total_tunnel_subs;
+}
+
+void ChannelMultiplexer::CountCapacityUsage(
+    int &max_active_messages, int &max_outstanding_slot_leases) const {
+  ServerChannel::CountCapacityUsage(max_active_messages,
+                                    max_outstanding_slot_leases);
+  for (const VirtualChannel *vchan : virtual_channels_) {
+    int vchan_active_messages;
+    int vchan_outstanding_slot_leases;
+    vchan->CountCapacityUsage(vchan_active_messages,
+                              vchan_outstanding_slot_leases);
+    max_active_messages += vchan_active_messages;
+    max_outstanding_slot_leases += vchan_outstanding_slot_leases;
+  }
 }
 } // namespace subspace

--- a/server/server_channel.h
+++ b/server/server_channel.h
@@ -99,13 +99,19 @@ private:
 class PublisherUser : public User {
 public:
   PublisherUser(ClientHandler *handler, int id, bool is_reliable, bool is_local,
-                bool is_bridge, bool for_tunnel, bool is_fixed_size)
+                bool is_bridge, bool for_tunnel, bool is_fixed_size,
+                int max_outstanding_slot_leases)
       : User(handler, id, is_reliable, is_bridge, for_tunnel),
-        is_local_(is_local), is_fixed_size_(is_fixed_size) {}
+        is_local_(is_local), is_fixed_size_(is_fixed_size),
+        max_outstanding_slot_leases_(
+            max_outstanding_slot_leases > 0 ? max_outstanding_slot_leases : 1) {}
 
   bool IsPublisher() const override { return true; }
   bool IsLocal() const { return is_local_; }
   bool IsFixedSize() const { return is_fixed_size_; }
+  int MaxOutstandingSlotLeases() const {
+    return max_outstanding_slot_leases_;
+  }
 
   toolbelt::FileDescriptor &GetRetirementFdWriter() {
     return retirement_pipe_.WriteFd();
@@ -135,6 +141,7 @@ public:
 private:
   bool is_local_;
   bool is_fixed_size_;
+  int max_outstanding_slot_leases_;
   toolbelt::Pipe retirement_pipe_;
 };
 
@@ -217,6 +224,7 @@ public:
                                                bool is_reliable, bool is_local,
                                                bool is_bridge, bool for_tunnel,
                                                bool is_fixed_size,
+                                               int max_outstanding_slot_leases,
                                                uint64_t process_id);
   absl::StatusOr<SubscriberUser *>
   AddSubscriber(ClientHandler *handler, bool is_reliable, bool is_bridge,
@@ -281,10 +289,15 @@ public:
   void RemoveUser(Server *server, int user_id);
   void RemoveAllUsersFor(ClientHandler *handler);
   virtual bool IsEmpty() const { return user_ids_.IsEmpty(); }
-  virtual absl::Status HasSufficientCapacity(int new_max_active_messages) const;
+  virtual absl::Status
+  HasSufficientCapacity(int new_max_active_messages,
+                        int new_max_outstanding_slot_leases) const;
   virtual void CountUsers(int &num_pubs, int &num_subs, int &num_bridge_pubs,
                           int &num_bridge_subs, int &num_tunnel_pubs,
                           int &num_tunnel_subs) const;
+  virtual void
+  CountCapacityUsage(int &max_active_messages,
+                     int &max_outstanding_slot_leases) const;
   virtual void GetChannelInfo(subspace::ChannelInfoProto *info);
   virtual void GetChannelStats(subspace::ChannelStatsProto *stats);
   void TriggerAllSubscribers();
@@ -420,6 +433,10 @@ public:
                                           bool set_if_missing,
                                           const char *user_type);
   int32_t MaxPublishers() const { return max_publishers_; }
+  absl::Status ValidateOrSetMaxSubscribers(int32_t max_subscribers,
+                                           bool set_if_missing,
+                                           const char *user_type);
+  int32_t MaxSubscribers() const { return max_subscribers_; }
 
   virtual void SetSharedMemoryFds(SharedMemoryFds fds) {
     shared_memory_fds_ = std::move(fds);
@@ -450,10 +467,13 @@ public:
     int num_pubs;
     int num_subs;
     int max_active_messages;
+    int max_outstanding_slot_leases;
     int slots_needed;
   };
 
-  CapacityInfo HasSufficientCapacityInternal(int new_max_active_messages) const;
+  CapacityInfo
+  HasSufficientCapacityInternal(int new_max_active_messages,
+                                int new_max_outstanding_slot_leases) const;
   absl::Status CapacityError(const CapacityInfo &info) const;
 
   virtual void GetStatsCounters(uint64_t &total_bytes, uint64_t &total_messages,
@@ -480,6 +500,8 @@ protected:
   SplitBufferOptions split_buffer_options_;
   bool max_publishers_set_ = false;
   int32_t max_publishers_ = 0;
+  bool max_subscribers_set_ = false;
+  int32_t max_subscribers_ = 0;
 };
 
 class VirtualChannel;
@@ -512,6 +534,8 @@ public:
   void CountUsers(int &num_pubs, int &num_subs, int &num_bridge_pubs,
                   int &num_bridge_subs, int &num_tunnel_pubs,
                   int &num_tunnel_subs) const override;
+  void CountCapacityUsage(int &max_active_messages,
+                          int &max_outstanding_slot_leases) const override;
 
 private:
   int next_vchan_id_ = 0;
@@ -585,8 +609,10 @@ public:
   }
 
   absl::Status
-  HasSufficientCapacity(int new_max_active_messages) const override {
-    return mux_->HasSufficientCapacity(new_max_active_messages);
+  HasSufficientCapacity(int new_max_active_messages,
+                        int new_max_outstanding_slot_leases) const override {
+    return mux_->HasSufficientCapacity(new_max_active_messages,
+                                       new_max_outstanding_slot_leases);
   };
 
   ChannelCounters &RecordUpdate(bool is_pub, bool add, bool reliable) override {

--- a/server/shadow_replicator.cc
+++ b/server/shadow_replicator.cc
@@ -174,6 +174,10 @@ void ShadowReplicator::SendCreateChannel(ServerChannel *channel) {
     msg->set_has_max_publishers(true);
     msg->set_max_publishers(channel->MaxPublishers());
   }
+  if (channel->MaxSubscribers() > 0) {
+    msg->set_has_max_subscribers(true);
+    msg->set_max_subscribers(channel->MaxSubscribers());
+  }
 
   const SharedMemoryFds &channel_fds = channel->GetFds();
   std::vector<toolbelt::FileDescriptor> fds;
@@ -202,6 +206,8 @@ void ShadowReplicator::SendAddPublisher(const std::string &channel_name,
   msg->set_is_bridge(pub->IsBridge());
   msg->set_for_tunnel(pub->ForTunnel());
   msg->set_is_fixed_size(pub->IsFixedSize());
+  msg->set_max_outstanding_slot_leases(
+      pub->MaxOutstandingSlotLeases());
 
   std::vector<toolbelt::FileDescriptor> fds;
   fds.push_back(const_cast<PublisherUser *>(pub)->GetPollFd());
@@ -293,6 +299,10 @@ void ShadowReplicator::SendUpdateChannelOptions(const ServerChannel *channel) {
   if (channel->MaxPublishers() > 0) {
     msg->set_has_max_publishers(true);
     msg->set_max_publishers(channel->MaxPublishers());
+  }
+  if (channel->MaxSubscribers() > 0) {
+    msg->set_has_max_subscribers(true);
+    msg->set_max_subscribers(channel->MaxSubscribers());
   }
   SendEvent(event);
 }
@@ -412,6 +422,8 @@ absl::StatusOr<RecoveredState> ShadowReplicator::ReceiveStateDump() {
           .split_buffers_over_bridge = msg.split_buffers_over_bridge(),
           .has_max_publishers = msg.has_max_publishers(),
           .max_publishers = msg.max_publishers(),
+          .has_max_subscribers = msg.has_max_subscribers(),
+          .max_subscribers = msg.max_subscribers(),
           .ccb_fd = std::move(fds[0]),
           .bcb_fd = std::move(fds[1]),
       });
@@ -454,6 +466,10 @@ absl::StatusOr<RecoveredState> ShadowReplicator::ReceiveStateDump() {
           .for_tunnel = msg.for_tunnel(),
           .is_fixed_size = msg.is_fixed_size(),
           .notify_retirement = msg.notify_retirement(),
+          .max_outstanding_slot_leases =
+              msg.max_outstanding_slot_leases() > 0
+                  ? msg.max_outstanding_slot_leases()
+                  : 1,
           .poll_fd = std::move(fds[0]),
           .trigger_fd = std::move(fds[1]),
           .retirement_read_fd = msg.notify_retirement()

--- a/server/shadow_replicator.h
+++ b/server/shadow_replicator.h
@@ -30,6 +30,7 @@ struct RecoveredPublisher {
   bool for_tunnel = false;
   bool is_fixed_size = false;
   bool notify_retirement = false;
+  int max_outstanding_slot_leases = 1;
   toolbelt::FileDescriptor poll_fd;
   toolbelt::FileDescriptor trigger_fd;
   toolbelt::FileDescriptor retirement_read_fd;
@@ -64,6 +65,8 @@ struct RecoveredChannel {
   bool split_buffers_over_bridge = false;
   bool has_max_publishers = false;
   int max_publishers = 0;
+  bool has_max_subscribers = false;
+  int max_subscribers = 0;
   toolbelt::FileDescriptor ccb_fd;
   toolbelt::FileDescriptor bcb_fd;
   std::vector<RegisteredClientBuffer> client_buffers;

--- a/shadow/shadow.cc
+++ b/shadow/shadow.cc
@@ -264,6 +264,8 @@ Shadow::HandleCreateChannel(const ShadowCreateChannel &msg,
     ch.split_buffers_over_bridge = msg.split_buffers_over_bridge();
     ch.has_max_publishers = msg.has_max_publishers();
     ch.max_publishers = msg.max_publishers();
+    ch.has_max_subscribers = msg.has_max_subscribers();
+    ch.max_subscribers = msg.max_subscribers();
     ch.ccb_fd = std::move(fds[0]);
     ch.bcb_fd = std::move(fds[1]);
   };
@@ -317,6 +319,10 @@ Shadow::HandleAddPublisher(const ShadowAddPublisher &msg,
       .for_tunnel = msg.for_tunnel(),
       .is_fixed_size = msg.is_fixed_size(),
       .notify_retirement = msg.notify_retirement(),
+      .max_outstanding_slot_leases =
+          msg.max_outstanding_slot_leases() > 0
+              ? msg.max_outstanding_slot_leases()
+              : 1,
       .poll_fd = std::move(fds[0]),
       .trigger_fd = std::move(fds[1]),
       .retirement_read_fd = msg.notify_retirement()
@@ -472,6 +478,8 @@ Shadow::HandleUpdateChannelOptions(const ShadowUpdateChannelOptions &msg) {
   channel.split_buffers_over_bridge = msg.split_buffers_over_bridge();
   channel.has_max_publishers = msg.has_max_publishers();
   channel.max_publishers = msg.max_publishers();
+  channel.has_max_subscribers = msg.has_max_subscribers();
+  channel.max_subscribers = msg.max_subscribers();
   return absl::OkStatus();
 }
 
@@ -541,6 +549,8 @@ absl::Status Shadow::SendStateDump(toolbelt::UnixSocket &socket) {
       msg->set_split_buffers_over_bridge(ch.split_buffers_over_bridge);
       msg->set_has_max_publishers(ch.has_max_publishers);
       msg->set_max_publishers(ch.max_publishers);
+      msg->set_has_max_subscribers(ch.has_max_subscribers);
+      msg->set_max_subscribers(ch.max_subscribers);
 
       std::vector<toolbelt::FileDescriptor> fds;
       fds.push_back(ch.ccb_fd);
@@ -578,6 +588,8 @@ absl::Status Shadow::SendStateDump(toolbelt::UnixSocket &socket) {
       msg->set_for_tunnel(pub.for_tunnel);
       msg->set_is_fixed_size(pub.is_fixed_size);
       msg->set_notify_retirement(pub.notify_retirement);
+      msg->set_max_outstanding_slot_leases(
+          pub.max_outstanding_slot_leases);
 
       std::vector<toolbelt::FileDescriptor> fds;
       fds.push_back(pub.poll_fd);

--- a/shadow/shadow.h
+++ b/shadow/shadow.h
@@ -27,6 +27,7 @@ struct ShadowPublisher {
   bool for_tunnel = false;
   bool is_fixed_size = false;
   bool notify_retirement = false;
+  int max_outstanding_slot_leases = 1;
   toolbelt::FileDescriptor poll_fd;
   toolbelt::FileDescriptor trigger_fd;
   toolbelt::FileDescriptor retirement_read_fd;
@@ -61,6 +62,8 @@ struct ShadowChannel {
   bool split_buffers_over_bridge = false;
   bool has_max_publishers = false;
   int max_publishers = 0;
+  bool has_max_subscribers = false;
+  int max_subscribers = 0;
   toolbelt::FileDescriptor ccb_fd;
   toolbelt::FileDescriptor bcb_fd;
   std::vector<RegisteredClientBuffer> client_buffers;

--- a/shadow/shadow_test.cc
+++ b/shadow/shadow_test.cc
@@ -249,7 +249,12 @@ TEST_F(ShadowTest, ShadowReceivesAddPublisher) {
   subspace::Client client;
   InitClient(client);
 
-  auto pub = client.CreatePublisher("shadow_test_chan2", 128, 2);
+  auto pub = client.CreatePublisher(
+      "shadow_test_chan2",
+      subspace::PublisherOptions()
+          .SetSlotSize(128)
+          .SetNumSlots(5)
+          .SetMaxOutstandingSlotLeases(3));
   ASSERT_THAT(pub, IsOk());
 
   ASSERT_TRUE(WaitForShadowState([]() {
@@ -265,6 +270,7 @@ TEST_F(ShadowTest, ShadowReceivesAddPublisher) {
     EXPECT_EQ(it->second.publishers.size(), 1u);
 
     auto &pub_entry = it->second.publishers.begin()->second;
+    EXPECT_EQ(pub_entry.max_outstanding_slot_leases, 3);
     EXPECT_TRUE(pub_entry.poll_fd.Valid());
     EXPECT_TRUE(pub_entry.trigger_fd.Valid());
   });


### PR DESCRIPTION
## Summary

Adds explicit publisher buffer leases so a publisher can own multiple unpublished channel slots at the same time. This supports asynchronous producers, external-memory pipelines, and workflows that must reclaim the exact slot reported by a retirement notification.

- Exposes lease APIs in the C++, C, Python, and Rust clients.
- Adds `ScopedPublisherBufferLease`, a move-only C++ RAII wrapper that automatically releases an unpublished lease on scope exit.
- Supports acquiring any available slot, publishing or releasing it, and reclaiming a specific retired slot.
- Uses generation-based `lease_id` tokens so stale leases cannot publish, release, or access metadata after a slot is reused.
- Supports payload metadata, split buffers, subscriber queues, virtual channels, client reconnection, and shadow-server recovery.
- Adds server-side capacity accounting for publisher lease budgets and subscriber active-message budgets.
- Adds configurable channel-wide subscriber limits through `max_subscribers`.

## How to use publisher leases

1. Configure `max_outstanding_slot_leases` on the publisher. The default is `1`.
2. Acquire a lease:
   - C++: `AcquireScopedBufferLease()` (preferred) or `AcquireBufferLease()`.
   - Python/Rust/C: use the corresponding explicit lease API.
3. Write the payload through the lease buffer and optionally populate its metadata.
4. Publish the lease, or release it without publishing. Either operation invalidates the lease token.
5. If exact-slot reuse is needed, enable retirement notifications, read the retired `int32_t` slot ID from the retirement fd, and call the reclaim API. Reclamation returns a new `lease_id`.

The existing `GetMessageBuffer()` / `PublishMessage()` workflow remains available and unchanged. Applications should choose either the implicit-buffer or explicit-lease workflow for a publisher. Explicit leases do not hold the thread-safe client mutex for the lifetime of the buffer.

For unreliable channels, registration enforces this capacity invariant:

```text
sum(publisher max outstanding leases)
  + sum(subscriber max active messages)
  <= num_slots - 1
```

This reserves enough headroom for every configured lease and active-message budget. Subscriber queue storage uses its separate queue arena and does not consume this slot budget.

## Documentation

See [Publisher Buffer Leases](https://github.com/dallison/subspace/blob/publisher_leases/docs/publisher-buffer-leases.md) for complete C++, C, Python, and Rust examples, lease lifecycle rules, retirement and exact-slot reclamation, capacity accounting, and subscriber limits.

## Test plan

- `bazelisk test //...`
- `bazelisk test //client:client_test --test_arg=--use_split_buffers`
- Cross-language tests cover multiple outstanding leases, RAII cleanup, metadata, stale-token rejection, release/reclaim behavior, subscriber queue delivery and fallback, split buffers, and shadow recovery.