### PR TITLE
Fix kReadNewest to check the ordinal

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "subspace",
-    version = "3.0.0",
+    version = "3.0.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -582,7 +582,7 @@
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
         "bzlTransitiveDigest": "eT6cMKC8/lOF0/pWxtwFM9dDgUj6wYzAHDNWS/fBCZ8=",
-        "usagesDigest": "4fRZ8PQG6B7QQECVGU7Eu39hXHHWXBRNnJqTZgXjkUY=",
+        "usagesDigest": "xVNAJFwElb5xjkzNP6swgkykg9QVQltdvm4jh5u1Nvo=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
           "ENV:CARGO_BAZEL_GENERATOR_SHA256 \\0",

--- a/client/client_test.cc
+++ b/client/client_test.cc
@@ -2179,6 +2179,48 @@ TEST_F(ClientTest, PublishSingleMessageAndReadNewest) {
   ASSERT_EQ(0, msg->length);
 }
 
+TEST_F(ClientTest, ReadNewestRecognizesReusedCurrentSlotAsNewGeneration) {
+  subspace::Client pub_client;
+  subspace::Client sub_client;
+  ASSERT_OK(pub_client.Init(Socket()));
+  ASSERT_OK(sub_client.Init(Socket()));
+
+  auto pub = EVAL_AND_ASSERT_OK(
+      pub_client.CreatePublisher("read_newest_reused_slot", 256, 3));
+  auto sub = EVAL_AND_ASSERT_OK(
+      sub_client.CreateSubscriber("read_newest_reused_slot"));
+
+  void *buffer = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
+  memcpy(buffer, "first", 5);
+  ASSERT_OK(pub.PublishMessage(5));
+
+  Message first =
+      EVAL_AND_ASSERT_OK(sub.ReadMessage(subspace::ReadMode::kReadNewest));
+  const int32_t first_slot_id = first.slot_id;
+  const uint64_t first_ordinal = first.ordinal;
+  first.Reset();
+
+  Message reused_slot_message;
+  for (int i = 0; i < 3; ++i) {
+    buffer = EVAL_AND_ASSERT_OK(pub.GetMessageBuffer());
+    memcpy(buffer, "newest", 6);
+    Message published = EVAL_AND_ASSERT_OK(pub.PublishMessage(6));
+    if (published.slot_id == first_slot_id) {
+      reused_slot_message = published;
+      break;
+    }
+  }
+  ASSERT_EQ(first_slot_id, reused_slot_message.slot_id);
+  ASSERT_GT(reused_slot_message.ordinal, first_ordinal);
+
+  Message newest =
+      EVAL_AND_ASSERT_OK(sub.ReadMessage(subspace::ReadMode::kReadNewest));
+  EXPECT_EQ(reused_slot_message.slot_id, newest.slot_id);
+  EXPECT_EQ(reused_slot_message.ordinal, newest.ordinal);
+  EXPECT_EQ("newest",
+            std::string(static_cast<const char *>(newest.buffer), newest.length));
+}
+
 TEST_F(ClientTest, PublishSingleMessageAndReadWithActivation) {
   subspace::Client pub_client;
   subspace::Client sub_client;

--- a/client/subscriber.cc
+++ b/client/subscriber.cc
@@ -698,8 +698,12 @@ MessageSlot *SubscriberImpl::LastSlot(MessageSlot *slot, bool reliable,
     if (!active_slots_.empty()) {
       new_slot = &active_slots_.back();
 
-      if (slot != nullptr && slot == new_slot->slot) {
-        // Same slot, nothing changes.
+      auto &tracker = GetOrdinalTracker(new_slot->vchan_id);
+      if (slot != nullptr &&
+          tracker.ordinals.Contains(
+              OrdinalAndVchanId{new_slot->ordinal, new_slot->vchan_id})) {
+        // A released current slot may have been reused for a newer message.
+        // Compare message generations rather than physical slots.
         new_slot = nullptr;
       }
     }


### PR DESCRIPTION
This fixes a bug in kReadNewest where it didn't detect a recycle of the current slot properly